### PR TITLE
fix(build): make prediction transpile + Go build work across all 6 languages

### DIFF
--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -51,10 +51,6 @@ if (platform === 'win32') {
 const GLOBAL_WRAPPER_FILE = './cs/ccxt/base/Exchange.Wrappers.cs';
 const EXCHANGE_WRAPPER_FOLDER = './cs/ccxt/wrappers/'
 const EXCHANGE_WS_WRAPPER_FOLDER = './cs/ccxt/exchanges/pro/wrappers/'
-const EXCHANGE_PREDICTION_WRAPPER_FOLDER = './cs/ccxt/wrappers/prediction/'
-const EXCHANGE_PREDICTION_WS_WRAPPER_FOLDER = './cs/ccxt/exchanges/prediction/pro/wrappers/'
-const EXCHANGES_PREDICTION_FOLDER = './cs/ccxt/exchanges/prediction/';
-const EXCHANGES_PREDICTION_WS_FOLDER = './cs/ccxt/exchanges/prediction/pro/';
 const ERRORS_FILE = './cs/ccxt/base/Exchange.Errors.cs';
 const BASE_METHODS_FILE = './cs/ccxt/base/Exchange.BaseMethods.cs';
 const EXCHANGES_FOLDER = './cs/ccxt/exchanges/';
@@ -1569,7 +1565,6 @@ async function runMain () {
         log.bright.green ({ force })
     }
     const transpiler = new NewTranspiler ();
-    const prediction = process.argv.includes ('--prediction')
     const inputExchanges = process.argv.slice (2).filter (x => !x.startsWith ('--'))
     if (baseClassOnly) {
         transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -661,7 +661,7 @@ class NewTranspiler {
                 classNameMap[exchangeName] = capitalize(exchangeName) + 'Core';
                 classNameMap[`${exchangeName}Rest`] = capitalize(exchangeName) + 'Core';
             });
-            exchangeIdsPrediction.forEach((exchangeName: string) => {
+            predictionIds.forEach((exchangeName: string) => {
                 classNameMap[exchangeName] = capitalize(exchangeName) + 'Core';
                 classNameMap[`${exchangeName}Rest`] = capitalize(exchangeName) + 'Core';
             });
@@ -808,7 +808,7 @@ class NewTranspiler {
         const values = [
             // "using ccxt;",
             namespace,
-            (ws || prediction) ? 'import ccxt "github.com/ccxt/ccxt/go/v4"' : '',
+            (ws || this.isPrediction) ? 'import ccxt "github.com/ccxt/ccxt/go/v4"' : '',
             // 'import "helpers"'
         ]
         return values;
@@ -1823,7 +1823,7 @@ ${constStatements.join('\n')}
     createDynamicInstanceFile(ws = false, prediction = false){
         const subFolder = ws ? '/pro' : (prediction ? '/prediction' : '');
         const dynamicInstanceFile = `./go/v4${subFolder}/exchange_dynamic.go`;
-        const exchanges = ws ? exchangeIdsWs : (prediction ? exchangeIdsPrediction : ['Exchange'].concat(exchangeIds));
+        const exchanges = ws ? exchangeIdsWs : (prediction ? predictionIds : ['Exchange'].concat(exchangeIds));
         const externalPackage = ws || prediction; // packages outside go/v4 import the base ccxt package
         const caseStatements = exchanges.map(exchange => {
             const coreName = (exchange === 'Exchange') ? exchange : capitalize(exchange) + 'Core';
@@ -2368,6 +2368,15 @@ ${caseStatements.join('\n')}
                 // package-level types/functions of go/v4 need the ccxt. qualifier
                 // (this also rewrites the embedded struct member into ccxt.PredictionExchange)
                 content = this.addPackagePrefix(content, this.extractTypeAndFuncNames(EXCHANGES_FOLDER), 'ccxt');
+                // inherited prediction helpers (outcome, shortenSlug, checkEventsAndMarkets, ...)
+                // reach the derived exchange via callDynamically. The shared `<-callDynamically`
+                // fixup only covers awaited calls; non-awaited/sync ones stay bare and would be
+                // undefined in package ccxtprediction. Route them through the exported
+                // channel-based dispatcher — CallInternalMethod forwards both plain and channel
+                // returns, so the `<-` receive is always valid.
+                content = this.regexAll (content, [
+                    [/callDynamically\(/gm, '<-this.CallDynamically('],
+                ]);
             }
         } else {
             const restPackagePrefix = this.isPrediction ? `${PREDICTION_PACKAGE}.` : 'ccxt.';
@@ -2935,14 +2944,13 @@ if (isMainEntry(import.meta.url)) {
         transpiledExchanges = [ exchange ];
     }
     if (prediction) {
-        transpiledExchanges = exchangeIdsPrediction;
+        transpiledExchanges = predictionIds;
     }
     const multiprocess = process.argv.includes ('--multiprocess') || process.argv.includes ('--multi');
     shouldTranspileTests = process.argv.includes ('--noTests') ? false : true;
     if (!child && !multiprocess) {
         log.bright.green ({ force });
     }
-    const prediction = process.argv.includes ('--prediction');
     const inputExchanges = process.argv.slice (2).filter (x => !x.startsWith ('--'));
     const transpiler = new NewTranspiler (ws);
     if (baseClassOnly) {

--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -1935,7 +1935,32 @@ class Transpiler {
             python3,
             php,
             phpAsync,
+            methodNames,
         } = this.transpileMethodsToAllLanguages ('PredictionExchange', methods)
+
+        // The per-method transpile only snake-cases base-Exchange method calls (e.g. this.safeString),
+        // not the class's own methods (this.setOutcomesFromMarkets) or super calls (super.setMarkets).
+        // PredictionExchange is the first base-path class that uses both, so apply the same self/super
+        // (Python) and $this->/parent:: (PHP) conversion the derived-exchange path does.
+        const convertMethods = methodNames.concat (this.getBaseMethods ())
+        const fixPyCalls = (body: string) => {
+            let out = body
+            for (const method of convertMethods) {
+                const r = new RegExp ('(self|super\\([^)]+\\))\\.(' + method + ')([^a-zA-Z0-9_])', 'g')
+                out = out.replace (r, (match: any, p1: string, p2: string, p3: string) => p1 + '.' + unCamelCase (p2) + p3)
+            }
+            return out
+        }
+        const fixPhpCalls = (body: string) => {
+            let out = body
+            for (const method of convertMethods) {
+                let r = new RegExp ('\\$this->(' + method + ')\\s?(\\(|[^a-zA-Z0-9_])', 'g')
+                out = out.replace (r, (match: any, p1: string, p2: string) => ((p2 === '(') ? ('$this->' + unCamelCase (p1) + p2) : ("array($this, '" + unCamelCase (p1) + "')" + p2)))
+                r = new RegExp ('parent::(' + method + ')\\s?(\\(|[^a-zA-Z0-9_])', 'g')
+                out = out.replace (r, (match: any, p1: string, p2: string) => ((p2 === '(') ? ('parent::' + unCamelCase (p1) + p2) : ("array($this, '" + unCamelCase (p1) + "')" + p2)))
+            }
+            return out
+        }
 
         const pythonDelimiter = '# ' + delimiter + '\n'
         const phpDelimiter = '// ' + delimiter + '\n'
@@ -1948,12 +1973,12 @@ class Transpiler {
 
         if (this.buildPython) {
             log.magenta ('→', python3File.yellow)
-            replaceInFile (python3File,  new RegExp (pythonDelimiter + restOfFile), pythonDelimiter + python3.join ('\n') + '\n')
+            replaceInFile (python3File,  new RegExp (pythonDelimiter + restOfFile), pythonDelimiter + fixPyCalls (python3.join ('\n')) + '\n')
         }
 
         if (this.buildPHP) {
             log.magenta ('→', phpAsyncFile.yellow)
-            replaceInFile (phpAsyncFile, new RegExp (phpDelimiter + restOfFile),    phpDelimiter + phpAsync.join ('\n') + '\n}\n')
+            replaceInFile (phpAsyncFile, new RegExp (phpDelimiter + restOfFile),    phpDelimiter + fixPhpCalls (phpAsync.join ('\n')) + '\n}\n')
         }
     }
 

--- a/go/v4/exchange.go
+++ b/go/v4/exchange.go
@@ -2204,3 +2204,19 @@ func (this *Exchange) UnlockId() bool {
 	this.idMutex.Unlock()
 	return true
 }
+
+// FetchEvents is a default stub so every exchange satisfies IDerivedExchange.
+// Prediction exchanges (PredictionExchange and its derivatives) override it.
+func (this *Exchange) FetchEvents(optionalArgs ...any) <-chan any {
+	ch := make(chan any)
+	go func() any {
+		defer close(ch)
+		defer ReturnPanicError(ch)
+		queries := GetArg(optionalArgs, 0, nil)
+		_ = queries
+		params := GetArg(optionalArgs, 1, map[string]any{})
+		_ = params
+		panic(NotSupported(Add(this.Id, " fetchEvents() is not supported yet")))
+	}()
+	return ch
+}


### PR DESCRIPTION
## Summary

Completes the `PredictionExchange` refactor so **every prediction-market exchange builds and live-tests in all 6 languages** (TS/JS, Python, PHP, C#, Go, Java). Hand-written source only — 4 files; regenerate the rest with the usual `emitAPI*` + `transpile*` + per-language build.

## Verified live (all 5 exchanges × 6 languages)

| Exchange | JS/TS | Python | PHP | C# | Go | Java |
|---|---|---|---|---|---|---|
| polymarket | ✅ 330 ev | ✅ 300 ev | ✅ | ✅ bid 0.05 | ✅ | ✅ bid 0.016 |
| kalshi | ✅ | ✅ | ✅ 12 | ✅ 0.241 | ✅ OI 46k | ✅ 0.77 |
| myriad | ✅ | ✅ | ✅ | ✅ 0.173 | ✅ fee 0.01 | ✅ 0.173 |
| limitless | ✅ | ✅ | ✅ | ✅ 0.23 | ✅ trades 38 | ✅ 0.23 |
| hyperliquid | ✅ 94 ev | ✅ | ✅ 4 | ✅ | ✅ | ✅ |

Exercised `fetchEvents`, `fetchTicker`, `fetchTickers`, `fetchOrderBook`, `fetchStatus`, `fetchOpenInterest`, `fetchTradingFee`, `fetchTrades`.

## Changes

**`build/goTranspiler.ts`**
- rename undefined `exchangeIdsPrediction` → `predictionIds` (3 sites) — transpiler `ReferenceError`.
- `getGoImports`: bare `prediction` → `this.isPrediction` (prediction case already returns early above).
- prediction package emitted bare `callDynamically(` (undefined in package `ccxtprediction`); rewrite to `<-this.CallDynamically(`. Correct for both sync and async dispatched methods because `CallInternalMethod` forwards plain and channel returns alike.

**`go/v4/exchange.go`**
- default `FetchEvents` stub on base `Exchange` so every regular exchange satisfies `IDerivedExchange` (the interface gained `FetchEvents` with no base default → all regular exchanges failed to compile). Prediction exchanges override it.

**`build/transpile.ts`**
- apply self/super method-name snake_case conversion to the prediction base methods (Python `super().set_markets()`, PHP `parent::set_markets()`).

**`build/csharpTranspiler.ts`**
- remove duplicate const declarations (merge artifacts) that crashed the C# transpiler on load.

## No regressions
- `go build ./v4`, `./v4/pro`, `./v4/prediction` all clean; regular exchanges byte-identical (reverted incidental gofmt churn).
- Java `:lib:compileJava` BUILD SUCCESSFUL (all 107 exchanges).
- JS `tsBuild` clean; `binance.fetchTicker('BTC/USDT')` live-OK.

## Notes
- Also required (regenerated, not in this diff): `npm run emitAPITs/Py/Php/Cs/Go/Java` — the prediction abstracts must extend `PredictionExchange`, not `Exchange`, or `ccxt.prediction.*` is undefined / TS type errors appear.
- **Latent bug (not fixed here):** `this.checkEventsAndMarkets(outcome)` is called without `await` although the method is `async`; the validation guard silently doesn't run in async languages (Python warns "coroutine never awaited"). Should be `await`ed in `ts/src/prediction/*.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)