### PR TITLE
Add additional methods for Hibachi

### DIFF
--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -106,5 +106,9 @@ async function example () {
 
     const openInterest = await exchange.fetchOpenInterest('BTC/USDT:USDT');
     console.log('fetchOpenInterest', openInterest);
+
+    const fundingRate = await exchange.fetchFundingRate('BTC/USDT:USDT');
+    console.log('fetchFundingRate', fundingRate);
+
 }
 example ();

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -110,5 +110,7 @@ async function example () {
     const fundingRate = await exchange.fetchFundingRate('BTC/USDT:USDT');
     console.log('fetchFundingRate', fundingRate);
 
+    const fundingRateHistory = await exchange.fetchFundingRateHistory('BTC/USDT:USDT', undefined, 2);
+    console.log('fetchFundingRateHistory', fundingRateHistory);
 }
 example ();

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -103,5 +103,8 @@ async function example () {
 
     const timestamp = await exchange.fetchTime();
     console.log('fetchTime', timestamp)
+
+    const openInterest = await exchange.fetchOpenInterest('BTC/USDT:USDT');
+    console.log('fetchOpenInterest', openInterest);
 }
 example ();

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -114,7 +114,12 @@ async function example () {
     console.log('fetchFundingRateHistory', fundingRateHistory);
 
     // Batch orders
+    const order6 = await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.234, 1.234);
+    const order7 = await exchange.createOrder('BTC/USDT:USDT', 'limit', 'buy', 1.012, 1.012);
+    const cancelOrders = await exchange.cancelOrders([order6.id, order7.id]);
+    console.log('cancelOrders', cancelOrders);
     await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.234, 1.234);
+    await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.012, 1.012);
     const cancelAll = await exchange.cancelAllOrders('ETH/USDT:USDT');
     console.log(cancelAll);
 

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -121,6 +121,13 @@ async function example () {
         {'symbol': 'ETH/USDT:USDT', 'type': 'limit', 'side': 'buy', 'amount': 1.003, 'price': 1.003},
     ]);
     console.log('createOrders', createOrders);
+    const editOrders = await exchange.editOrders([
+        // @ts-expect-error OrderRequest lacks `id` but we expects it for editing
+        {'id': createOrders[0].id, 'symbol': 'ETH/USDT:USDT', 'type': 'limit', 'side': 'buy', 'amount': 1.111, 'price': 0.999},
+        // @ts-expect-error OrderRequest lacks `id` but we expects it for editing
+        {'id': createOrders[1].id, 'symbol': 'BTC/USDT:USDT', 'type': 'limit', 'side': 'buy', 'amount': 1.112, 'price': 0.998},
+    ]);
+    console.log('editOrders', editOrders);
     const cancelOrders = await exchange.cancelOrders([createOrders[0].id, createOrders[1].id]);
     console.log('cancelOrders', cancelOrders);
     const cancelAll = await exchange.cancelAllOrders('ETH/USDT:USDT');

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -114,12 +114,15 @@ async function example () {
     console.log('fetchFundingRateHistory', fundingRateHistory);
 
     // Batch orders
-    const order6 = await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.234, 1.234);
-    const order7 = await exchange.createOrder('BTC/USDT:USDT', 'limit', 'buy', 1.012, 1.012);
-    const cancelOrders = await exchange.cancelOrders([order6.id, order7.id]);
+    const createOrders = await exchange.createOrders([
+        {'symbol': 'ETH/USDT:USDT', 'type': 'limit', 'side': 'buy', 'amount': 1.234, 'price': 1.234},
+        {'symbol': 'BTC/USDT:USDT', 'type': 'limit', 'side': 'buy', 'amount': 1.001, 'price': 1.001},
+        {'symbol': 'ETH/USDT:USDT', 'type': 'limit', 'side': 'buy', 'amount': 1.002, 'price': 1.002},
+        {'symbol': 'ETH/USDT:USDT', 'type': 'limit', 'side': 'buy', 'amount': 1.003, 'price': 1.003},
+    ]);
+    console.log('createOrders', createOrders);
+    const cancelOrders = await exchange.cancelOrders([createOrders[0].id, createOrders[1].id]);
     console.log('cancelOrders', cancelOrders);
-    await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.234, 1.234);
-    await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.012, 1.012);
     const cancelAll = await exchange.cancelAllOrders('ETH/USDT:USDT');
     console.log(cancelAll);
 

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -100,5 +100,8 @@ async function example () {
 
     const withdrawals = await exchange.fetchWithdrawals ();
     console.log ('fetchWithdrawals', withdrawals);
+
+    const timestamp = await exchange.fetchTime();
+    console.log('fetchTime', timestamp)
 }
 example ();

--- a/examples/ts/hibachi-example.ts
+++ b/examples/ts/hibachi-example.ts
@@ -112,5 +112,11 @@ async function example () {
 
     const fundingRateHistory = await exchange.fetchFundingRateHistory('BTC/USDT:USDT', undefined, 2);
     console.log('fetchFundingRateHistory', fundingRateHistory);
+
+    // Batch orders
+    await exchange.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1.234, 1.234);
+    const cancelAll = await exchange.cancelAllOrders('ETH/USDT:USDT');
+    console.log(cancelAll);
+
 }
 example ();

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -15,6 +15,7 @@ interface Exchange {
     publicGetMarketDataStats (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataKlines (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataOrderbook (params?: {}): Promise<implicitReturnType>;
+    publicGetExchangeUtcTimestamp (params?: {}): Promise<implicitReturnType>;
     privateGetCapitalDepositInfo (params?: {}): Promise<implicitReturnType>;
     privateGetCapitalHistory (params?: {}): Promise<implicitReturnType>;
     privateGetTradeAccountTradingHistory (params?: {}): Promise<implicitReturnType>;

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -15,6 +15,7 @@ interface Exchange {
     publicGetMarketDataStats (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataKlines (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataOrderbook (params?: {}): Promise<implicitReturnType>;
+    publicGetMarketDataOpenInterest (params?: {}): Promise<implicitReturnType>;
     publicGetExchangeUtcTimestamp (params?: {}): Promise<implicitReturnType>;
     privateGetCapitalDepositInfo (params?: {}): Promise<implicitReturnType>;
     privateGetCapitalHistory (params?: {}): Promise<implicitReturnType>;

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -27,6 +27,7 @@ interface Exchange {
     privateGetTradeOrders (params?: {}): Promise<implicitReturnType>;
     privatePutTradeOrder (params?: {}): Promise<implicitReturnType>;
     privateDeleteTradeOrder (params?: {}): Promise<implicitReturnType>;
+    privateDeleteTradeOrders (params?: {}): Promise<implicitReturnType>;
     privatePostTradeOrder (params?: {}): Promise<implicitReturnType>;
     privatePostCapitalWithdraw (params?: {}): Promise<implicitReturnType>;
 }

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -29,6 +29,7 @@ interface Exchange {
     privateDeleteTradeOrder (params?: {}): Promise<implicitReturnType>;
     privateDeleteTradeOrders (params?: {}): Promise<implicitReturnType>;
     privatePostTradeOrder (params?: {}): Promise<implicitReturnType>;
+    privatePostTradeOrders (params?: {}): Promise<implicitReturnType>;
     privatePostCapitalWithdraw (params?: {}): Promise<implicitReturnType>;
 }
 abstract class Exchange extends _Exchange {}

--- a/ts/src/abstract/hibachi.ts
+++ b/ts/src/abstract/hibachi.ts
@@ -16,6 +16,7 @@ interface Exchange {
     publicGetMarketDataKlines (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataOrderbook (params?: {}): Promise<implicitReturnType>;
     publicGetMarketDataOpenInterest (params?: {}): Promise<implicitReturnType>;
+    publicGetMarketDataFundingRates (params?: {}): Promise<implicitReturnType>;
     publicGetExchangeUtcTimestamp (params?: {}): Promise<implicitReturnType>;
     privateGetCapitalDepositInfo (params?: {}): Promise<implicitReturnType>;
     privateGetCapitalHistory (params?: {}): Promise<implicitReturnType>;

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -84,7 +84,7 @@ export default class hibachi extends Exchange {
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
-                'fetchOpen': true,
+                'fetchOpenInterest': true,
                 'fetchOpenInterestHistory': false,
                 'fetchOpenOrder': false,
                 'fetchOpenOrders': true,

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -98,7 +98,7 @@ export default class hibachi extends Exchange {
                 'fetchStatus': false,
                 'fetchTicker': true,
                 'fetchTickers': false,
-                'fetchTime': false,
+                'fetchTime': true,
                 'fetchTrades': true,
                 'fetchTradingFee': false,
                 'fetchTradingFees': true,
@@ -142,6 +142,7 @@ export default class hibachi extends Exchange {
                         'market/data/stats': 1,
                         'market/data/klines': 1,
                         'market/data/orderbook': 1,
+                        'exchange/utc-timestamp': 1,
                     },
                 },
                 'private': {
@@ -250,7 +251,7 @@ export default class hibachi extends Exchange {
             'commonCurrencies': {},
             'exceptions': {
                 'exact': {
-                    '2': BadRequest, //  {"errorCode":2,"message":"Invalid signature: Failed to verify signature"}
+                    '2': BadRequest, // {"errorCode":2,"message":"Invalid signature: Failed to verify signature"}
                     '3': OrderNotFound, // {"errorCode":3,"message":"Not found: order ID 33","status":"failed"}
                     '4': BadRequest, // {"errorCode":4,"message":"Missing accountId","status":"failed"}
                 },
@@ -1811,5 +1812,21 @@ export default class hibachi extends Exchange {
             }
         }
         return this.parseTransactions (withdrawals, currency, since, limit, params);
+    }
+
+    /**
+     * @method
+     * @name hibachi#fetchTime
+     * @description fetches the current integer timestamp in milliseconds from the exchange server
+     * @see http://api-doc.hibachi.xyz/#b5c6a3bc-243d-4d35-b6d4-a74c92495434
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {int} the current integer timestamp in milliseconds from the exchange server
+     */
+    async fetchTime (params = {}): Promise<Int> {
+        const response = await this.publicGetExchangeUtcTimestamp (params);
+        //
+        //     { "timestampMs":1754077574040 }
+        //
+        return this.safeInteger (response, 'timestampMs');
     }
 }


### PR DESCRIPTION
As discussed we added those 8 methods for Hibachi:
```
cancelAllOrders
cancelOrders
createOrders
editOrders
fetchFundingRate
fetchFundingRateHistory
fetchOpenInterest
fetchTime
```

Once this get reviewed and merged, it should show in this PR: https://github.com/ccxt/ccxt/pull/26550