### PR TITLE
fix(bybit): handleErrorMessage reads req_id (snake) for public-WS errors

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -2410,7 +2410,10 @@ export default class bybit extends bybitRest {
                     delete client.subscriptions[messageHash];
                 }
             } else {
-                const messageHash = this.safeString (message, 'reqId');
+                // Bybit's public-WS subscribe responses echo back `req_id` (snake-case,
+                // matches what watchTopics sends); the trading-WS order responses use
+                // `reqId` (camel). The handler runs for both paths, so read either.
+                const messageHash = this.safeString2 (message, 'req_id', 'reqId');
                 client.reject (error, messageHash);
             }
             return true;


### PR DESCRIPTION
## Summary

One-line fix to \`ts/src/pro/bybit.ts:2413\` (\`handleErrorMessage\`).

## Bug

The public-WS subscribe path sends \`req_id\` (snake_case — see \`ts/src/pro/bybit.ts:2291\`), and bybit echoes that field name back on responses (documented in the unsubscribe handler comment at line 2509: \`\"req_id\": \"2\"\`). The error handler was reading \`reqId\` (camel) only — that works for the **trading**-WS order error responses but returns null on **public**-WS subscribe errors.

A null messageHash sends \`client.reject(error, null)\` down the **fan-out branch** in \`ts/src/base/ws/Client.ts:154\` — every pending future on the connection gets rejected. One bad subscribe takes down every watch* in flight.

## Fix

Read both with \`safeString2('req_id', 'reqId')\`, matching the precedent in \`ts/src/pro/kraken.ts:332\` (which uses the exact same pattern for the same reason).

The same file already handles dual casing on two adjacent reads — \`safeStringN(['code','ret_code','retCode'])\` at line 2384 and \`safeString2('retMsg','ret_msg')\` at line 2389. This just brings the \`reqId\` read in line.

## Why this matters

The cascade-rejection is visible in Java's WS sweep where bybit's \`watch*\` tests fail in lockstep — one of them triggers the cascade and the rest collapse. The trigger is a separate engine-level race in \`watchMultiple\` (handled in a different PR), but **regardless of whether the trigger is fixed**, this handler should not fan out a single subscribe-error to unrelated futures.

JS / Python / PHP rarely hit it because their single-threaded event loops mostly avoid the trigger. Java / Go / C# can hit it under real-thread parallelism. The fix is in the TS source so it propagates to every transpile target uniformly.

## Test plan

- [x] Read the same-file precedent (\`safeStringN\` / \`safeString2\`) — change matches the established convention
- [x] Cross-reference \`kraken.ts:332\` — same pattern for the same reason
- [ ] Re-transpile and run Java WS sweep — bybit cascading rejections should drop to single targeted rejections