### PR TITLE
feat(prediction): unify PredictionOrderBook + complete native types in all langs

### DIFF
--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -384,6 +384,7 @@ class NewTranspiler {
             'OrderType': 'string',
             'OrderSide': 'string', // tmp
             'PredictionEvent': 'Dictionary<string, object>', // no concrete C# struct; surface as a dict
+            'fetchEventsParams': 'Dictionary<string, object>', // params bag; surface as a dict
         }
 
         if (wrappedType === undefined || wrappedType === 'Undefined') {

--- a/build/generateJavaWrappers.ts
+++ b/build/generateJavaWrappers.ts
@@ -38,7 +38,7 @@ const KNOWN_TYPES = new Set([
     'FundingHistory', 'DepositWithdrawFee',
     'OrderRequest', 'CancellationRequest', 'WithdrawalResponse',
     // native dedicated prediction-market types (io.github.ccxt.types.Prediction*)
-    'PredictionTicker', 'PredictionTickers', 'PredictionOrder', 'PredictionTrade', 'PredictionPosition', 'PredictionOrderBook',
+    'PredictionTicker', 'PredictionTickers', 'PredictionOrder', 'PredictionTrade', 'PredictionPosition', 'PredictionOrderBook', 'PredictionTradingFee', 'PredictionOpenInterest',
 ]);
 
 // --- Type helpers ---
@@ -585,6 +585,9 @@ const PREDICTION_TYPE_MAP: Record<string, string> = {
     'Order': 'PredictionOrder',
     'Trade': 'PredictionTrade',
     'Position': 'PredictionPosition',
+    'OrderBook': 'PredictionOrderBook',
+    'TradingFeeInterface': 'PredictionTradingFee',
+    'OpenInterest': 'PredictionOpenInterest',
 };
 function toPredictionMethods(rest: MethodInfo[]): MethodInfo[] {
     return rest.map((m) => {

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -895,6 +895,7 @@ class NewTranspiler {
             'OrderType': 'string',
             'OrderSide': 'string', // tmp
             'PredictionEvent': 'map[string]any', // no concrete Go struct; surface as a map
+            'fetchEventsParams': 'map[string]interface{}', // params bag; surface as a map
         };
 
         if (wrappedType === undefined || wrappedType === 'Undefined') {
@@ -2083,6 +2084,9 @@ ${caseStatements.join('\n')}
         }
 
         if (prediction) {
+            // the prediction package needs its OWN DynamicallyCreateInstance (over
+            // prediction ids); the base one in package ccxt only knows regular ids
+            this.createDynamicInstanceFile (false, true);
             log.bright.green ('Transpiled prediction exchanges successfully.');
             return;
         }

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -81,6 +81,12 @@ const goTypeOptions: dict = {};
 // names of the options structs that live in the base ccxt package; used by the
 // prediction pass to decide between aliasing (type X = ccxt.X) and emitting a local struct
 const baseGoTypeOptionNames = new Set<string>();
+// option struct/func names the prediction package declares LOCALLY because its method
+// renamed a base param (e.g. fetchTickers `outcomes` vs base `symbols`). Keyed by method
+// capName → [Options, OptionsStruct, WithXxx...]. These must NOT be ccxt.-qualified in the
+// wrapper file of an exchange that DEFINES the method (so it binds to the local struct), but
+// MUST stay ccxt.-qualified where the method is a base delegation (missing-method wrapper).
+const predictionLocalOptionStructs = new Map<string, string[]>();
 
 const WRAPPER_METHODS: {} = {};
 
@@ -1226,12 +1232,28 @@ class NewTranspiler {
             param.initializer === 'undefined' ||
             param.initializer === '{}'
         ));
+        // prediction is tracked via the instance flag; the isWs param is a plain boolean here
+        const isPrediction = this.isPrediction || (isWs === 'prediction');
         if (
             (optionalParams.length === 0) ||
-            (capName in goTypeOptions) ||
             (params.length === 1 && params[0].name === 'params')
         ) {
             return;
+        }
+        // reuse an already-generated struct, EXCEPT when a prediction method's optional params
+        // differ from the existing (base) struct — e.g. fetchTickers takes `outcomes` not
+        // `symbols`, so it needs a prediction-LOCAL struct with the renamed field instead of
+        // the ccxt.-qualified base one (which would have no `Outcomes` field).
+        let predictionLocalOverride = false;
+        if (capName in goTypeOptions) {
+            if (isPrediction) {
+                const existingFields = (goTypeOptions[capName].match (/^\s+(\w+) \*/gm) || []).map (s => s.trim ().split (' ')[0]);
+                const predFields = optionalParams.map (param => capitalize (param.name));
+                predictionLocalOverride = predFields.some (f => existingFields.indexOf (f) === -1);
+            }
+            if (!predictionLocalOverride) {
+                return;
+            }
         }
         const i1 = this.inden(1);
         const one = this.inden(0);
@@ -1241,10 +1263,16 @@ class NewTranspiler {
         const options = `${capName}Options`;
         const optionsStruct = `${capName}OptionsStruct`;
 
-        const isPrediction = (isWs === 'prediction');
         // the prediction package aliases the structs that already exist in the base
-        // package and declares local ones for prediction-only methods
-        const useAlias = (isWs === true) || (isPrediction && baseGoTypeOptionNames.has(capName));
+        // package and declares local ones for prediction-only / param-renamed methods
+        const useAlias = (isWs === true) || (isPrediction && baseGoTypeOptionNames.has(capName) && !predictionLocalOverride);
+        if (predictionLocalOverride) {
+            const localNames = [ options, optionsStruct ];
+            optionalParams
+                .filter ((param) => param.optional || param.initializer !== undefined)
+                .forEach ((param) => localNames.push (`With${capName}${capitalize (param.name)}`));
+            predictionLocalOptionStructs.set (capName, localNames);
+        }
         const qualify = (type: string | undefined) => (isPrediction ? this.qualifyBaseGoType(type) : type);
 
         if (useAlias) {
@@ -1580,7 +1608,21 @@ class NewTranspiler {
             missingMethodsWrappers,
         ].join('\n');
         if (ws || this.isPrediction) {
-            file = this.addPackagePrefix(file, this.extractTypeAndFuncNames(EXCHANGES_FOLDER), 'ccxt');
+            const baseNames = this.extractTypeAndFuncNames(EXCHANGES_FOLDER);
+            if (this.isPrediction) {
+                // only for methods THIS exchange actually defines: keep its renamed-param option
+                // overrides unqualified so the wrapper binds to the local struct (with `Outcomes`).
+                // For methods it delegates to base (missing-method wrappers), leave them ccxt.-qualified.
+                for (const wrapper of wrappers) {
+                    const localNames = predictionLocalOptionStructs.get(capitalize(wrapper.name));
+                    if (localNames !== undefined) {
+                        for (const name of localNames) {
+                            baseNames.delete(name);
+                        }
+                    }
+                }
+            }
+            file = this.addPackagePrefix(file, baseNames, 'ccxt');
         }
         log.magenta ('→', (path as any).yellow);
 
@@ -2147,7 +2189,10 @@ ${caseStatements.join('\n')}
                 ''
             ];
             for (const key in goTypeOptions) {
-                if (ccxtNames.has(key + 'Options') || ccxtNames.has(key + 'OptionsStruct')) {
+                // emit param-renamed prediction overrides locally even though a same-named
+                // struct exists in base (e.g. FetchTickersOptionsStruct with Outcomes)
+                const isLocalOverride = predictionLocalOptionStructs.has(key);
+                if (!isLocalOverride && (ccxtNames.has(key + 'Options') || ccxtNames.has(key + 'OptionsStruct'))) {
                     continue;
                 }
                 file.push(goTypeOptions[key]);

--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -892,11 +892,15 @@ class Transpiler {
             'TransferEntry': /-> TransferEntry:/,
             'PredictionEvent': /-> (?:List\[)?PredictionEvent/,
             'PredictionOutcome': /: (?:List\[)?PredictionOutcome/,
+            'fetchEventsParams': /: (?:List\[)?fetchEventsParams\b/,
             'PredictionTicker': /-> (?:List\[)?PredictionTicker\b/,
             'PredictionTickers': /-> (?:List\[)?PredictionTickers\b/,
             'PredictionOrder': /-> (?:List\[)?PredictionOrder\b/,
+            'PredictionOrderBook': /-> (?:List\[)?PredictionOrderBook\b/,
             'PredictionTrade': /-> (?:List\[)?PredictionTrade\b/,
             'PredictionPosition': /-> (?:List\[)?PredictionPosition\b/,
+            'PredictionTradingFee': /-> (?:List\[)?PredictionTradingFee\b/,
+            'PredictionOpenInterest': /-> (?:List\[)?PredictionOpenInterest\b/,
         }
         const matches: string[] = []
         let match
@@ -1735,7 +1739,7 @@ class Transpiler {
                     'Dictionary<any>': 'array',
                     'Dict': 'array',
                 }
-                const phpArrayRegex = /^(?:Market|Currency|Account|AccountStructure|BalanceAccount|object|OHLCV|ADL|Order|OrderBook|Tickers?|Trade|Transaction|Balances?|MarketInterface|TransferEntry|TransferEntries|Leverages|Leverage|Greeks|MarginModes|MarginMode|MarketMarginModes|MarginModification|LastPrice|LastPrices|TradingFeeInterface|Currencies|TradingFees|CrossBorrowRate|IsolatedBorrowRate|FundingRates|FundingRate|LedgerEntry|LeverageTier|LeverageTiers|Conversion|DepositAddress|LongShortRatio|Position|BorrowInterest|PredictionTicker|PredictionTickers|PredictionOrder|PredictionTrade|PredictionPosition|PredictionOrderBook|PredictionEvent|PredictionMarket|PredictionOutcome|OpenInterests)( \| undefined)?$|\w+\[\]/
+                const phpArrayRegex = /^(?:Market|Currency|Account|AccountStructure|BalanceAccount|object|OHLCV|ADL|Order|OrderBook|Tickers?|Trade|Transaction|Balances?|MarketInterface|TransferEntry|TransferEntries|Leverages|Leverage|Greeks|MarginModes|MarginMode|MarketMarginModes|MarginModification|LastPrice|LastPrices|TradingFeeInterface|Currencies|TradingFees|CrossBorrowRate|IsolatedBorrowRate|FundingRates|FundingRate|LedgerEntry|LeverageTier|LeverageTiers|Conversion|DepositAddress|LongShortRatio|Position|BorrowInterest|PredictionTicker|PredictionTickers|PredictionOrder|PredictionTrade|PredictionPosition|PredictionOrderBook|PredictionEvent|PredictionMarket|PredictionOutcome|fetchEventsParams|OpenInterests)( \| undefined)?$|\w+\[\]/
 
                 phpArgs = argsArray.map (x => {
                     const parts = x.split (':')

--- a/cs/ccxt/base/Exchange.BaseMethods.cs
+++ b/cs/ccxt/base/Exchange.BaseMethods.cs
@@ -890,7 +890,9 @@ public partial class Exchange
             for (object i = 0; isLessThan(i, getArrayLength(parsedArray)); postFixIncrement(ref i))
             {
                 object entry = getValue(parsedArray, i);
-                object entryFiledEqualValue = isEqual(getValue(entry, field), value);
+                // safeValue (not entry[field]) so a missing field is a non-match, not a
+                // KeyError in python/php — prediction structures key on outcome, not symbol
+                object entryFiledEqualValue = isEqual(this.safeValue(entry, field), value);
                 object firstCondition = ((bool) isTrue(valueIsDefined)) ? entryFiledEqualValue : true;
                 object entryKeyValue = this.safeValue(entry, key);
                 object entryKeyGESince = isTrue(isTrue((entryKeyValue)) && isTrue((!isEqual(since, null)))) && isTrue((isGreaterThanOrEqual(entryKeyValue, since)));
@@ -3564,22 +3566,27 @@ public partial class Exchange
         });
     }
 
-    public virtual object filterBySymbol(object objects, object symbol = null)
+    public virtual object filterByKey(object objects, object key, object value = null)
     {
-        if (isTrue(isEqual(symbol, null)))
+        if (isTrue(isEqual(value, null)))
         {
             return objects;
         }
         object result = new List<object>() {};
         for (object i = 0; isLessThan(i, getArrayLength(objects)); postFixIncrement(ref i))
         {
-            object objectSymbol = this.safeString(getValue(objects, i), "symbol");
-            if (isTrue(isEqual(objectSymbol, symbol)))
+            object objectValue = this.safeString(getValue(objects, i), key);
+            if (isTrue(isEqual(objectValue, value)))
             {
                 ((IList<object>)result).Add(getValue(objects, i));
             }
         }
         return result;
+    }
+
+    public virtual object filterBySymbol(object objects, object symbol = null)
+    {
+        return this.filterByKey(objects, "symbol", symbol);
     }
 
     public virtual object parseOHLCV(object ohlcv, object market = null)

--- a/cs/ccxt/base/PredictionExchange.cs
+++ b/cs/ccxt/base/PredictionExchange.cs
@@ -19,18 +19,7 @@ public partial class PredictionExchange : Exchange
         return this.safeBool(this.has, "prediction", false);
     }
 
-    public async virtual Task<object> loadMarketsAndEvents(object reload = null, object parameters = null)
-    {
-        reload ??= false;
-        parameters ??= new Dictionary<string, object>();
-        object res = await promiseAll(new List<object> {this.loadMarkets(reload, parameters), this.loadEvents(reload, parameters)});
-        return new Dictionary<string, object>() {
-            { "markets", getValue(res, 0) },
-            { "events", getValue(res, 1) },
-        };
-    }
-
-    public virtual void checkEventsAndMarkets(object outcome = null)
+    public virtual void checkEvents(object outcome = null)
     {
         // pure synchronous guard (no I/O) — callers invoke it without await, so leaving it
         // async would make the coroutine never run in Python/PHP and silently skip validation.
@@ -65,6 +54,121 @@ public partial class PredictionExchange : Exchange
             return new List<object>() {singleQuery};
         }
         return this.safeList(parameters, "queries", new List<object>() {});
+    }
+
+    public virtual object applyEventFetchParams(object events, object parameters = null, object queries = null)
+    {
+        // applies the unified fetchEvents options client-side (eventId/slug/status/searchIn/sort/limit)
+        // so exchanges whose API can't filter natively still support them consistently
+        parameters ??= new Dictionary<string, object>();
+        object result = events;
+        object eventId = this.safeString(parameters, "eventId");
+        object slug = this.safeString(parameters, "slug");
+        if (isTrue(isTrue((!isEqual(eventId, null))) || isTrue((!isEqual(slug, null)))))
+        {
+            object filtered = new List<object>() {};
+            for (object i = 0; isLessThan(i, getArrayLength(result)); postFixIncrement(ref i))
+            {
+                object eventVar = getValue(result, i);
+                object idMatch = isTrue((!isEqual(eventId, null))) && isTrue((isEqual(this.safeString(eventVar, "id"), eventId)));
+                object slugMatch = isTrue((!isEqual(slug, null))) && isTrue((isEqual(this.safeString(eventVar, "slug"), slug)));
+                if (isTrue(isTrue(idMatch) || isTrue(slugMatch)))
+                {
+                    ((IList<object>)filtered).Add(eventVar);
+                }
+            }
+            result = filtered;
+        }
+        result = this.filterEventsByStatus(result, this.safeString(parameters, "status"));
+        if (isTrue(isTrue((!isEqual(queries, null))) && isTrue((isGreaterThan(getArrayLength(queries), 0)))))
+        {
+            result = this.filterEventsBySearchIn(result, queries, this.safeString(parameters, "searchIn"));
+        }
+        object sort = this.safeString(parameters, "sort");
+        if (isTrue(!isEqual(sort, null)))
+        {
+            object sortKey = null;
+            if (isTrue(isEqual(sort, "volume")))
+            {
+                sortKey = "volume";
+            } else if (isTrue(isEqual(sort, "liquidity")))
+            {
+                sortKey = "liquidity";
+            } else if (isTrue(isEqual(sort, "newest")))
+            {
+                sortKey = "created";
+            }
+            if (isTrue(!isEqual(sortKey, null)))
+            {
+                result = this.sortBy(result, sortKey, true, 0);
+            }
+        }
+        object limit = this.safeInteger(parameters, "limit");
+        if (isTrue(!isEqual(limit, null)))
+        {
+            result = this.arraySlice(result, 0, limit);
+        }
+        return result;
+    }
+
+    public virtual object filterEventsByStatus(object events, object status = null)
+    {
+        // 'active' | 'inactive' | 'closed' | 'all' — 'inactive' and 'closed' are interchangeable
+        if (isTrue(isTrue((isEqual(status, null))) || isTrue((isEqual(status, "all")))))
+        {
+            return events;
+        }
+        object wantActive = (isEqual(status, "active"));
+        object result = new List<object>() {};
+        for (object i = 0; isLessThan(i, getArrayLength(events)); postFixIncrement(ref i))
+        {
+            object eventVar = getValue(events, i);
+            object isActive = this.safeBool(eventVar, "active");
+            // keep events whose status is unknown (already filtered server-side, no `active` field)
+            if (isTrue(isTrue((isEqual(isActive, null))) || isTrue((isEqual(isActive, wantActive)))))
+            {
+                ((IList<object>)result).Add(eventVar);
+            }
+        }
+        return result;
+    }
+
+    public virtual object filterEventsBySearchIn(object events, object queries, object searchIn = null)
+    {
+        // keep events whose title and/or description contains one of the queries (searchIn defaults to 'both')
+        if (isTrue(isTrue(isTrue((isEqual(searchIn, null))) || isTrue((isEqual(queries, null)))) || isTrue((isEqual(getArrayLength(queries), 0)))))
+        {
+            return events;
+        }
+        object checkTitle = isTrue((isEqual(searchIn, "title"))) || isTrue((isEqual(searchIn, "both")));
+        object checkDescription = isTrue((isEqual(searchIn, "description"))) || isTrue((isEqual(searchIn, "both")));
+        object result = new List<object>() {};
+        for (object i = 0; isLessThan(i, getArrayLength(events)); postFixIncrement(ref i))
+        {
+            object eventVar = getValue(events, i);
+            object title = this.safeStringLower(eventVar, "title", "");
+            object description = this.safeStringLower(eventVar, "description", "");
+            object matched = false;
+            for (object qi = 0; isLessThan(qi, getArrayLength(queries)); postFixIncrement(ref qi))
+            {
+                object q = ((string)getValue(queries, qi)).ToLower();
+                if (isTrue(isTrue(checkTitle) && isTrue((isGreaterThanOrEqual(getIndexOf(title, q), 0)))))
+                {
+                    matched = true;
+                    break;
+                }
+                if (isTrue(isTrue(checkDescription) && isTrue((isGreaterThanOrEqual(getIndexOf(description, q), 0)))))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+            if (isTrue(matched))
+            {
+                ((IList<object>)result).Add(eventVar);
+            }
+        }
+        return result;
     }
 
     public async virtual Task<object> fetchEvents(object parameters = null)
@@ -375,6 +479,19 @@ public partial class PredictionExchange : Exchange
         return this.toPredictionStructure(parsed, position);
     }
 
+    public virtual object safePredictionOrderBook(object orderbook, object outcomeObj = null)
+    {
+        // normalize a parsed order book to the prediction shape: replace the unified
+        // `symbol` with the `outcome` handle and attach the outcome identity fields
+        // (outcomeId / market) so books match the PredictionOrderBook structure.
+        object fallback = this.safeString2(orderbook, "outcome", "symbol");
+        ((IDictionary<string,object>)orderbook)["outcome"] = ((bool) isTrue((isEqual(outcomeObj, null)))) ? fallback : this.safeString(outcomeObj, "outcome", fallback);
+        ((IDictionary<string,object>)orderbook)["outcomeId"] = ((bool) isTrue((isEqual(outcomeObj, null)))) ? this.safeString(orderbook, "outcomeId") : this.safeString(outcomeObj, "outcomeId");
+        ((IDictionary<string,object>)orderbook)["market"] = ((bool) isTrue((isEqual(outcomeObj, null)))) ? this.safeString(orderbook, "market") : this.safeString(outcomeObj, "market");
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return this.omit(orderbook, "symbol");
+    }
+
     public virtual object toPredictionStructure(object parsed, object raw)
     {
         // rename the unified `symbol` to the prediction `outcome` handle and attach the
@@ -386,8 +503,8 @@ public partial class PredictionExchange : Exchange
         ((IDictionary<string,object>)parsed)["label"] = this.safeString(raw, "label");
         ((IDictionary<string,object>)parsed)["market"] = this.safeString(raw, "market");
         ((IDictionary<string,object>)parsed)["event"] = this.safeString(raw, "event");
-        ((IDictionary<string,object>)parsed).Remove((string)"symbol");
-        return parsed;
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return this.omit(parsed, "symbol");
     }
 
     public virtual object filterByOutcomeSinceLimit(object array, object outcome = null, object since = null, object limit = null, object tail = null)

--- a/cs/ccxt/base/PredictionTypes.cs
+++ b/cs/ccxt/base/PredictionTypes.cs
@@ -270,6 +270,89 @@ public struct PredictionPosition
     }
 }
 
+public struct PredictionOrderBook
+{
+    public List<List<double>>? bids;
+    public List<List<double>>? asks;
+    public string? symbol;
+    public Int64? timestamp;
+    public string? datetime;
+    public Int64? nonce;
+    // prediction-specific
+    public string? outcome;
+    public string? outcomeId;
+    public string? market;
+
+    public PredictionOrderBook(object orderbook2)
+    {
+        var orderbook = (IDictionary<string, object>)orderbook2;
+        bids = orderbook.ContainsKey("bids") ? ((IEnumerable<object>)orderbook["bids"]).Select(x => ((IEnumerable<object>)x).Select(y => Convert.ToDouble(y)).ToList()).ToList() : null;
+        asks = orderbook.ContainsKey("asks") ? ((IEnumerable<object>)orderbook["asks"]).Select(x => ((IEnumerable<object>)x).Select(y => Convert.ToDouble(y)).ToList()).ToList() : null;
+        symbol = Exchange.SafeString(orderbook, "symbol");
+        timestamp = Exchange.SafeInteger(orderbook, "timestamp");
+        datetime = Exchange.SafeString(orderbook, "datetime");
+        nonce = Exchange.SafeInteger(orderbook, "nonce");
+        outcome = Exchange.SafeString(orderbook, "outcome");
+        outcomeId = Exchange.SafeString(orderbook, "outcomeId");
+        market = Exchange.SafeString(orderbook, "market");
+    }
+}
+
+public struct PredictionTradingFee
+{
+    public string? symbol;
+    public double? maker;
+    public double? taker;
+    public bool? percentage;
+    public bool? tierBased;
+    // prediction-specific
+    public string? outcome;
+    public string? outcomeId;
+    public string? market;
+    public Dictionary<string, object> info;
+
+    public PredictionTradingFee(object fee2)
+    {
+        var fee = (Dictionary<string, object>)fee2;
+        symbol = Exchange.SafeString(fee, "symbol");
+        maker = Exchange.SafeFloat(fee, "maker");
+        taker = Exchange.SafeFloat(fee, "taker");
+        percentage = fee.ContainsKey("percentage") && fee["percentage"] != null ? (bool)fee["percentage"] : null;
+        tierBased = fee.ContainsKey("tierBased") && fee["tierBased"] != null ? (bool)fee["tierBased"] : null;
+        outcome = Exchange.SafeString(fee, "outcome");
+        outcomeId = Exchange.SafeString(fee, "outcomeId");
+        market = Exchange.SafeString(fee, "market");
+        info = Helper.GetInfo(fee);
+    }
+}
+
+public struct PredictionOpenInterest
+{
+    public string? symbol;
+    public double? openInterestAmount;
+    public double? openInterestValue;
+    public Int64? timestamp;
+    public string? datetime;
+    // prediction-specific
+    public string? outcome;
+    public string? outcomeId;
+    public string? market;
+    public Dictionary<string, object> info;
+
+    public PredictionOpenInterest(object openInterest)
+    {
+        symbol = Exchange.SafeString(openInterest, "symbol");
+        openInterestAmount = Exchange.SafeFloat(openInterest, "openInterestAmount");
+        openInterestValue = Exchange.SafeFloat(openInterest, "openInterestValue");
+        timestamp = Exchange.SafeInteger(openInterest, "timestamp");
+        datetime = Exchange.SafeString(openInterest, "datetime");
+        outcome = Exchange.SafeString(openInterest, "outcome");
+        outcomeId = Exchange.SafeString(openInterest, "outcomeId");
+        market = Exchange.SafeString(openInterest, "market");
+        info = Helper.GetInfo(openInterest);
+    }
+}
+
 public struct PredictionTickers
 {
     public Dictionary<string, object> info;

--- a/cs/ccxt/exchanges/prediction/hyperliquid.cs
+++ b/cs/ccxt/exchanges/prediction/hyperliquid.cs
@@ -752,10 +752,9 @@ public partial class hyperliquid : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure)
      */
-    public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
+    public async override Task<object> fetchTickers(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        object outcomes = symbols;
         object requestedOutcomeSymbols = new Dictionary<string, object>() {};
         if (isTrue(!isEqual(outcomes, null)))
         {
@@ -1082,10 +1081,9 @@ public partial class hyperliquid : PredictionExchange
      * @param {string} [params.user] wallet address
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    public async override Task<object> fetchPositions(object symbols = null, object parameters = null)
+    public async override Task<object> fetchPositions(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        object outcomes = symbols;
         object requestedOutcomeSymbols = new Dictionary<string, object>() {};
         if (isTrue(!isEqual(outcomes, null)))
         {

--- a/cs/ccxt/exchanges/prediction/hyperliquid.cs
+++ b/cs/ccxt/exchanges/prediction/hyperliquid.cs
@@ -576,9 +576,7 @@ public partial class hyperliquid : PredictionExchange
         object outcomes = new List<object>() {new Dictionary<string, object>() {
     { "id", this.outcomeCoin(yesEncoding) },
     { "outcomeId", this.outcomeCoin(yesEncoding) },
-    { "symbol", yesOutcomeSymbol },
     { "outcome", yesOutcomeSymbol },
-    { "marketSymbol", parentSymbol },
     { "market", parentSymbol },
     { "label", yesLabel },
     { "active", active },
@@ -597,9 +595,7 @@ public partial class hyperliquid : PredictionExchange
 }, new Dictionary<string, object>() {
     { "id", this.outcomeCoin(noEncoding) },
     { "outcomeId", this.outcomeCoin(noEncoding) },
-    { "symbol", noOutcomeSymbol },
     { "outcome", noOutcomeSymbol },
-    { "marketSymbol", parentSymbol },
     { "market", parentSymbol },
     { "label", noLabel },
     { "active", active },
@@ -721,8 +717,7 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object coin = this.safeString(info, "coinName");
@@ -761,17 +756,16 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcomes = symbols;
-        await this.loadMarkets();
         object requestedOutcomeSymbols = new Dictionary<string, object>() {};
         if (isTrue(!isEqual(outcomes, null)))
         {
             for (object i = 0; isLessThan(i, getArrayLength(outcomes)); postFixIncrement(ref i))
             {
                 object requested = getValue(outcomes, i);
-                this.checkEventsAndMarkets(requested);
+                this.checkEvents(requested);
                 object requestedOutcomeObj = this.outcome(requested);
-                object requestedSymbol = this.safeString(requestedOutcomeObj, "symbol", requested);
-                ((IDictionary<string,object>)requestedOutcomeSymbols)[(string)requestedSymbol] = true;
+                object requestedOutcome = this.safeString(requestedOutcomeObj, "outcome", requested);
+                ((IDictionary<string,object>)requestedOutcomeSymbols)[(string)requestedOutcome] = true;
             }
         }
         object response = await this.publicPostInfo(this.extend(new Dictionary<string, object>() {
@@ -783,15 +777,15 @@ public partial class hyperliquid : PredictionExchange
         object mids = this.safeDict(response, "mids", response);
         object tickers = new Dictionary<string, object>() {};
         object outcomesMap = ((bool) isTrue((!isEqual(this.outcomes, null)))) ? this.outcomes : new Dictionary<string, object>() {};
-        object outcomeSymbols = new List<object>(((IDictionary<string,object>)outcomesMap).Keys);
-        for (object i = 0; isLessThan(i, getArrayLength(outcomeSymbols)); postFixIncrement(ref i))
+        object outcomeHandles = new List<object>(((IDictionary<string,object>)outcomesMap).Keys);
+        for (object i = 0; isLessThan(i, getArrayLength(outcomeHandles)); postFixIncrement(ref i))
         {
-            object outcomeSymbol = getValue(outcomeSymbols, i);
-            if (isTrue(isTrue(!isEqual(outcomes, null)) && !isTrue((inOp(requestedOutcomeSymbols, outcomeSymbol)))))
+            object outcomeHandle = getValue(outcomeHandles, i);
+            if (isTrue(isTrue(!isEqual(outcomes, null)) && !isTrue((inOp(requestedOutcomeSymbols, outcomeHandle)))))
             {
                 continue;
             }
-            object outcomeObj = this.safeDict(outcomesMap, outcomeSymbol, new Dictionary<string, object>() {});
+            object outcomeObj = this.safeDict(outcomesMap, outcomeHandle, new Dictionary<string, object>() {});
             object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
             object coin = this.safeString(info, "coinName");
             object mid = this.safeNumber(mids, coin);
@@ -805,7 +799,7 @@ public partial class hyperliquid : PredictionExchange
                 { "mid", mid },
                 { "time", this.milliseconds() },
             }, ((object)outcomeObj));
-            ((IDictionary<string,object>)tickers)[(string)outcomeSymbol] = ticker;
+            ((IDictionary<string,object>)tickers)[(string)outcomeHandle] = ticker;
         }
         return tickers;
     }
@@ -852,7 +846,7 @@ public partial class hyperliquid : PredictionExchange
             mid = divide(this.sum(bid, ask), 2);
         }
         // day volume lives on the parent market's ctx; resolve it from the outcome's marketSymbol
-        object parentSymbol = this.safeString(mkt, "marketSymbol");
+        object parentSymbol = this.safeString(mkt, "outcome");
         object parentMarket = ((bool) isTrue((!isEqual(parentSymbol, null)))) ? this.safeMarket(parentSymbol) : null;
         object ctx = ((bool) isTrue((!isEqual(parentMarket, null)))) ? this.safeDict(this.safeDict(((object)parentMarket), "info", new Dictionary<string, object>() {}), "ctx", new Dictionary<string, object>() {}) : new Dictionary<string, object>() {};
         object dayVolume = this.safeNumber(ctx, "dayNtlVlm");
@@ -860,7 +854,7 @@ public partial class hyperliquid : PredictionExchange
             { "symbol", symbol },
             { "outcomeId", this.safeString(mkt, "id") },
             { "label", this.safeString(mkt, "label") },
-            { "market", this.safeString(mkt, "marketSymbol") },
+            { "market", this.safeString(mkt, "outcome") },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
             { "high", null },
@@ -897,8 +891,7 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object request = new Dictionary<string, object>() {
@@ -932,10 +925,11 @@ public partial class hyperliquid : PredictionExchange
             object entry = getValue(rawAsks, i);
             ((IList<object>)asks).Add(new List<object> {this.safeNumber(entry, "px"), this.safeNumber(entry, "sz")});
         }
-        return this.parseOrderBook(new Dictionary<string, object>() {
+        object orderbook = this.parseOrderBook(new Dictionary<string, object>() {
             { "bids", bids },
             { "asks", asks },
         }, this.safeString(outcomeObj, "symbol", outcome), timestamp);
+        return this.safePredictionOrderBook(orderbook, outcomeObj);
     }
 
     /**
@@ -956,10 +950,9 @@ public partial class hyperliquid : PredictionExchange
         timeframe ??= "1m";
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
-        object market = this.market(this.safeString(outcomeObj, "marketSymbol"));
+        object market = this.market(this.safeString(outcomeObj, "outcome"));
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object until = this.safeInteger(parameters, "until", this.milliseconds());
         object startTime = since;
@@ -1093,17 +1086,16 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcomes = symbols;
-        await this.loadMarkets();
         object requestedOutcomeSymbols = new Dictionary<string, object>() {};
         if (isTrue(!isEqual(outcomes, null)))
         {
             for (object i = 0; isLessThan(i, getArrayLength(outcomes)); postFixIncrement(ref i))
             {
                 object requested = getValue(outcomes, i);
-                this.checkEventsAndMarkets(requested);
+                this.checkEvents(requested);
                 object requestedOutcomeObj = this.outcome(requested);
-                object requestedSymbol = this.safeString(requestedOutcomeObj, "symbol", requested);
-                ((IDictionary<string,object>)requestedOutcomeSymbols)[(string)requestedSymbol] = true;
+                object requestedOutcome = this.safeString(requestedOutcomeObj, "outcome", requested);
+                ((IDictionary<string,object>)requestedOutcomeSymbols)[(string)requestedOutcome] = true;
             }
         }
         object userAddress = null;
@@ -1136,8 +1128,8 @@ public partial class hyperliquid : PredictionExchange
             object outcomeObj = this.safeOutcome(outcomeId);
             if (isTrue(!isEqual(outcomes, null)))
             {
-                object outcomeSymbol = this.safeString(outcomeObj, "symbol");
-                if (isTrue(isTrue(isEqual(outcomeSymbol, null)) || !isTrue((inOp(requestedOutcomeSymbols, outcomeSymbol)))))
+                object outcomeHandle = this.safeString(outcomeObj, "outcome");
+                if (isTrue(isTrue(isEqual(outcomeHandle, null)) || !isTrue((inOp(requestedOutcomeSymbols, outcomeHandle)))))
                 {
                     continue;
                 }
@@ -1175,7 +1167,7 @@ public partial class hyperliquid : PredictionExchange
             { "symbol", this.safeString(outcomeObj, "symbol") },
             { "outcomeId", this.safeString(outcomeObj, "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "timestamp", null },
             { "datetime", null },
             { "isolated", false },
@@ -1345,11 +1337,10 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         await this.initializeClient();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
-        object market = this.market(this.safeString(outcomeObj, "marketSymbol"));
+        object market = this.market(this.safeString(outcomeObj, "outcome"));
         object outcomeInfo = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object nonce = this.milliseconds();
         object isBuy = (isEqual(((string)side).ToUpper(), "BUY"));
@@ -1379,12 +1370,12 @@ public partial class hyperliquid : PredictionExchange
         {
             object priceStr = this.numberToString(price);
             px = ((bool) isTrue(isBuy)) ? Precise.stringMul(priceStr, Precise.stringAdd("1", slippage)) : Precise.stringMul(priceStr, Precise.stringSub("1", slippage));
-            px = this.priceToPrecision(this.safeString(outcomeObj, "marketSymbol"), px);
+            px = this.priceToPrecision(this.safeString(outcomeObj, "outcome"), px);
         } else
         {
-            px = this.priceToPrecision(this.safeString(outcomeObj, "marketSymbol"), price);
+            px = this.priceToPrecision(this.safeString(outcomeObj, "outcome"), price);
         }
-        object sz = this.amountToPrecision(this.safeString(outcomeObj, "marketSymbol"), amount);
+        object sz = this.amountToPrecision(this.safeString(outcomeObj, "outcome"), amount);
         object orderType = new Dictionary<string, object>() {
             { "limit", new Dictionary<string, object>() {
                 { "tif", tif },
@@ -1452,10 +1443,10 @@ public partial class hyperliquid : PredictionExchange
             { "timestamp", nonce },
             { "datetime", this.iso8601(nonce) },
             { "status", orderStatus },
-            { "symbol", this.safeString(outcomeObj, "symbol", outcome) },
+            { "outcome", this.safeString(outcomeObj, "outcome", outcome) },
             { "outcomeId", this.safeString(outcomeObj, "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "type", type },
             { "side", side },
             { "price", price },
@@ -1507,9 +1498,8 @@ public partial class hyperliquid : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " cancelOrders() requires an outcome argument")) ;
         }
-        await this.loadMarkets();
         await this.initializeClient();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object outcomeInfo = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object assetId = this.safeInteger(outcomeInfo, "assetId");
@@ -1563,7 +1553,7 @@ public partial class hyperliquid : PredictionExchange
         object innerResponse = this.safeDict(response, "response");
         object data = this.safeDict(innerResponse, "data");
         object statuses = this.safeList(data, "statuses", new List<object>() {});
-        object outcomeSymbol = this.safeString(outcomeObj, "symbol", outcome);
+        object outcomeSymbol = this.safeString(outcomeObj, "outcome", outcome);
         object requestIds = ids;
         if (isTrue(!isEqual(clientOrderId, null)))
         {
@@ -1595,11 +1585,10 @@ public partial class hyperliquid : PredictionExchange
                 { "clientOrderId", ((bool) isTrue((!isEqual(clientOrderId, null)))) ? requestId : null },
                 { "info", status },
                 { "status", "canceled" },
-                { "symbol", outcomeSymbol },
                 { "outcome", outcomeSymbol },
                 { "outcomeId", this.safeString(outcomeObj, "id") },
                 { "label", this.safeString(outcomeObj, "label") },
-                { "market", this.safeString(outcomeObj, "marketSymbol") },
+                { "market", this.safeString(outcomeObj, "outcome") },
                 { "timestamp", this.milliseconds() },
                 { "datetime", this.iso8601(this.milliseconds()) },
             };
@@ -1625,7 +1614,6 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object userAddress = null;
         var userAddressparametersVariable = this.handlePublicAddress("fetchOpenOrders", parameters);
         userAddress = ((IList<object>)userAddressparametersVariable)[0];
@@ -1651,9 +1639,9 @@ public partial class hyperliquid : PredictionExchange
         object outcomeHandle = null;
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             object outcomeObj = this.outcome(outcome);
-            outcomeHandle = this.safeString(outcomeObj, "symbol");
+            outcomeHandle = this.safeString(outcomeObj, "outcome");
         }
         return this.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit);
     }
@@ -1674,7 +1662,6 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object userAddress = null;
         var userAddressparametersVariable = this.handlePublicAddress("fetchOrders", parameters);
         userAddress = ((IList<object>)userAddressparametersVariable)[0];
@@ -1716,9 +1703,9 @@ public partial class hyperliquid : PredictionExchange
         object outcomeHandle = null;
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             object outcomeObj = this.outcome(outcome);
-            outcomeHandle = this.safeString(outcomeObj, "symbol");
+            outcomeHandle = this.safeString(outcomeObj, "outcome");
         }
         return this.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit);
     }
@@ -1739,7 +1726,6 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object userAddress = null;
         var userAddressparametersVariable = this.handlePublicAddress("fetchOrder", parameters);
         userAddress = ((IList<object>)userAddressparametersVariable)[0];
@@ -1763,9 +1749,9 @@ public partial class hyperliquid : PredictionExchange
         object parsed = this.parseOrder(orderWrapper, null);
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             object outcomeObj = this.outcome(outcome);
-            object expected = this.safeString(outcomeObj, "symbol");
+            object expected = this.safeString(outcomeObj, "outcome");
             if (isTrue(!isEqual(this.safeString(parsed, "outcome"), expected)))
             {
                 throw new OrderNotFound ((string)add(add(add(add(this.id, " fetchOrder() order "), id), " is not in outcome "), expected)) ;
@@ -1808,7 +1794,7 @@ public partial class hyperliquid : PredictionExchange
         object status = this.parseOrderStatus(this.safeString2(order, "ccxtStatus", "status"));
         object coin = this.safeString(entry, "coin");
         object outcomeObj = this.safeOutcome(coin, ((object)market));
-        object marketSymbol = this.safeString(outcomeObj, "marketSymbol");
+        object marketSymbol = this.safeString(outcomeObj, "outcome");
         object resolvedMarket = ((bool) isTrue(marketSymbol)) ? this.safeMarket(marketSymbol, ((object)market)) : market;
         object sideRaw = this.safeString(entry, "side");
         object side = ((bool) isTrue((isEqual(sideRaw, "B")))) ? "buy" : "sell";
@@ -1831,10 +1817,10 @@ public partial class hyperliquid : PredictionExchange
             { "datetime", this.iso8601(timestamp) },
             { "lastTradeTimestamp", null },
             { "status", status },
-            { "symbol", this.safeString(outcomeObj, "symbol") },
+            { "outcome", this.safeString(outcomeObj, "outcome") },
             { "outcomeId", this.safeString(outcomeObj, "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "type", this.parseOrderType(this.safeString(entry, "orderType", "limit")) },
             { "timeInForce", tif },
             { "postOnly", postOnly },
@@ -1916,7 +1902,6 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object userAddress = null;
         var userAddressparametersVariable = this.handlePublicAddress("fetchMyTrades", parameters);
         userAddress = ((IList<object>)userAddressparametersVariable)[0];
@@ -1943,9 +1928,9 @@ public partial class hyperliquid : PredictionExchange
         object outcomeHandle = null;
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             object outcomeObj = this.outcome(outcome);
-            outcomeHandle = this.safeString(outcomeObj, "symbol");
+            outcomeHandle = this.safeString(outcomeObj, "outcome");
         }
         return this.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit);
     }
@@ -1985,13 +1970,13 @@ public partial class hyperliquid : PredictionExchange
         object amount = this.safeString(trade, "sz");
         object coin = this.safeString(trade, "coin");
         object outcomeObj = this.safeOutcome(coin, ((object)market));
-        object marketSymbol = this.safeString(outcomeObj, "marketSymbol");
+        object marketSymbol = this.safeString(outcomeObj, "outcome");
         object resolvedMarket = ((bool) isTrue(marketSymbol)) ? this.safeMarket(marketSymbol, ((object)market)) : market;
         object rawSide = this.safeString(trade, "side");
         object side = ((bool) isTrue((isEqual(rawSide, "B")))) ? "buy" : "sell";
         object fee = this.safeNumber(trade, "fee");
         object feeCurrency = this.safeString(trade, "feeToken", "USDC");
-        object outcomeSymbol = this.safeString(outcomeObj, "symbol");
+        object outcomeSymbol = this.safeString(outcomeObj, "outcome");
         object feeObject = null;
         if (isTrue(!isEqual(fee, null)))
         {
@@ -2010,11 +1995,10 @@ public partial class hyperliquid : PredictionExchange
             { "info", trade },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", outcomeSymbol },
             { "outcome", outcomeSymbol },
             { "outcomeId", this.safeString(outcomeObj, "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "order", this.safeString(trade, "oid") },
             { "type", "limit" },
             { "side", side },
@@ -2039,7 +2023,6 @@ public partial class hyperliquid : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object queries = this.parseSearchQueries(parameters);
-        await this.loadMarkets();
         object marketValues = new List<object>(((IDictionary<string,object>)this.markets).Values);
         // Group markets by parentSymbol
         object groupMap = new Dictionary<string, object>() {};
@@ -2106,7 +2089,7 @@ public partial class hyperliquid : PredictionExchange
             object ev = getValue(events, i);
             ((IDictionary<string,object>)this.events)[(string)getValue(ev, "symbol")] = ev;
         }
-        return events;
+        return this.applyEventFetchParams(events, parameters, queries);
     }
 
     /**

--- a/cs/ccxt/exchanges/prediction/kalshi.cs
+++ b/cs/ccxt/exchanges/prediction/kalshi.cs
@@ -740,9 +740,10 @@ public partial class kalshi : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
+    public async override Task<object> fetchTickers(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
+        object symbols = outcomes;
         object targets = new List<object>() {};
         if (isTrue(!isEqual(symbols, null)))
         {
@@ -1230,10 +1231,9 @@ public partial class kalshi : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    public async override Task<object> fetchPositions(object symbols = null, object parameters = null)
+    public async override Task<object> fetchPositions(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        object outcomes = symbols;
         object outcomesLength = 0;
         if (isTrue(!isEqual(outcomes, null)))
         {

--- a/cs/ccxt/exchanges/prediction/kalshi.cs
+++ b/cs/ccxt/exchanges/prediction/kalshi.cs
@@ -373,9 +373,7 @@ public partial class kalshi : PredictionExchange
             ((IList<object>)outcomes).Add(new Dictionary<string, object>() {
                 { "id", getValue(outcomeIds, oi) },
                 { "outcomeId", getValue(outcomeIds, oi) },
-                { "symbol", outcomeHandle },
                 { "outcome", outcomeHandle },
-                { "marketSymbol", marketSymbol },
                 { "market", marketSymbol },
                 { "label", label },
                 { "active", active },
@@ -470,8 +468,7 @@ public partial class kalshi : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object ticker = this.safeString(getValue(outcomeObj, "info"), "ticker");
         object request = new Dictionary<string, object>() {
@@ -575,8 +572,7 @@ public partial class kalshi : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object ticker = this.safeString(getValue(outcomeObj, "info"), "ticker");
         object request = new Dictionary<string, object>() {
@@ -593,7 +589,7 @@ public partial class kalshi : PredictionExchange
         //     { "ticker": "...", "open_interest_fp": "60802.01", ... }   // open interest in contracts
         //
         object timestamp = this.milliseconds();
-        return this.safeOpenInterest(new Dictionary<string, object>() {
+        object openInterest = this.safeOpenInterest(new Dictionary<string, object>() {
             { "symbol", this.safeSymbol(null, market) },
             { "openInterestAmount", this.safeNumber2(interest, "open_interest_fp", "open_interest") },
             { "openInterestValue", null },
@@ -603,6 +599,10 @@ public partial class kalshi : PredictionExchange
             { "datetime", this.iso8601(timestamp) },
             { "info", interest },
         }, market);
+        ((IDictionary<string,object>)openInterest)["outcome"] = this.safeOutcomeSymbol(null, market);
+        ((IDictionary<string,object>)openInterest)["outcomeId"] = this.safeString(market, "outcomeId");
+        ((IDictionary<string,object>)openInterest).Remove((string)"symbol");
+        return openInterest;
     }
 
     /**
@@ -672,11 +672,11 @@ public partial class kalshi : PredictionExchange
         //     }
         //
         object marketAny = ((object)market);
-        object outcomeObj = this.safeOutcome(this.safeString(marketAny, "symbol"), marketAny);
+        object outcomeObj = this.safeOutcome(this.safeString(marketAny, "outcome"), marketAny);
         object outcomeLabel = ((bool) isTrue(market)) ? this.safeString(market, "label", this.safeString(getValue(market, "info"), "outcomeLabel", "YES")) : "YES";
         object isNo = isEqual(((string)outcomeLabel).ToUpper(), "NO");
         object now = this.milliseconds();
-        object symbol = this.safeString(outcomeObj, "symbol");
+        object symbol = this.safeString(outcomeObj, "outcome");
         object yesAsk = this.safeNumber(raw, "yes_ask_dollars");
         object yesBid = this.safeNumber(raw, "yes_bid_dollars");
         object noAsk = this.safeNumber(raw, "no_ask_dollars");
@@ -705,10 +705,10 @@ public partial class kalshi : PredictionExchange
             average = this.parseNumber(Precise.stringDiv(Precise.stringAdd(this.numberToString(bid), this.numberToString(ask)), "2"));
         }
         return this.safePredictionTicker(new Dictionary<string, object>() {
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "outcomeId", this.safeString2(outcomeObj, "outcomeId", "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString2(outcomeObj, "market", "marketSymbol") },
+            { "market", this.safeString2(outcomeObj, "market", "outcome") },
             { "timestamp", now },
             { "datetime", this.iso8601(now) },
             { "high", null },
@@ -743,18 +743,17 @@ public partial class kalshi : PredictionExchange
     public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         object targets = new List<object>() {};
         if (isTrue(!isEqual(symbols, null)))
         {
             for (object i = 0; isLessThan(i, getArrayLength(symbols)); postFixIncrement(ref i))
             {
-                this.checkEventsAndMarkets(getValue(symbols, i));
+                this.checkEvents(getValue(symbols, i));
                 ((IList<object>)targets).Add(getValue(symbols, i));
             }
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
             object allKeys = new List<object>(((IDictionary<string,object>)this.outcomes).Keys);
             for (object i = 0; isLessThan(i, getArrayLength(allKeys)); postFixIncrement(ref i))
             {
@@ -842,8 +841,7 @@ public partial class kalshi : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object ticker = this.safeString(getValue(outcomeObj, "info"), "ticker");
         object isNo = isEqual(getValue(outcomeObj, "label"), "NO");
@@ -900,7 +898,7 @@ public partial class kalshi : PredictionExchange
                 ((IList<object>)asks).Add(new List<object>() {price, this.safeNumber(getValue(rawNo, ai), 1)});
             }
         }
-        return this.sortedOrders(this.safeString(outcomeObj, "symbol", outcome), timestamp, bids, asks);
+        return this.safePredictionOrderBook(this.sortedOrders(this.safeString(outcomeObj, "outcome", outcome), timestamp, bids, asks), outcomeObj);
     }
 
     /**
@@ -920,7 +918,7 @@ public partial class kalshi : PredictionExchange
         bids = this.sortBy(bids, 0, true);
         asks = this.sortBy(asks, 0);
         return new Dictionary<string, object>() {
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "bids", bids },
             { "asks", asks },
             { "timestamp", timestamp },
@@ -946,8 +944,7 @@ public partial class kalshi : PredictionExchange
         timeframe ??= "1m";
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object ticker = this.safeString(getValue(outcomeObj, "info"), "ticker");
         object seriesTicker = this.safeString(getValue(outcomeObj, "info"), "seriesTicker", ticker);
@@ -1087,8 +1084,7 @@ public partial class kalshi : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object ticker = this.safeString(getValue(outcomeObj, "info"), "ticker");
         object request = new Dictionary<string, object>() {
@@ -1140,10 +1136,10 @@ public partial class kalshi : PredictionExchange
         object amount = this.safeNumber(trade, "count", amountFp);
         object rawSide = this.safeStringLower(trade, "taker_side");
         object marketAny = ((object)market);
-        object outcomeObj = this.safeOutcome(this.safeString(marketAny, "symbol"), marketAny);
+        object outcomeObj = this.safeOutcome(this.safeString(marketAny, "outcome"), marketAny);
         object marketInfo = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object requestedOutcomeLabel = this.safeStringLower(outcomeObj, "label", this.safeStringLower(marketInfo, "outcomeLabel"));
-        object outcomeSymbol = this.safeString(outcomeObj, "symbol");
+        object outcomeSymbol = this.safeString(outcomeObj, "outcome");
         object outcomeId = this.safeString2(outcomeObj, "outcomeId", "id");
         object side = null;
         if (isTrue(isTrue(isEqual(rawSide, "yes")) || isTrue(isEqual(rawSide, "no"))))
@@ -1166,11 +1162,10 @@ public partial class kalshi : PredictionExchange
             { "info", trade },
             { "timestamp", ts },
             { "datetime", this.iso8601(ts) },
-            { "symbol", outcomeSymbol },
             { "outcome", outcomeSymbol },
             { "outcomeId", outcomeId },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString2(outcomeObj, "market", "marketSymbol") },
+            { "market", this.safeString2(outcomeObj, "market", "outcome") },
             { "order", null },
             { "type", null },
             { "side", side },
@@ -1193,7 +1188,7 @@ public partial class kalshi : PredictionExchange
     public async override Task<object> fetchBalance(object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        this.checkEventsAndMarkets();
+        this.checkEvents();
         object response = await this.kalshiPrivateGetPortfolioBalance(parameters);
         return this.parseBalance(response);
     }
@@ -1248,11 +1243,11 @@ public partial class kalshi : PredictionExchange
         {
             for (object i = 0; isLessThan(i, getArrayLength(outcomes)); postFixIncrement(ref i))
             {
-                this.checkEventsAndMarkets(getValue(outcomes, i));
+                this.checkEvents(getValue(outcomes, i));
             }
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object response = await this.kalshiPrivateGetPortfolioPositions(parameters);
         object positions = (IList<object>)(this.safeList(response, "market_positions", new List<object>() {}));
@@ -1282,10 +1277,10 @@ public partial class kalshi : PredictionExchange
         }
         return this.safePredictionPosition(new Dictionary<string, object>() {
             { "id", null },
-            { "symbol", this.safeString(outcomeObj, "symbol", ticker) },
+            { "outcome", this.safeString(outcomeObj, "outcome", ticker) },
             { "outcomeId", this.safeString2(outcomeObj, "outcomeId", "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString2(outcomeObj, "market", "marketSymbol") },
+            { "market", this.safeString2(outcomeObj, "market", "outcome") },
             { "timestamp", null },
             { "datetime", null },
             { "contracts", contractsValue },
@@ -1329,10 +1324,10 @@ public partial class kalshi : PredictionExchange
         object outcome = symbol;
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object request = new Dictionary<string, object>() {
             { "status", "resting" },
@@ -1363,10 +1358,10 @@ public partial class kalshi : PredictionExchange
         parameters ??= new Dictionary<string, object>();
         if (isTrue(!isEqual(symbol, null)))
         {
-            this.checkEventsAndMarkets(symbol);
+            this.checkEvents(symbol);
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object response = await this.kalshiPrivateGetPortfolioOrdersOrderId(this.extend(new Dictionary<string, object>() {
             { "order_id", id },
@@ -1413,10 +1408,10 @@ public partial class kalshi : PredictionExchange
             { "datetime", this.iso8601(ts) },
             { "lastTradeTimestamp", null },
             { "status", status },
-            { "symbol", this.safeString(mkt, "symbol") },
+            { "outcome", this.safeString(mkt, "outcome") },
             { "outcomeId", this.safeString2(mkt, "outcomeId", "id") },
             { "label", this.safeString(mkt, "label") },
-            { "market", this.safeString2(mkt, "market", "marketSymbol") },
+            { "market", this.safeString2(mkt, "market", "outcome") },
             { "type", this.safeStringLower(order, "type", "limit") },
             { "timeInForce", "GTC" },
             { "postOnly", null },
@@ -1470,8 +1465,7 @@ public partial class kalshi : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object ticker = this.safeString(getValue(outcomeObj, "info"), "ticker");
         object outcomeLabel = getValue(outcomeObj, "label");
@@ -1511,10 +1505,10 @@ public partial class kalshi : PredictionExchange
         parameters ??= new Dictionary<string, object>();
         if (isTrue(!isEqual(symbol, null)))
         {
-            this.checkEventsAndMarkets(symbol);
+            this.checkEvents(symbol);
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object response = await this.kalshiPrivateDeletePortfolioOrdersOrderId(this.extend(new Dictionary<string, object>() {
             { "order_id", id },
@@ -1537,15 +1531,14 @@ public partial class kalshi : PredictionExchange
         object outcome = symbol;
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object request = new Dictionary<string, object>() {};
         if (isTrue(!isEqual(outcome, null)))
         {
-            await this.loadMarkets();
             object outcomeObj = this.outcome(outcome);
             ((IDictionary<string,object>)request)["ticker"] = this.safeString(getValue(outcomeObj, "info"), "ticker");
         }
@@ -1571,10 +1564,16 @@ public partial class kalshi : PredictionExchange
         parameters ??= new Dictionary<string, object>();
         object queries = this.parseSearchQueries(parameters);
         parameters = this.omit(parameters, new List<object>() {"query", "queries"});
-        object status = this.safeString(parameters, "status", this.safeString(this.options, "defaultEventStatus", "open"));
+        // map the unified status onto the kalshi event status (open / closed) so it is pushed server-side
+        object requestedStatus = this.safeString(parameters, "status", this.safeString(this.options, "defaultEventStatus", "active"));
+        object status = "open";
+        if (isTrue(isTrue((isEqual(requestedStatus, "closed"))) || isTrue((isEqual(requestedStatus, "inactive")))))
+        {
+            status = "closed";
+        }
         object pageLimit = this.safeInteger(parameters, "limit", 200);
         object maxPages = this.safeInteger(parameters, "maxPages", 50);
-        object rest = this.omit(parameters, new List<object>() {"status", "limit", "maxPages"});
+        object rest = this.omit(parameters, new List<object>() {"status", "limit", "maxPages", "sort", "searchIn", "eventId", "slug"});
         if (!isTrue(this.events))
         {
             this.events = new Dictionary<string, object>() {};
@@ -1701,19 +1700,19 @@ public partial class kalshi : PredictionExchange
             for (object j = 0; isLessThan(j, getArrayLength(outcomesList)); postFixIncrement(ref j))
             {
                 object oc = getValue(outcomesList, j);
-                object ocSymbol = this.safeString(oc, "symbol");
+                object ocSymbol = this.safeString(oc, "outcome");
                 if (isTrue(!isEqual(ocSymbol, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes)[(string)ocSymbol] = oc;
                 }
-                object ocId = this.safeString(oc, "id");
+                object ocId = this.safeString(oc, "outcomeId");
                 if (isTrue(!isEqual(ocId, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes_by_id)[(string)ocId] = oc;
                 }
             }
         }
-        return result;
+        return this.applyEventFetchParams(result, parameters, queries);
     }
 
     /**
@@ -1819,23 +1818,41 @@ public partial class kalshi : PredictionExchange
         // }
         object rawMarkets = (IList<object>)(this.safeList(rawEvent, "markets", new List<object>() {}));
         object marketsList = new List<object>() {};
+        // aggregate volume/liquidity from the markets and derive the creation time so sort works
+        object totalVolume = 0;
+        object totalLiquidity = 0;
+        object earliestCreated = null;
         for (object i = 0; isLessThan(i, getArrayLength(rawMarkets)); postFixIncrement(ref i))
         {
             object rawMarket = getValue(rawMarkets, i);
             object parsed = this.parseMarket(rawMarket);
             ((IList<object>)marketsList).Add(parsed);
+            totalVolume = this.sum(totalVolume, this.safeNumber2(rawMarket, "volume_fp", "volume", 0));
+            totalLiquidity = this.sum(totalLiquidity, this.safeNumber2(rawMarket, "liquidity_dollars", "liquidity", 0));
+            object marketCreated = this.parse8601(this.safeString(rawMarket, "open_time"));
+            if (isTrue(isTrue((!isEqual(marketCreated, null))) && isTrue((isTrue((isEqual(earliestCreated, null))) || isTrue((isLessThan(marketCreated, earliestCreated)))))))
+            {
+                earliestCreated = marketCreated;
+            }
         }
         object ticker = this.safeString(rawEvent, "event_ticker");
         object title = this.safeString(rawEvent, "title");
+        object created = this.parse8601(this.safeString(rawEvent, "created_date_iso"));
+        if (isTrue(isEqual(created, null)))
+        {
+            created = earliestCreated;
+        }
         return this.extend(new Dictionary<string, object>() {
             { "id", ticker },
             { "slug", ticker },
             { "symbol", ((bool) isTrue(title)) ? this.shortenSlug(title) : null },
             { "title", title },
             { "markets", marketsList },
+            { "volume", totalVolume },
+            { "liquidity", totalLiquidity },
             { "url", this.safeString(rawEvent, "url") },
             { "image", this.safeString(rawEvent, "image_url") },
-            { "created", this.parse8601(this.safeString(rawEvent, "created_date_iso")) },
+            { "created", created },
             { "createdDatetime", this.safeString(rawEvent, "created_date_iso") },
             { "end", this.parse8601(this.safeString(rawEvent, "end_date_iso")) },
             { "endDatetime", this.safeString(rawEvent, "end_date_iso") },

--- a/cs/ccxt/exchanges/prediction/limitless.cs
+++ b/cs/ccxt/exchanges/prediction/limitless.cs
@@ -1080,9 +1080,10 @@ public partial class limitless : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
+    public async override Task<object> fetchTickers(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
+        object symbols = outcomes;
         object result = new Dictionary<string, object>() {};
         if (isTrue(isEqual(symbols, null)))
         {
@@ -2654,9 +2655,10 @@ public partial class limitless : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    public async override Task<object> fetchPositions(object symbols = null, object parameters = null)
+    public async override Task<object> fetchPositions(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
+        object symbols = outcomes;
         object symbolsLength = 0;
         if (isTrue(!isEqual(symbols, null)))
         {

--- a/cs/ccxt/exchanges/prediction/limitless.cs
+++ b/cs/ccxt/exchanges/prediction/limitless.cs
@@ -748,6 +748,8 @@ public partial class limitless : PredictionExchange
         object title = this.safeString(eventVar, "title", groupId);
         object markets = new List<object>() {};
         object rawMarkets = this.safeList(eventVar, "markets", new List<object>() {});
+        // aggregate 24h volume across the markets so sort by volume works
+        object totalVolume = 0;
         for (object i = 0; isLessThan(i, getArrayLength(rawMarkets)); postFixIncrement(ref i))
         {
             object rawMarket = getValue(rawMarkets, i);
@@ -760,6 +762,8 @@ public partial class limitless : PredictionExchange
             {
                 ((IList<object>)markets).Add(this.parseMarket(rawMarket));
             }
+            object marketInfo = this.safeDict(rawMarket, "info", rawMarket);
+            totalVolume = this.sum(totalVolume, this.safeNumber2(marketInfo, "volume24h", "volume", 0));
         }
         return ((object)this.extend(new Dictionary<string, object>() {
             { "id", groupId },
@@ -768,6 +772,8 @@ public partial class limitless : PredictionExchange
             { "title", title },
             { "description", this.safeString(eventVar, "description") },
             { "markets", markets },
+            { "volume", totalVolume },
+            { "liquidity", this.safeNumber(eventVar, "liquidity") },
             { "url", this.safeString(eventVar, "url") },
             { "image", this.safeString(eventVar, "imageUrl", this.safeString(eventVar, "image")) },
             { "active", this.safeBool(eventVar, "active", true) },
@@ -798,8 +804,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object slug = this.safeString(getValue(outcomeObj, "info"), "slug");
         object request = new Dictionary<string, object>() {
@@ -1039,7 +1044,7 @@ public partial class limitless : PredictionExchange
         object now = this.milliseconds();
         object outcomeSymbol = this.safeOutcomeSymbol(null, market);
         return this.safePredictionTicker(new Dictionary<string, object>() {
-            { "symbol", outcomeSymbol },
+            { "outcome", outcomeSymbol },
             { "outcomeId", this.safeString(market, "outcomeId") },
             { "label", this.safeString(market, "label") },
             { "market", this.safeString(market, "market") },
@@ -1078,7 +1083,6 @@ public partial class limitless : PredictionExchange
     public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         object result = new Dictionary<string, object>() {};
         if (isTrue(isEqual(symbols, null)))
         {
@@ -1106,7 +1110,7 @@ public partial class limitless : PredictionExchange
         object slugs = new List<object>() {};
         for (object i = 0; isLessThan(i, getArrayLength(symbols)); postFixIncrement(ref i))
         {
-            this.checkEventsAndMarkets(getValue(symbols, i));
+            this.checkEvents(getValue(symbols, i));
             object outcomeObj = this.outcome(getValue(symbols, i));
             object slug = this.safeString(getValue(outcomeObj, "info"), "slug");
             if (!isTrue((inOp(outcomesBySlug, slug))))
@@ -1169,8 +1173,7 @@ public partial class limitless : PredictionExchange
     public async override Task<object> fetchTrades(object symbol, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(symbol);
+        this.checkEvents(symbol);
         object outcomeObj = this.outcome(symbol);
         object slug = this.safeString(getValue(outcomeObj, "info"), "slug");
         object tokenId = this.safeString(outcomeObj, "outcomeId");
@@ -1235,8 +1238,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object slug = this.safeString(getValue(outcomeObj, "info"), "slug");
         object request = new Dictionary<string, object>() {
@@ -1304,14 +1306,15 @@ public partial class limitless : PredictionExchange
             }
             ((IList<object>)asks).Add(new List<object> {this.parseNumber(priceStr), this.parseNumber(sizeStr)});
         }
-        return new Dictionary<string, object>() {
-            { "symbol", this.safeOutcomeSymbol(outcome, outcomeObj) },
+        object orderbook = new Dictionary<string, object>() {
+            { "outcome", this.safeOutcomeSymbol(outcome, outcomeObj) },
             { "bids", this.sortBy(bids, 0, true) },
             { "asks", this.sortBy(asks, 0) },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
             { "nonce", null },
         };
+        return this.safePredictionOrderBook(orderbook, outcomeObj);
     }
 
     /**
@@ -1330,8 +1333,7 @@ public partial class limitless : PredictionExchange
     {
         timeframe ??= "1d";
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(symbol);
+        this.checkEvents(symbol);
         object outcomeObj = this.outcome(symbol);
         object slug = this.safeString(getValue(outcomeObj, "info"), "slug");
         object outcomeLabel = this.safeStringUpper(getValue(outcomeObj, "info"), "outcomeLabel");
@@ -1466,8 +1468,7 @@ public partial class limitless : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " fetchOrders requires an outcome argument")) ;
         }
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object info = this.safeDict(outcomeObj, "info");
         object request = new Dictionary<string, object>() {
@@ -1523,8 +1524,7 @@ public partial class limitless : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " fetchOpenOrders requires an outcome argument")) ;
         }
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         parameters = this.extend(parameters, new Dictionary<string, object>() {
             { "statuses", new List<object>() {"LIVE"} },
         });
@@ -1550,8 +1550,7 @@ public partial class limitless : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " fetchClosedOrders requires an outcome argument")) ;
         }
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         parameters = this.extend(parameters, new Dictionary<string, object>() {
             { "statuses", new List<object>() {"MATCHED"} },
         });
@@ -1572,8 +1571,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object length = getArrayLength(ids);
         if (isTrue(isGreaterThan(length, 50)))
         {
@@ -1716,8 +1714,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object orders = await this.fetchOrdersByIds(new List<object>() {id}, outcome, parameters);
         object order = this.safeDict(orders, 0);
         if (isTrue(isEqual(order, null)))
@@ -1907,7 +1904,6 @@ public partial class limitless : PredictionExchange
             { "datetime", datetime },
             { "lastTradeTimestamp", null },
             { "status", this.parseOrderStatus(rawStatus) },
-            { "symbol", outcomeSymbol },
             { "outcome", outcomeSymbol },
             { "outcomeId", this.safeString(mkt, "outcomeId") },
             { "label", this.safeString(mkt, "label") },
@@ -2021,7 +2017,6 @@ public partial class limitless : PredictionExchange
     public async override Task<object> fetchAccounts(object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         object response = await this.limitlessPrivateGetProfilesMe(parameters);
         object responseList = new List<object>() {response};
         return this.parseAccounts(responseList);
@@ -2044,9 +2039,8 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object accounts = await this.loadAccounts();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object account = this.safeDict(accounts, 0);
         object accountInfo = this.safeDict(account, "info");
@@ -2305,8 +2299,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object request = new Dictionary<string, object>() {
             { "order_id", id },
         };
@@ -2328,8 +2321,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object request = new Dictionary<string, object>() {
             { "orderIds", ids },
         };
@@ -2360,8 +2352,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         if (isTrue(!isEqual(outcome, null)))
         {
             object warn = true;
@@ -2409,8 +2400,7 @@ public partial class limitless : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object paginate = false;
         object maxLimit = 100;
         var paginateparametersVariable = this.handleOptionAndParams(parameters, "fetchMyTrades", "paginate", paginate);
@@ -2549,7 +2539,6 @@ public partial class limitless : PredictionExchange
                 { "info", trade },
                 { "timestamp", ts },
                 { "datetime", this.iso8601(ts) },
-                { "symbol", feedOutcome },
                 { "outcome", feedOutcome },
                 { "outcomeId", this.safeString(market, "outcomeId") },
                 { "label", this.safeString(market, "label") },
@@ -2625,7 +2614,6 @@ public partial class limitless : PredictionExchange
             { "info", trade },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", tradeOutcome },
             { "outcome", tradeOutcome },
             { "outcomeId", this.safeString(trade, "asset") },
             { "label", this.safeString(outcome, "label") },
@@ -2678,11 +2666,11 @@ public partial class limitless : PredictionExchange
         {
             for (object i = 0; isLessThan(i, getArrayLength(symbols)); postFixIncrement(ref i))
             {
-                this.checkEventsAndMarkets(getValue(symbols, i));
+                this.checkEvents(getValue(symbols, i));
             }
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object response = await this.limitlessPrivateGetPortfolioPositions(parameters);
         //
@@ -2842,7 +2830,6 @@ public partial class limitless : PredictionExchange
         object entryPrice = this.applyScale(this.safeString(position, "fillPrice"));
         return new Dictionary<string, object>() {
             { "id", null },
-            { "symbol", outcomeSymbol },
             { "outcome", outcomeSymbol },
             { "outcomeId", this.safeString(market, "outcomeId") },
             { "label", this.safeString(market, "label") },
@@ -2892,12 +2879,11 @@ public partial class limitless : PredictionExchange
         object queriesLength = getArrayLength(queries);
         if (isTrue(!isTrue(queries) || isTrue(isEqual(queriesLength, 0))))
         {
-            await this.loadMarkets();
             result = (IList<object>)(new List<object>(((IDictionary<string,object>)this.events).Values));
         } else
         {
             object limit = this.safeInteger(parameters, "limit", 50);
-            object rest = this.omit(parameters, new List<object>() {"query", "queries", "limit"});
+            object rest = this.omit(parameters, new List<object>() {"query", "queries", "limit", "sort", "searchIn", "eventId", "slug", "status"});
             object seen = new Dictionary<string, object>() {};
             object rawMarkets = new List<object>() {};
             for (object i = 0; isLessThan(i, getArrayLength(queries)); postFixIncrement(ref i))
@@ -2962,7 +2948,7 @@ public partial class limitless : PredictionExchange
             }
         }
         this.rebuildOutcomes();
-        return result;
+        return this.applyEventFetchParams(result, parameters, queries);
     }
 
     /**
@@ -2985,12 +2971,12 @@ public partial class limitless : PredictionExchange
             for (object j = 0; isLessThan(j, getArrayLength(outcomesList)); postFixIncrement(ref j))
             {
                 object oc = getValue(outcomesList, j);
-                object ocSymbol = this.safeString(oc, "symbol");
+                object ocSymbol = this.safeString(oc, "outcome");
                 if (isTrue(!isEqual(ocSymbol, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes)[(string)ocSymbol] = oc;
                 }
-                object ocId = this.safeString(oc, "id");
+                object ocId = this.safeString(oc, "outcomeId");
                 if (isTrue(!isEqual(ocId, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes_by_id)[(string)ocId] = oc;

--- a/cs/ccxt/exchanges/prediction/myriad.cs
+++ b/cs/ccxt/exchanges/prediction/myriad.cs
@@ -383,9 +383,10 @@ public partial class myriad : PredictionExchange
      * @param {string} [params.address] the wallet address to query, defaults to this.walletAddress
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    public async override Task<object> fetchPositions(object symbols = null, object parameters = null)
+    public async override Task<object> fetchPositions(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
+        object symbols = outcomes;
         object address = this.safeString2(parameters, "address", "user", this.walletAddress);
         if (isTrue(isEqual(address, null)))
         {
@@ -2457,9 +2458,10 @@ public partial class myriad : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
+    public async override Task<object> fetchTickers(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
+        object symbols = outcomes;
         this.ensureOutcomesLoaded();
         object result = new Dictionary<string, object>() {};
         if (isTrue(isEqual(symbols, null)))

--- a/cs/ccxt/exchanges/prediction/myriad.cs
+++ b/cs/ccxt/exchanges/prediction/myriad.cs
@@ -435,7 +435,7 @@ public partial class myriad : PredictionExchange
         return this.safePredictionPosition(new Dictionary<string, object>() {
             { "info", position },
             { "id", id },
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "outcomeId", outcomeId },
             { "label", outcomeTitle },
             { "market", marketSymbol },
@@ -465,7 +465,7 @@ public partial class myriad : PredictionExchange
     public async virtual Task<object> fetchTradeQuote(object symbol, object side, object amount, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        this.checkEventsAndMarkets(symbol);
+        this.checkEvents(symbol);
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object networkId = this.safeString(info, "networkId");
@@ -503,7 +503,7 @@ public partial class myriad : PredictionExchange
     public virtual object parseTradeQuote(object quote, object market = null)
     {
         return new Dictionary<string, object>() {
-            { "symbol", this.safeString(market, "symbol") },
+            { "outcome", this.safeString(market, "outcome") },
             { "side", this.safeStringLower(quote, "action") },
             { "value", this.safeNumber(quote, "value") },
             { "shares", this.safeNumber(quote, "shares") },
@@ -736,7 +736,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> createOrder(object symbol, object type, object side, object amount, object price = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -911,7 +910,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> createOrders(object orders, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object ordersLength = getArrayLength(orders);
         object result = new List<object>() {};
@@ -948,7 +946,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> editOrder(object id, object symbol, object type, object side, object amount = null, object price = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         await this.cancelOrder(id, symbol);
         return await this.createOrderbookOrder(symbol, type, side, amount, price, parameters);
@@ -968,7 +965,7 @@ public partial class myriad : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " createOrder() requires a privateKey to sign the on-chain transaction")) ;
         }
-        this.checkEventsAndMarkets(symbol);
+        this.checkEvents(symbol);
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object networkId = this.safeString(info, "networkId");
@@ -1187,7 +1184,7 @@ public partial class myriad : PredictionExchange
                 composite = add(add(add(add(networkId, ":"), marketId), "/"), outcomeId);
             }
             outcomeObj = this.safeOutcome(composite, ((object)market));
-            symbol = this.safeString(outcomeObj, "symbol");
+            symbol = this.safeString(outcomeObj, "outcome");
         }
         return this.safePredictionOrder(new Dictionary<string, object>() {
             { "id", orderHash },
@@ -1196,10 +1193,10 @@ public partial class myriad : PredictionExchange
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
             { "lastTradeTimestamp", null },
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "outcomeId", this.safeString(outcomeObj, "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "type", ((bool) isTrue(isMarketTif)) ? "market" : "limit" },
             { "timeInForce", tif },
             { "postOnly", (isEqual(tif, "PO")) },
@@ -1234,7 +1231,6 @@ public partial class myriad : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " cancelOrder() requires a privateKey to sign the cancellation")) ;
         }
-        await this.loadMarkets();
         object fetched = await this.myriadPublicGetOrdersHash(this.extend(new Dictionary<string, object>() {
             { "hash", id },
         }, parameters));
@@ -1279,7 +1275,6 @@ public partial class myriad : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " cancelAllOrders() requires a privateKey to sign the cancellation")) ;
         }
-        await this.loadMarkets();
         object trader = this.ethGetAddressFromPrivateKey(this.privateKey);
         object marketId = this.safeString(parameters, "market_id", "0");
         object networkId = this.safeString(parameters, "network_id", this.safeString(this.options, "defaultNetworkId", "56"));
@@ -1326,7 +1321,6 @@ public partial class myriad : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " cancelOrders() requires a privateKey to sign the cancellations")) ;
         }
-        await this.loadMarkets();
         object idsLength = getArrayLength(ids);
         object signedOrders = new List<object>() {};
         object wrappers = new List<object>() {};
@@ -1371,7 +1365,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> fetchOrder(object id, object symbol = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         object response = await this.myriadPublicGetOrdersHash(this.extend(new Dictionary<string, object>() {
             { "hash", id },
         }, parameters));
@@ -1400,7 +1393,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> fetchOrders(object symbol = null, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         object request = new Dictionary<string, object>() {};
         object trader = this.safeString(parameters, "trader");
         if (isTrue(isEqual(trader, null)))
@@ -1536,7 +1528,7 @@ public partial class myriad : PredictionExchange
             { "info", this.safeDict(order, "info", new Dictionary<string, object>() {}) },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", this.safeString(order, "outcome") },
+            { "outcome", this.safeString(order, "outcome") },
             { "outcomeId", this.safeString(order, "outcomeId") },
             { "label", this.safeString(order, "label") },
             { "market", this.safeString(order, "market") },
@@ -1642,10 +1634,10 @@ public partial class myriad : PredictionExchange
             { "info", this.extend(new Dictionary<string, object>() {
                 { "transactionHash", txHash },
             }, this.safeDict(quote, "info", new Dictionary<string, object>() {})) },
-            { "symbol", this.safeString(market, "symbol") },
+            { "outcome", this.safeString(market, "outcome") },
             { "outcomeId", this.safeString(market, "id") },
             { "label", this.safeString(market, "label") },
-            { "market", this.safeString(market, "marketSymbol") },
+            { "market", this.safeString(market, "outcome") },
             { "type", "market" },
             { "side", side },
             { "price", this.safeNumber(quote, "priceAverage") },
@@ -1677,6 +1669,8 @@ public partial class myriad : PredictionExchange
             { "title", this.safeString2(raw, "title", "shortName") },
             { "description", this.safeString(raw, "description") },
             { "markets", new List<object>() {market} },
+            { "volume", this.safeNumber2(raw, "volumeNotional24h", "volume24h") },
+            { "liquidity", this.safeNumber(raw, "liquidity") },
             { "url", null },
             { "image", this.safeString(raw, "imageUrl") },
             { "active", (isEqual(state, "open")) },
@@ -1737,9 +1731,7 @@ public partial class myriad : PredictionExchange
             ((IList<object>)outcomes).Add(new Dictionary<string, object>() {
                 { "id", outcomeCompositeId },
                 { "outcomeId", outcomeCompositeId },
-                { "symbol", outcomeHandle },
                 { "outcome", outcomeHandle },
-                { "marketSymbol", marketSymbol },
                 { "market", marketSymbol },
                 { "label", outcomeLabel },
                 { "active", active },
@@ -1844,7 +1836,6 @@ public partial class myriad : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(outcome);
         object networkId = this.safeString(getValue(outcomeObj, "info"), "networkId");
@@ -1943,7 +1934,6 @@ public partial class myriad : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(outcome);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -1963,14 +1953,15 @@ public partial class myriad : PredictionExchange
         object fees = this.safeDict(response, "fees", new Dictionary<string, object>() {});
         object buy = this.safeDict(fees, "buy", new Dictionary<string, object>() {});
         object sell = this.safeDict(fees, "sell", new Dictionary<string, object>() {});
-        return new Dictionary<string, object>() {
+        return ((object)new Dictionary<string, object>() {
             { "info", response },
-            { "symbol", this.safeSymbol(null, ((object)outcomeObj)) },
+            { "outcome", this.safeOutcomeSymbol(null, ((object)outcomeObj)) },
+            { "outcomeId", this.safeString(outcomeObj, "outcomeId") },
             { "maker", this.safeNumber(sell, "fee") },
             { "taker", this.safeNumber(buy, "fee") },
             { "percentage", true },
             { "tierBased", false },
-        };
+        });
     }
 
     /**
@@ -2073,10 +2064,10 @@ public partial class myriad : PredictionExchange
         }
         object now = this.milliseconds();
         return this.safePredictionTicker(new Dictionary<string, object>() {
-            { "symbol", this.safeString(market, "symbol") },
+            { "outcome", this.safeString(market, "outcome") },
             { "outcomeId", this.safeString(market, "id") },
             { "label", this.safeString(market, "label") },
-            { "market", this.safeString(market, "marketSymbol") },
+            { "market", this.safeString(market, "outcome") },
             { "timestamp", now },
             { "datetime", this.iso8601(now) },
             { "high", null },
@@ -2113,7 +2104,6 @@ public partial class myriad : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(outcome);
         object networkId = this.safeString(getValue(outcomeObj, "info"), "networkId");
@@ -2134,7 +2124,7 @@ public partial class myriad : PredictionExchange
             //         "asks": [ [ "990000000000000000", "151975683890577539072" ] ]
             //     }
             //
-            return this.parseWeiOrderBook(obResponse, this.safeOutcomeSymbol(outcome, outcomeObj));
+            return this.safePredictionOrderBook(this.parseWeiOrderBook(obResponse, this.safeOutcomeSymbol(outcome, outcomeObj)), outcomeObj);
         }
         object request = new Dictionary<string, object>() {
             { "id", marketId },
@@ -2252,14 +2242,15 @@ public partial class myriad : PredictionExchange
         {
             ((IList<object>)asks).Add(new List<object>() {ask, synthSize});
         }
-        return new Dictionary<string, object>() {
-            { "symbol", this.safeOutcomeSymbol(outcome, outcomeObj) },
+        object orderbook = new Dictionary<string, object>() {
+            { "outcome", this.safeOutcomeSymbol(outcome, outcomeObj) },
             { "bids", bids },
             { "asks", asks },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
             { "nonce", null },
         };
+        return this.safePredictionOrderBook(orderbook, outcomeObj);
     }
 
     /**
@@ -2293,7 +2284,7 @@ public partial class myriad : PredictionExchange
         }
         object timestamp = this.milliseconds();
         return new Dictionary<string, object>() {
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "bids", this.sortBy(bids, 0, true) },
             { "asks", this.sortBy(asks, 0) },
             { "timestamp", timestamp },
@@ -2318,7 +2309,6 @@ public partial class myriad : PredictionExchange
     {
         timeframe ??= "1d";
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(symbol);
         object outcomeInfo = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -2470,7 +2460,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object result = new Dictionary<string, object>() {};
         if (isTrue(isEqual(symbols, null)))
@@ -2559,7 +2548,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> fetchTrades(object symbol, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -2642,10 +2630,10 @@ public partial class myriad : PredictionExchange
             { "info", trade },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", this.safeString(market, "symbol") },
+            { "outcome", this.safeString(market, "outcome") },
             { "outcomeId", this.safeString(market, "id") },
             { "label", this.safeString(market, "label") },
-            { "market", this.safeString(market, "marketSymbol") },
+            { "market", this.safeString(market, "outcome") },
             { "order", null },
             { "type", null },
             { "side", this.safeString(trade, "action") },
@@ -2673,13 +2661,14 @@ public partial class myriad : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object queries = this.parseSearchQueries(parameters);
-        object rest = this.omit(parameters, new List<object>() {"query", "queries"});
+        object rest = this.omit(parameters, new List<object>() {"query", "queries", "sort", "searchIn", "eventId", "slug", "status"});
         object queriesLength = getArrayLength(queries);
         if (isTrue(isEqual(queriesLength, 0)))
         {
-            await this.loadMarkets();
             this.populateOutcomes();
-            return (IList<object>)(new List<object>(((IDictionary<string,object>)this.events).Values));
+            // hoist Object.values to a local — inline as a call argument breaks the php regex transpiler
+            object existingEvents = (IList<object>)(new List<object>(((IDictionary<string,object>)this.events).Values));
+            return this.applyEventFetchParams(existingEvents, parameters, queries);
         }
         object rawMarkets = await this.fetchRawMarketsBySearch(queries, rest);
         if (!isTrue(this.events))
@@ -2705,7 +2694,7 @@ public partial class myriad : PredictionExchange
             }
         }
         this.populateOutcomes();
-        return result;
+        return this.applyEventFetchParams(result, parameters, queries);
     }
 
     /**
@@ -2742,12 +2731,17 @@ public partial class myriad : PredictionExchange
             for (object j = 0; isLessThan(j, getArrayLength(outcomesList)); postFixIncrement(ref j))
             {
                 object oc = getValue(outcomesList, j);
-                object ocSymbol = this.safeString(oc, "symbol");
+                // accept the legacy symbol/id keys too: in Go/C#/Java the prediction
+                // setMarkets override is not dispatched, so oc is not pre-normalized
+                object ocSymbol = this.safeString2(oc, "outcome", "symbol");
+                object ocId = this.safeString2(oc, "outcomeId", "id");
+                ((IDictionary<string,object>)oc)["outcome"] = ocSymbol;
+                ((IDictionary<string,object>)oc)["outcomeId"] = ocId;
+                ((IDictionary<string,object>)oc)["market"] = this.safeString2(oc, "market", "marketSymbol");
                 if (isTrue(!isEqual(ocSymbol, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes)[(string)ocSymbol] = oc;
                 }
-                object ocId = this.safeString(oc, "id");
                 if (isTrue(!isEqual(ocId, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes_by_id)[(string)ocId] = oc;
@@ -2782,6 +2776,8 @@ public partial class myriad : PredictionExchange
             { "title", this.safeString(rawEvent, "title") },
             { "description", this.safeString(rawEvent, "description") },
             { "markets", marketsList },
+            { "volume", this.safeNumber2(rawEvent, "volumeNotional24h", "volume24h") },
+            { "liquidity", this.safeNumber(rawEvent, "liquidity") },
             { "url", this.safeString(rawEvent, "url") },
             { "image", this.safeString(rawEvent, "imageUrl", this.safeString(rawEvent, "image")) },
             { "active", this.safeBool(rawEvent, "active") },
@@ -2830,7 +2826,7 @@ public partial class myriad : PredictionExchange
         }
         object ocId = add(add(add(add(networkId, ":"), marketId), "/"), outcomeId);
         object outcomeObj = this.safeDict(this.outcomes_by_id, ocId);
-        return this.safeString(outcomeObj, "symbol");
+        return this.safeString(outcomeObj, "outcome");
     }
 
     public async virtual Task<object> connectCentrifugo(object url)
@@ -2969,7 +2965,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> watchOrderBook(object symbol, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -3069,7 +3064,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> watchTrades(object symbol, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -3101,7 +3095,6 @@ public partial class myriad : PredictionExchange
         {
             throw new ArgumentsRequired ((string)add(this.id, " watchMyTrades() requires a symbol (the trades channel is per-market)")) ;
         }
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -3151,10 +3144,10 @@ public partial class myriad : PredictionExchange
             { "info", data },
             { "timestamp", ts },
             { "datetime", this.iso8601(ts) },
-            { "symbol", sym },
+            { "outcome", sym },
             { "outcomeId", this.safeString(outcomeObj, "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "order", this.safeString(taker, "orderHash") },
             { "type", null },
             { "side", this.safeStringLower(taker, "side") },
@@ -3206,10 +3199,10 @@ public partial class myriad : PredictionExchange
                         { "info", maker },
                         { "timestamp", ts },
                         { "datetime", this.iso8601(ts) },
-                        { "symbol", makerSym },
+                        { "outcome", makerSym },
                         { "outcomeId", this.safeString(makerOutcomeObj, "id") },
                         { "label", this.safeString(makerOutcomeObj, "label") },
-                        { "market", this.safeString(makerOutcomeObj, "marketSymbol") },
+                        { "market", this.safeString(makerOutcomeObj, "outcome") },
                         { "order", this.safeString(maker, "orderHash") },
                         { "type", null },
                         { "side", this.safeStringLower(maker, "side") },
@@ -3255,7 +3248,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> watchTicker(object symbol, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object outcomeObj = this.outcome(symbol);
         object info = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -3279,7 +3271,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> watchTickers(object symbols = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         if (isTrue(isEqual(symbols, null)))
         {
@@ -3369,10 +3360,10 @@ public partial class myriad : PredictionExchange
             object outcomeObj = this.safeOutcome(sym);
             object last = this.fromWei(this.safeString(oc, "last"));
             object ticker = this.safePredictionTicker(new Dictionary<string, object>() {
-                { "symbol", sym },
+                { "outcome", sym },
                 { "outcomeId", this.safeString(outcomeObj, "id") },
                 { "label", this.safeString(outcomeObj, "label") },
-                { "market", this.safeString(outcomeObj, "marketSymbol") },
+                { "market", this.safeString(outcomeObj, "outcome") },
                 { "timestamp", ts },
                 { "datetime", this.iso8601(ts) },
                 { "high", null },
@@ -3413,7 +3404,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> watchOrders(object symbol = null, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object trader = this.walletAddressFromKeys();
         object networkId = this.safeString(this.options, "defaultNetworkId", "56");
@@ -3455,10 +3445,10 @@ public partial class myriad : PredictionExchange
             { "info", data },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", sym },
+            { "outcome", sym },
             { "outcomeId", this.safeString(outcomeObj, "id") },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "type", ((bool) isTrue(isMarketTif)) ? "market" : "limit" },
             { "timeInForce", tif },
             { "side", this.safeStringLower(data, "side") },
@@ -3495,7 +3485,6 @@ public partial class myriad : PredictionExchange
     public async override Task<object> watchPositions(object symbols = null, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         this.ensureOutcomesLoaded();
         object trader = this.walletAddressFromKeys();
         object networkId = this.safeString(this.options, "defaultNetworkId", "56");
@@ -3582,10 +3571,10 @@ public partial class myriad : PredictionExchange
         object parsed = this.safePredictionPosition(new Dictionary<string, object>() {
             { "info", data },
             { "id", posId },
-            { "symbol", sym },
+            { "outcome", sym },
             { "outcomeId", posId },
             { "label", this.safeString(outcomeObj, "label") },
-            { "market", this.safeString(outcomeObj, "marketSymbol") },
+            { "market", this.safeString(outcomeObj, "outcome") },
             { "timestamp", ts },
             { "datetime", this.iso8601(ts) },
             { "side", "long" },

--- a/cs/ccxt/exchanges/prediction/polymarket.cs
+++ b/cs/ccxt/exchanges/prediction/polymarket.cs
@@ -1313,7 +1313,11 @@ public partial class polymarket : PredictionExchange
                 ((IList<object>)filteredTrades).Add(trade);
             }
         }
-        return this.parseTrades(filteredTrades, outcomeObj, since, limit);
+        // the trades are already narrowed to this outcome by asset id above; pass no market so the
+        // base parseTrades doesn't apply its symbol filter (prediction trades carry `outcome`, not
+        // `symbol`, so a symbol-bearing outcome object would drop them all). parseTrade resolves the
+        // outcome from each trade's asset id.
+        return this.parseTrades(filteredTrades, null, since, limit);
     }
 
     /**

--- a/cs/ccxt/exchanges/prediction/polymarket.cs
+++ b/cs/ccxt/exchanges/prediction/polymarket.cs
@@ -1054,10 +1054,7 @@ public partial class polymarket : PredictionExchange
         //
         object timestamp = this.safeInteger(response, "timestamp");
         object orderbook = this.parseOrderBook(response, this.safeOutcomeSymbol(outcome, outcomeObj), timestamp, "bids", "asks", "price", "size");
-        ((IDictionary<string,object>)orderbook)["outcome"] = this.safeString(outcomeObj, "outcome");
-        ((IDictionary<string,object>)orderbook)["outcomeId"] = this.safeString(outcomeObj, "outcomeId");
-        ((IDictionary<string,object>)orderbook)["market"] = this.safeString(outcomeObj, "market");
-        return orderbook;
+        return this.safePredictionOrderBook(orderbook, outcomeObj);
     }
 
     /**

--- a/cs/ccxt/exchanges/prediction/polymarket.cs
+++ b/cs/ccxt/exchanges/prediction/polymarket.cs
@@ -340,7 +340,26 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object pageSize = this.safeInteger(parameters, "limit", 50);
-        object rest = this.omit(parameters, new List<object>() {"limit"});
+        // map the unified sort/status onto the gamma search params
+        object sort = this.safeString(parameters, "sort");
+        object sortParam = "volume";
+        if (isTrue(isEqual(sort, "liquidity")))
+        {
+            sortParam = "liquidity";
+        } else if (isTrue(isEqual(sort, "newest")))
+        {
+            sortParam = "startDate";
+        }
+        object status = this.safeString(parameters, "status", "active");
+        object eventsStatus = "active";
+        if (isTrue(isTrue((isEqual(status, "closed"))) || isTrue((isEqual(status, "inactive")))))
+        {
+            eventsStatus = "closed";
+        } else if (isTrue(isEqual(status, "all")))
+        {
+            eventsStatus = null;
+        }
+        object rest = this.omit(parameters, new List<object>() {"limit", "sort", "status", "searchIn", "eventId", "slug", "query", "queries"});
         object seen = new Dictionary<string, object>() {};
         object rawEvents = new List<object>() {};
         for (object qi = 0; isLessThan(qi, getArrayLength(queries)); postFixIncrement(ref qi))
@@ -349,8 +368,13 @@ public partial class polymarket : PredictionExchange
             object baseRequest = new Dictionary<string, object>() {
                 { "q", q },
                 { "limit_per_type", pageSize },
-                { "events_status", "active" },
+                { "sort", sortParam },
+                { "ascending", false },
             };
+            if (isTrue(!isEqual(eventsStatus, null)))
+            {
+                ((IDictionary<string,object>)baseRequest)["events_status"] = eventsStatus;
+            }
             object firstRequest = new Dictionary<string, object>() {
                 { "page", 1 },
             };
@@ -423,20 +447,33 @@ public partial class polymarket : PredictionExchange
         object limit = this.safeInteger(parameters, "limit", this.safeInteger(this.options, "fetchMarketsLimit", 1000));
         object maxPages = Math.Ceiling(Convert.ToDouble(divide(limit, pageSize)));
         object status = this.safeString(parameters, "status", this.safeString(this.options, "defaultEventStatus", "active"));
-        object rest = this.omit(parameters, new List<object>() {"status", "limit"});
+        // sort maps to the gamma `order` field; 'volume' is the default ranking
+        object sort = this.safeString(parameters, "sort");
+        object order = "volume";
+        if (isTrue(isEqual(sort, "liquidity")))
+        {
+            order = "liquidity";
+        } else if (isTrue(isEqual(sort, "newest")))
+        {
+            order = "startDate";
+        }
+        object rest = this.omit(parameters, new List<object>() {"status", "limit", "sort", "searchIn", "eventId", "slug", "query", "queries"});
         object baseRequest = new Dictionary<string, object>() {
             { "limit", pageSize },
-            { "order", "volume24hr" },
+            { "order", order },
             { "ascending", false },
         };
         baseRequest = this.extend(baseRequest, rest);
         if (isTrue(isEqual(status, "active")))
         {
             ((IDictionary<string,object>)baseRequest)["active"] = true;
-        } else if (isTrue(isEqual(status, "closed")))
+            ((IDictionary<string,object>)baseRequest)["closed"] = false;
+        } else if (isTrue(isTrue((isEqual(status, "closed"))) || isTrue((isEqual(status, "inactive")))))
         {
+            ((IDictionary<string,object>)baseRequest)["active"] = false;
             ((IDictionary<string,object>)baseRequest)["closed"] = true;
         }
+        // 'all' — no active/closed filter
         // fetch page 1 first; if full, fire remaining pages in parallel
         object firstPageRequest = new Dictionary<string, object>() {
             { "offset", 0 },
@@ -736,7 +773,7 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object tokenId = getValue(outcomeObj, "outcomeId");
         object promises = new List<object> {this.clobPublicGetMidpoint(new Dictionary<string, object>() {
@@ -806,11 +843,11 @@ public partial class polymarket : PredictionExchange
         {
             for (object i = 0; isLessThan(i, getArrayLength(outcomes)); postFixIncrement(ref i))
             {
-                this.checkEventsAndMarkets(getValue(outcomes, i));
+                this.checkEvents(getValue(outcomes, i));
             }
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object outcomesMap = ((bool) isTrue((!isEqual(this.outcomes, null)))) ? this.outcomes : new Dictionary<string, object>() {};
         object targets = new List<object>() {};
@@ -948,7 +985,7 @@ public partial class polymarket : PredictionExchange
             quoteVolume = this.safeNumber2(getValue(market, "info"), "volume24hr", "volume");
         }
         return this.safePredictionTicker(new Dictionary<string, object>() {
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "outcomeId", this.safeString(market, "outcomeId") },
             { "label", this.safeString(market, "label") },
             { "market", this.safeString(market, "market") },
@@ -988,7 +1025,7 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object tokenId = ((string)getValue(outcomeObj, "outcomeId"));
         object request = new Dictionary<string, object>() {
@@ -1040,7 +1077,7 @@ public partial class polymarket : PredictionExchange
         timeframe ??= "1m";
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object tokenId = ((string)getValue(outcomeObj, "outcomeId"));
         object fidelityMin = this.safeInteger(this.timeframes, timeframe, 1); // fidelity in minutes
@@ -1197,7 +1234,7 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object outcomeInfo = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
         object conditionId = this.safeString(outcomeInfo, "conditionId");
@@ -1222,7 +1259,7 @@ public partial class polymarket : PredictionExchange
         //     { "market": "0x7976b8...92", "value": 4925662.470476 }
         //
         object timestamp = this.milliseconds();
-        return this.safeOpenInterest(new Dictionary<string, object>() {
+        object openInterest = this.safeOpenInterest(new Dictionary<string, object>() {
             { "symbol", this.safeOutcomeSymbol(null, market) },
             { "openInterestAmount", null },
             { "openInterestValue", this.safeNumber(interest, "value") },
@@ -1232,6 +1269,10 @@ public partial class polymarket : PredictionExchange
             { "datetime", this.iso8601(timestamp) },
             { "info", interest },
         }, market);
+        ((IDictionary<string,object>)openInterest)["outcome"] = this.safeOutcomeSymbol(null, market);
+        ((IDictionary<string,object>)openInterest)["outcomeId"] = this.safeString(market, "outcomeId");
+        ((IDictionary<string,object>)openInterest).Remove((string)"symbol");
+        return openInterest;
     }
 
     /**
@@ -1247,7 +1288,7 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object tokenId = this.safeString(outcomeObj, "outcomeId");
         object request = new Dictionary<string, object>() {
@@ -1259,14 +1300,15 @@ public partial class polymarket : PredictionExchange
         //
         object baseFeeBps = this.safeString(response, "base_fee");
         object rate = ((bool) isTrue((!isEqual(baseFeeBps, null)))) ? this.parseNumber(Precise.stringDiv(baseFeeBps, "10000")) : null;
-        return new Dictionary<string, object>() {
+        return ((object)new Dictionary<string, object>() {
             { "info", response },
-            { "symbol", this.safeOutcomeSymbol(null, ((object)outcomeObj)) },
+            { "outcome", this.safeOutcomeSymbol(null, ((object)outcomeObj)) },
+            { "outcomeId", this.safeString(outcomeObj, "outcomeId") },
             { "maker", rate },
             { "taker", rate },
             { "percentage", true },
             { "tierBased", false },
-        };
+        });
     }
 
     /**
@@ -1284,7 +1326,7 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        this.checkEventsAndMarkets(outcome);
+        this.checkEvents(outcome);
         object outcomeObj = this.outcome(outcome);
         object tokenId = ((string)getValue(outcomeObj, "outcomeId"));
         object outcomeInfo = this.safeDict(outcomeObj, "info", new Dictionary<string, object>() {});
@@ -1339,7 +1381,7 @@ public partial class polymarket : PredictionExchange
         object outcomeObj = null;
         if (isTrue(!isEqual(symbol, null)))
         {
-            this.checkEventsAndMarkets(symbol);
+            this.checkEvents(symbol);
             outcomeObj = this.outcome(symbol);
             ((IDictionary<string,object>)request)["asset_id"] = getValue(outcomeObj, "outcomeId");
         }
@@ -1430,7 +1472,6 @@ public partial class polymarket : PredictionExchange
             { "info", trade },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", symbol },
             { "outcome", symbol },
             { "outcomeId", assetId },
             { "label", this.safeString(mkt, "label") },
@@ -1520,11 +1561,11 @@ public partial class polymarket : PredictionExchange
         {
             for (object i = 0; isLessThan(i, getArrayLength(outcomes)); postFixIncrement(ref i))
             {
-                this.checkEventsAndMarkets(getValue(outcomes, i));
+                this.checkEvents(getValue(outcomes, i));
             }
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         if (isTrue(isEqual(this.walletAddress, null)))
         {
@@ -1601,7 +1642,7 @@ public partial class polymarket : PredictionExchange
         }
         return this.safePredictionPosition(new Dictionary<string, object>() {
             { "id", this.safeString(position, "id") },
-            { "symbol", getValue(marketData, "outcome") },
+            { "outcome", getValue(marketData, "outcome") },
             { "outcomeId", getValue(marketData, "outcomeId") },
             { "market", getValue(marketData, "market") },
             { "label", getValue(marketData, "label") },
@@ -1650,10 +1691,10 @@ public partial class polymarket : PredictionExchange
         object outcome = symbol;
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object request = new Dictionary<string, object>() {};
         object outcomeObj = null;
@@ -1684,10 +1725,10 @@ public partial class polymarket : PredictionExchange
         object outcome = symbol;
         if (isTrue(!isEqual(outcome, null)))
         {
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
         } else
         {
-            this.checkEventsAndMarkets();
+            this.checkEvents();
         }
         object request = new Dictionary<string, object>() {
             { "id", id },
@@ -1735,7 +1776,7 @@ public partial class polymarket : PredictionExchange
             { "datetime", this.iso8601(ts) },
             { "lastTradeTimestamp", null },
             { "status", status },
-            { "symbol", getValue(mkt, "outcome") },
+            { "outcome", getValue(mkt, "outcome") },
             { "outcomeId", this.safeString(mkt, "outcomeId") },
             { "label", this.safeString(mkt, "label") },
             { "market", this.safeString(mkt, "market") },
@@ -2243,7 +2284,7 @@ public partial class polymarket : PredictionExchange
         if (isTrue(!isEqual(outcome, null)))
         {
             // scope to a single outcome token via DELETE /cancel-market-orders { asset_id }
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             object outcomeObj = this.outcome(outcome);
             object request = new Dictionary<string, object>() {
                 { "asset_id", getValue(outcomeObj, "outcomeId") },
@@ -2274,19 +2315,39 @@ public partial class polymarket : PredictionExchange
      * @see https://docs.polymarket.com/api-reference/search/search-markets-events-and-profiles
      * @see https://docs.polymarket.com/api-reference/events/list-events
      * @param {object} [params] extra exchange-specific parameters
-     * @param {string} [params.query] a single search term; when omitted (and no queries) the most active events are returned (capped)
+     * @param {string} [params.query] a single keyword search term
      * @param {string[]} [params.queries] multiple search terms (alternative to query)
-     * @param {int} [params.limit] when searching, page size per query (default 50); when omitted, max events to fetch (default options.fetchMarketsLimit, 1000), ordered by 24h volume
+     * @param {int} [params.limit] max number of events to return
+     * @param {string} [params.sort] 'volume' (default), 'liquidity' or 'newest' — mapped to the gamma order field
+     * @param {string} [params.status] 'active' (default), 'inactive', 'closed' or 'all' ('inactive' and 'closed' are interchangeable)
+     * @param {string} [params.searchIn] when searching, restrict the match to 'title' (default), 'description' or 'both'
+     * @param {string} [params.eventId] direct lookup by event id (short-circuits the listing/search)
+     * @param {string} [params.slug] direct lookup by event slug
      * @returns {object[]} an array of event structures
      */
     public async override Task<object> fetchEvents(object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
+        object requestedEventId = this.safeString(parameters, "eventId");
+        object requestedSlug = this.safeString(parameters, "slug");
         object queries = this.parseSearchQueries(parameters);
-        object rest = this.omit(parameters, new List<object>() {"query", "queries"});
+        object rest = this.omit(parameters, new List<object>() {"query", "queries", "eventId", "slug"});
         object queriesLength = getArrayLength(queries);
         object rawEvents = new List<object>() {};
-        if (isTrue(isGreaterThan(queriesLength, 0)))
+        if (isTrue(isTrue((!isEqual(requestedEventId, null))) || isTrue((!isEqual(requestedSlug, null)))))
+        {
+            // direct lookup by event id or slug via the events endpoint (returns a list)
+            object lookup = new Dictionary<string, object>() {};
+            if (isTrue(!isEqual(requestedEventId, null)))
+            {
+                ((IDictionary<string,object>)lookup)["id"] = requestedEventId;
+            } else
+            {
+                ((IDictionary<string,object>)lookup)["slug"] = requestedSlug;
+            }
+            object response = await this.gammaPublicGetEvents(lookup);
+            rawEvents = ((bool) isTrue((!isEqual(response, null)))) ? response : new List<object>() {};
+        } else if (isTrue(isGreaterThan(queriesLength, 0)))
         {
             rawEvents = await this.fetchRawEventsBySearch(queries, rest);
         } else
@@ -2356,19 +2417,32 @@ public partial class polymarket : PredictionExchange
             for (object j = 0; isLessThan(j, getArrayLength(outcomesList)); postFixIncrement(ref j))
             {
                 object oc = getValue(outcomesList, j);
-                object ocSymbol = this.safeString(oc, "symbol");
+                object ocSymbol = this.safeString(oc, "outcome");
                 if (isTrue(!isEqual(ocSymbol, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes)[(string)ocSymbol] = oc;
                 }
-                object ocId = this.safeString(oc, "id");
+                object ocId = this.safeString(oc, "outcomeId");
                 if (isTrue(!isEqual(ocId, null)))
                 {
                     ((IDictionary<string,object>)this.outcomes_by_id)[(string)ocId] = oc;
                 }
             }
         }
-        return result;
+        // the gamma search endpoint is fuzzy, so refine the search path by status and searchIn
+        // client-side (searchIn defaults to 'title', matching the reference behaviour)
+        object filtered = result;
+        if (isTrue(isGreaterThan(queriesLength, 0)))
+        {
+            filtered = this.filterEventsByStatus(filtered, this.safeString(parameters, "status", "active"));
+            filtered = this.filterEventsBySearchIn(filtered, queries, this.safeString(parameters, "searchIn", "title"));
+        }
+        object finalLimit = this.safeInteger(parameters, "limit");
+        if (isTrue(!isEqual(finalLimit, null)))
+        {
+            filtered = this.arraySlice(filtered, 0, finalLimit);
+        }
+        return filtered;
     }
 
     /**
@@ -2874,7 +2948,7 @@ public partial class polymarket : PredictionExchange
             { "asks", asks },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", symbol },
+            { "outcome", symbol },
         });
         callDynamically(client as WebSocketClient, "resolve", new object[] {orderbook, add("orderbook::", symbol)});
         callDynamically(client as WebSocketClient, "resolve", new object[] {orderbook, add("ticker::", symbol)});
@@ -2933,7 +3007,7 @@ public partial class polymarket : PredictionExchange
             { "info", eventVar },
             { "timestamp", timestamp },
             { "datetime", this.iso8601(timestamp) },
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "outcomeId", this.safeString(market, "outcomeId") },
             { "label", this.safeString(market, "label") },
             { "market", this.safeString(market, "market") },
@@ -2974,7 +3048,6 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object outcomeObj = this.outcome(outcome);
         object tokenId = this.safeString(outcomeObj, "outcomeId");
         symbol = this.safeString(outcomeObj, "outcome");
@@ -3003,7 +3076,6 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object outcomeObj = this.outcome(outcome);
         object tokenId = this.safeString(outcomeObj, "outcomeId");
         symbol = this.safeString(outcomeObj, "outcome");
@@ -3030,7 +3102,6 @@ public partial class polymarket : PredictionExchange
     {
         parameters ??= new Dictionary<string, object>();
         object outcome = symbol;
-        await this.loadMarkets();
         object outcomeObj = this.outcome(outcome);
         object tokenId = this.safeString(outcomeObj, "outcomeId");
         symbol = this.safeString(outcomeObj, "outcome");
@@ -3086,7 +3157,7 @@ public partial class polymarket : PredictionExchange
         }
         object market = this.safeOutcome(symbol);
         return this.safePredictionTicker(new Dictionary<string, object>() {
-            { "symbol", symbol },
+            { "outcome", symbol },
             { "outcomeId", this.safeString(market, "outcomeId") },
             { "label", this.safeString(market, "label") },
             { "market", this.safeString(market, "market") },
@@ -3126,7 +3197,6 @@ public partial class polymarket : PredictionExchange
     public async override Task<object> watchOrders(object symbol = null, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         await this.loadApiCredentials();
         object messageHash = "orders";
         if (isTrue(!isEqual(symbol, null)))
@@ -3157,7 +3227,6 @@ public partial class polymarket : PredictionExchange
     public async override Task<object> watchMyTrades(object symbol = null, object since = null, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        await this.loadMarkets();
         await this.loadApiCredentials();
         object messageHash = "myTrades";
         if (isTrue(!isEqual(symbol, null)))

--- a/cs/ccxt/exchanges/prediction/polymarket.cs
+++ b/cs/ccxt/exchanges/prediction/polymarket.cs
@@ -830,10 +830,9 @@ public partial class polymarket : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    public async override Task<object> fetchTickers(object symbols = null, object parameters = null)
+    public async override Task<object> fetchTickers(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        object outcomes = symbols;
         object outcomesLength = 0;
         if (isTrue(!isEqual(outcomes, null)))
         {
@@ -1545,10 +1544,9 @@ public partial class polymarket : PredictionExchange
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    public async override Task<object> fetchPositions(object symbols = null, object parameters = null)
+    public async override Task<object> fetchPositions(object outcomes = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
-        object outcomes = symbols;
         object outcomesLength = 0;
         if (isTrue(!isEqual(outcomes, null)))
         {

--- a/cs/ccxt/wrappers/prediction/hyperliquid.cs
+++ b/cs/ccxt/wrappers/prediction/hyperliquid.cs
@@ -87,11 +87,11 @@ public partial class hyperliquid
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure).</returns>
-    public async Task<OrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
+    public async Task<PredictionOrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
     {
         var limit = limit2 == 0 ? null : (object)limit2;
         var res = await this.fetchOrderBook(symbol, limit, parameters);
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
     /// <summary>
     /// fetches candlestick OHLCV data for an outcome market
@@ -519,7 +519,7 @@ public partial class hyperliquid
     /// </list>
     /// </remarks>
     /// <returns> <term>PredictionEvent[]</term> array of event structures.</returns>
-    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters = null)
+    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters)
     {
         var res = await this.fetchEvents(parameters);
         return ((IList<object>)res).Select(item => (item as Dictionary<string, object>)).ToList();

--- a/cs/ccxt/wrappers/prediction/hyperliquid.cs
+++ b/cs/ccxt/wrappers/prediction/hyperliquid.cs
@@ -61,9 +61,9 @@ public partial class hyperliquid
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure).</returns>
-    public async Task<PredictionTickers> FetchTickers(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<PredictionTickers> FetchTickers(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchTickers(symbols, parameters);
+        var res = await this.fetchTickers(outcomes, parameters);
         return new PredictionTickers(res);
     }
     /// <summary>
@@ -179,9 +179,9 @@ public partial class hyperliquid
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> a list of [position structures](https://docs.ccxt.com/#/?id=position-structure).</returns>
-    public async Task<List<PredictionPosition>> FetchPositions(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<List<PredictionPosition>> FetchPositions(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchPositions(symbols, parameters);
+        var res = await this.fetchPositions(outcomes, parameters);
         return ((IList<object>)res).Select(item => new PredictionPosition(item)).ToList<PredictionPosition>();
     }
     /// <summary>

--- a/cs/ccxt/wrappers/prediction/kalshi.cs
+++ b/cs/ccxt/wrappers/prediction/kalshi.cs
@@ -93,10 +93,10 @@ public partial class kalshi
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> an [open interest structure](https://docs.ccxt.com/#/?id=open-interest-structure).</returns>
-    public async Task<OpenInterest> FetchOpenInterest(string symbol, Dictionary<string, object> parameters = null)
+    public async Task<PredictionOpenInterest> FetchOpenInterest(string symbol, Dictionary<string, object> parameters = null)
     {
         var res = await this.fetchOpenInterest(symbol, parameters);
-        return new OpenInterest(res);
+        return new PredictionOpenInterest(res);
     }
     /// <summary>
     /// fetches tickers for multiple outcomes at once, batching their market tickers through the markets endpoint
@@ -139,11 +139,11 @@ public partial class kalshi
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure).</returns>
-    public async Task<OrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
+    public async Task<PredictionOrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
     {
         var limit = limit2 == 0 ? null : (object)limit2;
         var res = await this.fetchOrderBook(symbol, limit, parameters);
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
     /// <summary>
     /// fetches OHLCV candlesticks for a single kalshi outcome from the candlesticks endpoint
@@ -437,7 +437,7 @@ public partial class kalshi
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> an array of event structures.</returns>
-    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters = null)
+    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters)
     {
         var res = await this.fetchEvents(parameters);
         return ((IList<object>)res).Select(item => (item as Dictionary<string, object>)).ToList();

--- a/cs/ccxt/wrappers/prediction/kalshi.cs
+++ b/cs/ccxt/wrappers/prediction/kalshi.cs
@@ -113,9 +113,9 @@ public partial class kalshi
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol.</returns>
-    public async Task<PredictionTickers> FetchTickers(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<PredictionTickers> FetchTickers(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchTickers(symbols, parameters);
+        var res = await this.fetchTickers(outcomes, parameters);
         return new PredictionTickers(res);
     }
     /// <summary>
@@ -248,9 +248,9 @@ public partial class kalshi
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> a list of [position structures](https://docs.ccxt.com/#/?id=position-structure).</returns>
-    public async Task<List<PredictionPosition>> FetchPositions(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<List<PredictionPosition>> FetchPositions(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchPositions(symbols, parameters);
+        var res = await this.fetchPositions(outcomes, parameters);
         return ((IList<object>)res).Select(item => new PredictionPosition(item)).ToList<PredictionPosition>();
     }
     /// <summary>

--- a/cs/ccxt/wrappers/prediction/limitless.cs
+++ b/cs/ccxt/wrappers/prediction/limitless.cs
@@ -155,11 +155,11 @@ public partial class limitless
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure).</returns>
-    public async Task<OrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
+    public async Task<PredictionOrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
     {
         var limit = limit2 == 0 ? null : (object)limit2;
         var res = await this.fetchOrderBook(symbol, limit, parameters);
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
     /// <summary>
     /// fetches historical prices for a single limitless market outcome and maps them to OHLCV format, uses the `interval` query parameter and selects the YES/NO series that matches the requested outcome
@@ -585,7 +585,7 @@ public partial class limitless
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> an array of event structures.</returns>
-    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters = null)
+    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters)
     {
         var res = await this.fetchEvents(parameters);
         return ((IList<object>)res).Select(item => (item as Dictionary<string, object>)).ToList();

--- a/cs/ccxt/wrappers/prediction/limitless.cs
+++ b/cs/ccxt/wrappers/prediction/limitless.cs
@@ -95,9 +95,9 @@ public partial class limitless
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol.</returns>
-    public async Task<PredictionTickers> FetchTickers(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<PredictionTickers> FetchTickers(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchTickers(symbols, parameters);
+        var res = await this.fetchTickers(outcomes, parameters);
         return new PredictionTickers(res);
     }
     /// <summary>
@@ -553,9 +553,9 @@ public partial class limitless
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> a list of [position structures](https://docs.ccxt.com/#/?id=position-structure).</returns>
-    public async Task<List<PredictionPosition>> FetchPositions(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<List<PredictionPosition>> FetchPositions(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchPositions(symbols, parameters);
+        var res = await this.fetchPositions(outcomes, parameters);
         return ((IList<object>)res).Select(item => new PredictionPosition(item)).ToList<PredictionPosition>();
     }
     /// <summary>

--- a/cs/ccxt/wrappers/prediction/myriad.cs
+++ b/cs/ccxt/wrappers/prediction/myriad.cs
@@ -143,9 +143,9 @@ public partial class myriad
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> a list of [position structures](https://docs.ccxt.com/#/?id=position-structure).</returns>
-    public async Task<List<PredictionPosition>> FetchPositions(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<List<PredictionPosition>> FetchPositions(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchPositions(symbols, parameters);
+        var res = await this.fetchPositions(outcomes, parameters);
         return ((IList<object>)res).Select(item => new PredictionPosition(item)).ToList<PredictionPosition>();
     }
     /// <summary>
@@ -753,9 +753,9 @@ public partial class myriad
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol.</returns>
-    public async Task<PredictionTickers> FetchTickers(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<PredictionTickers> FetchTickers(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchTickers(symbols, parameters);
+        var res = await this.fetchTickers(outcomes, parameters);
         return new PredictionTickers(res);
     }
     /// <summary>

--- a/cs/ccxt/wrappers/prediction/myriad.cs
+++ b/cs/ccxt/wrappers/prediction/myriad.cs
@@ -672,10 +672,10 @@ public partial class myriad
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> a [fee structure](https://docs.ccxt.com/#/?id=fee-structure).</returns>
-    public async Task<TradingFeeInterface> FetchTradingFee(string symbol, Dictionary<string, object> parameters = null)
+    public async Task<PredictionTradingFee> FetchTradingFee(string symbol, Dictionary<string, object> parameters = null)
     {
         var res = await this.fetchTradingFee(symbol, parameters);
-        return new TradingFeeInterface(res);
+        return new PredictionTradingFee(res);
     }
     /// <summary>
     /// fetches the real order book for order-book markets, or synthesizes a one-level book from the AMM price otherwise
@@ -698,11 +698,11 @@ public partial class myriad
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure).</returns>
-    public async Task<OrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
+    public async Task<PredictionOrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
     {
         var limit = limit2 == 0 ? null : (object)limit2;
         var res = await this.fetchOrderBook(symbol, limit, parameters);
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
     /// <summary>
     /// fetches price history for an outcome from the price_charts bucket embedded in the market response
@@ -825,7 +825,7 @@ public partial class myriad
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> an array of event structures.</returns>
-    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters = null)
+    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters)
     {
         var res = await this.fetchEvents(parameters);
         return ((IList<object>)res).Select(item => (item as Dictionary<string, object>)).ToList();

--- a/cs/ccxt/wrappers/prediction/polymarket.cs
+++ b/cs/ccxt/wrappers/prediction/polymarket.cs
@@ -140,9 +140,9 @@ public partial class polymarket
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol.</returns>
-    public async Task<PredictionTickers> FetchTickers(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<PredictionTickers> FetchTickers(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchTickers(symbols, parameters);
+        var res = await this.fetchTickers(outcomes, parameters);
         return new PredictionTickers(res);
     }
     /// <summary>
@@ -441,9 +441,9 @@ public partial class polymarket
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> a list of [position structures](https://docs.ccxt.com/#/?id=position-structure).</returns>
-    public async Task<List<PredictionPosition>> FetchPositions(List<String> symbols = null, Dictionary<string, object> parameters = null)
+    public async Task<List<PredictionPosition>> FetchPositions(List<String> outcomes = null, Dictionary<string, object> parameters = null)
     {
-        var res = await this.fetchPositions(symbols, parameters);
+        var res = await this.fetchPositions(outcomes, parameters);
         return ((IList<object>)res).Select(item => new PredictionPosition(item)).ToList<PredictionPosition>();
     }
     /// <summary>

--- a/cs/ccxt/wrappers/prediction/polymarket.cs
+++ b/cs/ccxt/wrappers/prediction/polymarket.cs
@@ -784,7 +784,7 @@ public partial class polymarket
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> an array of event structures.</returns>
-    public async Task<List<Dictionary<string, object>>> FetchEvents(fetchEventsParams parameters)
+    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters)
     {
         var res = await this.fetchEvents(parameters);
         return ((IList<object>)res).Select(item => (item as Dictionary<string, object>)).ToList();

--- a/cs/ccxt/wrappers/prediction/polymarket.cs
+++ b/cs/ccxt/wrappers/prediction/polymarket.cs
@@ -166,11 +166,11 @@ public partial class polymarket
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure).</returns>
-    public async Task<OrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
+    public async Task<PredictionOrderBook> FetchOrderBook(string symbol, Int64? limit2 = 0, Dictionary<string, object> parameters = null)
     {
         var limit = limit2 == 0 ? null : (object)limit2;
         var res = await this.fetchOrderBook(symbol, limit, parameters);
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
     /// <summary>
     /// fetches price history ticks for a single outcome token and buckets them client-side into OHLCV candles, snapping tick timestamps to the candle boundary
@@ -261,10 +261,10 @@ public partial class polymarket
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> an [open interest structure](https://docs.ccxt.com/#/?id=open-interest-structure).</returns>
-    public async Task<OpenInterest> FetchOpenInterest(string symbol, Dictionary<string, object> parameters = null)
+    public async Task<PredictionOpenInterest> FetchOpenInterest(string symbol, Dictionary<string, object> parameters = null)
     {
         var res = await this.fetchOpenInterest(symbol, parameters);
-        return new OpenInterest(res);
+        return new PredictionOpenInterest(res);
     }
     /// <summary>
     /// fetches the base fee rate for a prediction market outcome token
@@ -281,10 +281,10 @@ public partial class polymarket
     /// </list>
     /// </remarks>
     /// <returns> <term>object</term> a [fee structure](https://docs.ccxt.com/#/?id=fee-structure).</returns>
-    public async Task<TradingFeeInterface> FetchTradingFee(string symbol, Dictionary<string, object> parameters = null)
+    public async Task<PredictionTradingFee> FetchTradingFee(string symbol, Dictionary<string, object> parameters = null)
     {
         var res = await this.fetchTradingFee(symbol, parameters);
-        return new TradingFeeInterface(res);
+        return new PredictionTradingFee(res);
     }
     /// <summary>
     /// fetches public trade history for a single outcome token from the data API
@@ -742,19 +742,49 @@ public partial class polymarket
     /// <item>
     /// <term>params.query</term>
     /// <description>
-    /// string : a single search term; when omitted (and no queries) the most active events are returned (capped)
+    /// string : a single keyword search term
     /// </description>
     /// </item>
     /// <item>
     /// <term>params.limit</term>
     /// <description>
-    /// int : when searching, page size per query (default 50); when omitted, max events to fetch (default options.fetchMarketsLimit, 1000), ordered by 24h volume
+    /// int : max number of events to return
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>params.sort</term>
+    /// <description>
+    /// string : 'volume' (default), 'liquidity' or 'newest' — mapped to the gamma order field
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>params.status</term>
+    /// <description>
+    /// string : 'active' (default), 'inactive', 'closed' or 'all' ('inactive' and 'closed' are interchangeable)
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>params.searchIn</term>
+    /// <description>
+    /// string : when searching, restrict the match to 'title' (default), 'description' or 'both'
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>params.eventId</term>
+    /// <description>
+    /// string : direct lookup by event id (short-circuits the listing/search)
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>params.slug</term>
+    /// <description>
+    /// string : direct lookup by event slug
     /// </description>
     /// </item>
     /// </list>
     /// </remarks>
     /// <returns> <term>object[]</term> an array of event structures.</returns>
-    public async Task<List<Dictionary<string, object>>> FetchEvents(Dictionary<string, object> parameters = null)
+    public async Task<List<Dictionary<string, object>>> FetchEvents(fetchEventsParams parameters)
     {
         var res = await this.fetchEvents(parameters);
         return ((IList<object>)res).Select(item => (item as Dictionary<string, object>)).ToList();

--- a/go/v4/exchange_prediction_types.go
+++ b/go/v4/exchange_prediction_types.go
@@ -147,6 +147,57 @@ func NewPredictionPositionArray(data any) []PredictionPosition {
 	return result
 }
 
+type PredictionOrderBook struct {
+	OrderBook
+	Outcome   *string
+	OutcomeId *string
+	Market    *string
+}
+
+func NewPredictionOrderBook(data any) PredictionOrderBook {
+	m := data.(map[string]any)
+	return PredictionOrderBook{
+		OrderBook: NewOrderBook(data),
+		Outcome:   SafeStringTyped(m, "outcome"),
+		OutcomeId: SafeStringTyped(m, "outcomeId"),
+		Market:    SafeStringTyped(m, "market"),
+	}
+}
+
+type PredictionTradingFee struct {
+	TradingFeeInterface
+	Outcome   *string
+	OutcomeId *string
+	Market    *string
+}
+
+func NewPredictionTradingFee(data any) PredictionTradingFee {
+	m := data.(map[string]any)
+	return PredictionTradingFee{
+		TradingFeeInterface: NewTradingFeeInterface(data),
+		Outcome:             SafeStringTyped(m, "outcome"),
+		OutcomeId:           SafeStringTyped(m, "outcomeId"),
+		Market:              SafeStringTyped(m, "market"),
+	}
+}
+
+type PredictionOpenInterest struct {
+	OpenInterest
+	Outcome   *string
+	OutcomeId *string
+	Market    *string
+}
+
+func NewPredictionOpenInterest(data any) PredictionOpenInterest {
+	m := data.(map[string]any)
+	return PredictionOpenInterest{
+		OpenInterest: NewOpenInterest(data),
+		Outcome:      SafeStringTyped(m, "outcome"),
+		OutcomeId:    SafeStringTyped(m, "outcomeId"),
+		Market:       SafeStringTyped(m, "market"),
+	}
+}
+
 type PredictionTickers struct {
 	Info    map[string]any
 	Tickers map[string]PredictionTicker

--- a/java/cli/src/main/java/cli/Main.java
+++ b/java/cli/src/main/java/cli/Main.java
@@ -136,11 +136,9 @@ public class Main {
 
         for (Map.Entry<String, Boolean> entry : credentials.entrySet()) {
             String key = entry.getKey();
-            Boolean required = entry.getValue();
-
-            if (!Boolean.TRUE.equals(required)) {
-                continue;
-            }
+            // attempt every declared credential, not only required ones: some exchanges (e.g.
+            // polymarket) mark all credentials optional and validate at call time, but still need
+            // them set from keys.json / env to function
 
             String instanceIdKey = instance.id;
             String credentialValue = null;
@@ -275,12 +273,6 @@ public class Main {
     public static void main(String[] args) throws IOException, InterruptedException {
         System.out.println("[java][" + Version.VERSION +"] CCXT CLI");
         // System.out.println("User Directory: " + userDirectory);
-
-        args = new String[] {
-                "binance",
-                "watchTrades",
-                "BTC/USDT"
-        };
 
         if (args.length < 2) {
             System.out.println("Usage: java -cp <classpath> cli.Main [--verbose] [--sandbox] <exchange-id> [arg1 arg2 ...]");

--- a/java/lib/src/main/java/io/github/ccxt/Exchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/Exchange.java
@@ -4606,7 +4606,9 @@ public Object describe()
             for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(parsedArray)); i++)
             {
                 Object entry = Helpers.GetValue(parsedArray, i);
-                Object entryFiledEqualValue = Helpers.isEqual(Helpers.GetValue(entry, field), value);
+                // safeValue (not entry[field]) so a missing field is a non-match, not a
+                // KeyError in python/php — prediction structures key on outcome, not symbol
+                Object entryFiledEqualValue = Helpers.isEqual(this.safeValue(entry, field), value);
                 Object firstCondition = ((Helpers.isTrue(valueIsDefined))) ? entryFiledEqualValue : true;
                 Object entryKeyValue = this.safeValue(entry, key);
                 Object entryKeyGESince = Helpers.isTrue(Helpers.isTrue((entryKeyValue)) && Helpers.isTrue((!Helpers.isEqual(since, null)))) && Helpers.isTrue((Helpers.isGreaterThanOrEqual(entryKeyValue, since)));
@@ -7805,23 +7807,29 @@ public Object describe()
 
     }
 
-    public Object filterBySymbol(Object objects, Object... optionalArgs)
+    public Object filterByKey(Object objects, Object key, Object... optionalArgs)
     {
-        Object symbol = Helpers.getArg(optionalArgs, 0, null);
-        if (Helpers.isTrue(Helpers.isEqual(symbol, null)))
+        Object value = Helpers.getArg(optionalArgs, 0, null);
+        if (Helpers.isTrue(Helpers.isEqual(value, null)))
         {
             return objects;
         }
         Object result = new java.util.ArrayList<Object>(java.util.Arrays.asList());
         for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(objects)); i++)
         {
-            Object objectSymbol = this.safeString(Helpers.GetValue(objects, i), "symbol");
-            if (Helpers.isTrue(Helpers.isEqual(objectSymbol, symbol)))
+            Object objectValue = this.safeString(Helpers.GetValue(objects, i), key);
+            if (Helpers.isTrue(Helpers.isEqual(objectValue, value)))
             {
                 ((java.util.List<Object>)result).add(Helpers.GetValue(objects, i));
             }
         }
         return result;
+    }
+
+    public Object filterBySymbol(Object objects, Object... optionalArgs)
+    {
+        Object symbol = Helpers.getArg(optionalArgs, 0, null);
+        return this.filterByKey(objects, "symbol", symbol);
     }
 
     public Object parseOHLCV(Object ohlcv, Object... optionalArgs)

--- a/java/lib/src/main/java/io/github/ccxt/Exchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/Exchange.java
@@ -666,7 +666,13 @@ public class Exchange {
     }
 
     public Object encode (Object s) {
-        return s; // stub
+        // encode() turns a string into its UTF-8 byte representation (matches the JS Uint8Array
+        // contract). hash()/hmac() accept either bytes or a string, but binaryToBase16() and the
+        // EIP-712 encoders require real bytes, so returning the string unchanged was wrong.
+        if (s instanceof byte[]) {
+            return s;
+        }
+        return s.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public String urlencode(Object obj, boolean... sortParams) {
@@ -2458,7 +2464,33 @@ public class Exchange {
                 types.put(e.getKey(), (List<Map<String, String>>) e.getValue());
             }
 
-            String primaryType = messageTypes.keySet().iterator().next();
+            // The primary type is the EIP-712 root: the struct not referenced as a field type by
+            // any other struct. Java maps don't preserve insertion order, so taking the first key
+            // is unreliable and broke nested typed data (ERC-7739 TypedDataSign(Order contents,...))
+            // by hashing the wrong struct. Resolve the root by reference analysis instead.
+            java.util.Set<String> referencedTypes = new java.util.HashSet<>();
+            for (Map.Entry<String, Object> e : messageTypes.entrySet()) {
+                for (Map<String, String> field : (List<Map<String, String>>) e.getValue()) {
+                    String referencedType = field.get("type");
+                    int bracket = referencedType.indexOf("[");
+                    if (bracket >= 0) {
+                        referencedType = referencedType.substring(0, bracket);
+                    }
+                    if (messageTypes.containsKey(referencedType)) {
+                        referencedTypes.add(referencedType);
+                    }
+                }
+            }
+            String primaryType = null;
+            for (String typeName : messageTypes.keySet()) {
+                if (!referencedTypes.contains(typeName)) {
+                    primaryType = typeName;
+                    break;
+                }
+            }
+            if (primaryType == null) {
+                primaryType = messageTypes.keySet().iterator().next();
+            }
 
             byte[] domainSeparator = hashStruct("EIP712Domain", domain, types);
             byte[] messageHash = hashStruct(primaryType, messageData, types);
@@ -2825,10 +2857,30 @@ public class Exchange {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public Object ethAbiEncode(Object types2, Object args2)
     {
-        // throw new RuntimeException("not implemented");
-        return ""; // to do later
+        // static abi.encode: each argument becomes a 32-byte word, concatenated. Reuses the
+        // EIP-712 word encoder (encodeValue) which already left-pads uint/address and right-pads
+        // bytesN exactly as abi.encode does for static types (the only types used here: bytes32,
+        // uint256, address, uint8). The caller keccak-hashes the result.
+        List<Object> types = (List<Object>) types2;
+        List<Object> args = (List<Object>) args2;
+        Map<String, List<Map<String, String>>> noStructs = new java.util.HashMap<>();
+        List<byte[]> words = new ArrayList<>();
+        int total = 0;
+        for (int i = 0; i < types.size(); i++) {
+            byte[] word = encodeValue((String) types.get(i), args.get(i), noStructs);
+            words.add(word);
+            total += word.length;
+        }
+        byte[] out = new byte[total];
+        int pos = 0;
+        for (byte[] w : words) {
+            System.arraycopy(w, 0, out, pos, w.length);
+            pos += w.length;
+        }
+        return out;
     }
 
     public Object starknetEncodeStructuredData(Object domain2, Object messageTypes2, Object messageData2, Object address)

--- a/java/lib/src/main/java/io/github/ccxt/PredictionExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/PredictionExchange.java
@@ -581,6 +581,20 @@ public Object isPrediction()
         return this.toPredictionStructure(parsed, position);
     }
 
+    public Object safePredictionOrderBook(Object orderbook, Object... optionalArgs)
+    {
+        // normalize a parsed order book to the prediction shape: replace the unified
+        // `symbol` with the `outcome` handle and attach the outcome identity fields
+        // (outcomeId / market) so books match the PredictionOrderBook structure.
+        Object outcomeObj = Helpers.getArg(optionalArgs, 0, null);
+        Object fallback = this.safeString2(orderbook, "outcome", "symbol");
+        Helpers.addElementToObject(orderbook, "outcome", ((Helpers.isTrue((Helpers.isEqual(outcomeObj, null))))) ? fallback : this.safeString(outcomeObj, "outcome", fallback));
+        Helpers.addElementToObject(orderbook, "outcomeId", ((Helpers.isTrue((Helpers.isEqual(outcomeObj, null))))) ? this.safeString(orderbook, "outcomeId") : this.safeString(outcomeObj, "outcomeId"));
+        Helpers.addElementToObject(orderbook, "market", ((Helpers.isTrue((Helpers.isEqual(outcomeObj, null))))) ? this.safeString(orderbook, "market") : this.safeString(outcomeObj, "market"));
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return this.omit(orderbook, "symbol");
+    }
+
     public Object toPredictionStructure(Object parsed, Object raw)
     {
         // rename the unified `symbol` to the prediction `outcome` handle and attach the
@@ -592,8 +606,8 @@ public Object isPrediction()
         Helpers.addElementToObject(parsed, "label", this.safeString(raw, "label"));
         Helpers.addElementToObject(parsed, "market", this.safeString(raw, "market"));
         Helpers.addElementToObject(parsed, "event", this.safeString(raw, "event"));
-        ((java.util.Map<String,Object>)parsed).remove((String)"symbol");
-        return parsed;
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return this.omit(parsed, "symbol");
     }
 
     public Object filterByOutcomeSinceLimit(Object array, Object... optionalArgs)

--- a/java/lib/src/main/java/io/github/ccxt/PredictionExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/PredictionExchange.java
@@ -35,23 +35,7 @@ public Object isPrediction()
         return this.safeBool(this.has, "prediction", false);
     }
 
-    public java.util.concurrent.CompletableFuture<Object> loadMarketsAndEvents(Object... optionalArgs)
-    {
-
-        return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
-
-            Object reload = Helpers.getArg(optionalArgs, 0, false);
-            Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object res = (Helpers.promiseAll(new java.util.ArrayList<Object>(java.util.Arrays.asList(this.loadMarkets(reload, parameters), this.loadEvents(reload, parameters))))).join();
-            return new java.util.HashMap<String, Object>() {{
-                put( "markets", Helpers.GetValue(res, 0) );
-                put( "events", Helpers.GetValue(res, 1) );
-            }};
-        });
-
-    }
-
-    public void checkEventsAndMarkets(Object... optionalArgs)
+    public void checkEvents(Object... optionalArgs)
     {
         // pure synchronous guard (no I/O) — callers invoke it without await, so leaving it
         // async would make the coroutine never run in Python/PHP and silently skip validation.
@@ -87,6 +71,124 @@ public Object isPrediction()
             return new java.util.ArrayList<Object>(java.util.Arrays.asList(singleQuery));
         }
         return this.safeList(parameters, "queries", new java.util.ArrayList<Object>(java.util.Arrays.asList()));
+    }
+
+    public Object applyEventFetchParams(Object events, Object... optionalArgs)
+    {
+        // applies the unified fetchEvents options client-side (eventId/slug/status/searchIn/sort/limit)
+        // so exchanges whose API can't filter natively still support them consistently
+        Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
+        Object queries = Helpers.getArg(optionalArgs, 1, null);
+        Object result = events;
+        Object eventId = this.safeString(parameters, "eventId");
+        Object slug = this.safeString(parameters, "slug");
+        if (Helpers.isTrue(Helpers.isTrue((!Helpers.isEqual(eventId, null))) || Helpers.isTrue((!Helpers.isEqual(slug, null)))))
+        {
+            Object filtered = new java.util.ArrayList<Object>(java.util.Arrays.asList());
+            for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(result)); i++)
+            {
+                Object eventVar = Helpers.GetValue(result, i);
+                Object idMatch = Helpers.isTrue((!Helpers.isEqual(eventId, null))) && Helpers.isTrue((Helpers.isEqual(this.safeString(eventVar, "id"), eventId)));
+                Object slugMatch = Helpers.isTrue((!Helpers.isEqual(slug, null))) && Helpers.isTrue((Helpers.isEqual(this.safeString(eventVar, "slug"), slug)));
+                if (Helpers.isTrue(Helpers.isTrue(idMatch) || Helpers.isTrue(slugMatch)))
+                {
+                    ((java.util.List<Object>)filtered).add(eventVar);
+                }
+            }
+            result = filtered;
+        }
+        result = this.filterEventsByStatus(result, this.safeString(parameters, "status"));
+        if (Helpers.isTrue(Helpers.isTrue((!Helpers.isEqual(queries, null))) && Helpers.isTrue((Helpers.isGreaterThan(Helpers.getArrayLength(queries), 0)))))
+        {
+            result = this.filterEventsBySearchIn(result, queries, this.safeString(parameters, "searchIn"));
+        }
+        Object sort = this.safeString(parameters, "sort");
+        if (Helpers.isTrue(!Helpers.isEqual(sort, null)))
+        {
+            Object sortKey = null;
+            if (Helpers.isTrue(Helpers.isEqual(sort, "volume")))
+            {
+                sortKey = "volume";
+            } else if (Helpers.isTrue(Helpers.isEqual(sort, "liquidity")))
+            {
+                sortKey = "liquidity";
+            } else if (Helpers.isTrue(Helpers.isEqual(sort, "newest")))
+            {
+                sortKey = "created";
+            }
+            if (Helpers.isTrue(!Helpers.isEqual(sortKey, null)))
+            {
+                result = this.sortBy(result, sortKey, true, 0);
+            }
+        }
+        Object limit = this.safeInteger(parameters, "limit");
+        if (Helpers.isTrue(!Helpers.isEqual(limit, null)))
+        {
+            result = this.arraySlice(result, 0, limit);
+        }
+        return result;
+    }
+
+    public Object filterEventsByStatus(Object events, Object... optionalArgs)
+    {
+        // 'active' | 'inactive' | 'closed' | 'all' — 'inactive' and 'closed' are interchangeable
+        Object status = Helpers.getArg(optionalArgs, 0, null);
+        if (Helpers.isTrue(Helpers.isTrue((Helpers.isEqual(status, null))) || Helpers.isTrue((Helpers.isEqual(status, "all")))))
+        {
+            return events;
+        }
+        Object wantActive = (Helpers.isEqual(status, "active"));
+        Object result = new java.util.ArrayList<Object>(java.util.Arrays.asList());
+        for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(events)); i++)
+        {
+            Object eventVar = Helpers.GetValue(events, i);
+            Object isActive = this.safeBool(eventVar, "active");
+            // keep events whose status is unknown (already filtered server-side, no `active` field)
+            if (Helpers.isTrue(Helpers.isTrue((Helpers.isEqual(isActive, null))) || Helpers.isTrue((Helpers.isEqual(isActive, wantActive)))))
+            {
+                ((java.util.List<Object>)result).add(eventVar);
+            }
+        }
+        return result;
+    }
+
+    public Object filterEventsBySearchIn(Object events, Object queries, Object... optionalArgs)
+    {
+        // keep events whose title and/or description contains one of the queries (searchIn defaults to 'both')
+        Object searchIn = Helpers.getArg(optionalArgs, 0, null);
+        if (Helpers.isTrue(Helpers.isTrue(Helpers.isTrue((Helpers.isEqual(searchIn, null))) || Helpers.isTrue((Helpers.isEqual(queries, null)))) || Helpers.isTrue((Helpers.isEqual(Helpers.getArrayLength(queries), 0)))))
+        {
+            return events;
+        }
+        Object checkTitle = Helpers.isTrue((Helpers.isEqual(searchIn, "title"))) || Helpers.isTrue((Helpers.isEqual(searchIn, "both")));
+        Object checkDescription = Helpers.isTrue((Helpers.isEqual(searchIn, "description"))) || Helpers.isTrue((Helpers.isEqual(searchIn, "both")));
+        Object result = new java.util.ArrayList<Object>(java.util.Arrays.asList());
+        for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(events)); i++)
+        {
+            Object eventVar = Helpers.GetValue(events, i);
+            Object title = this.safeStringLower(eventVar, "title", "");
+            Object description = this.safeStringLower(eventVar, "description", "");
+            Object matched = false;
+            for (var qi = 0; Helpers.isLessThan(qi, Helpers.getArrayLength(queries)); qi++)
+            {
+                Object q = ((String)Helpers.GetValue(queries, qi)).toLowerCase();
+                if (Helpers.isTrue(Helpers.isTrue(checkTitle) && Helpers.isTrue((Helpers.isGreaterThanOrEqual(Helpers.getIndexOf(title, q), 0)))))
+                {
+                    matched = true;
+                    break;
+                }
+                if (Helpers.isTrue(Helpers.isTrue(checkDescription) && Helpers.isTrue((Helpers.isGreaterThanOrEqual(Helpers.getIndexOf(description, q), 0)))))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+            if (Helpers.isTrue(matched))
+            {
+                ((java.util.List<Object>)result).add(eventVar);
+            }
+        }
+        return result;
     }
 
     public java.util.concurrent.CompletableFuture<Object> fetchEvents(Object... optionalArgs)

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Hyperliquid.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Hyperliquid.java
@@ -110,18 +110,18 @@ public class Hyperliquid extends HyperliquidCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesAsync(String[] codes, Map<String, Object> params) { return fetchDepositAddressesAsync(codes == null ? null : java.util.Arrays.asList(codes), params); }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchOrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchOrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public MarginMode fetchMarginMode(String symbol, Map<String, Object> params) {
@@ -336,34 +336,34 @@ public class Hyperliquid extends HyperliquidCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesByNetworkAsync(String code) { return fetchDepositAddressesByNetworkAsync(code, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params));
-        return toTypedList(res, OpenInterest::new);
+        return toTypedList(res, PredictionOpenInterest::new);
     }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
-        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, OpenInterest::new));
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, PredictionOpenInterest::new));
     }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public OpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
+    public PredictionOpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterest(symbol, params));
-        return new OpenInterest(res);
+        return new PredictionOpenInterest(res);
     }
-    public OpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
+    public PredictionOpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
-        return super.fetchOpenInterest(symbol, params).thenApply(OpenInterest::new);
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
+        return super.fetchOpenInterest(symbol, params).thenApply(PredictionOpenInterest::new);
     }
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public OpenInterests fetchOpenInterests(List<String> symbols, Map<String, Object> params) {
@@ -1484,18 +1484,18 @@ public class Hyperliquid extends HyperliquidCore {
     }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchL3OrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchL3OrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchL3OrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public DepositAddress fetchDepositAddress(String code, Map<String, Object> params) {
@@ -1698,16 +1698,16 @@ public class Hyperliquid extends HyperliquidCore {
     }
 
     @SuppressWarnings("unchecked")
-    public TradingFeeInterface fetchTradingFee(String symbol, Map<String, Object> params) {
+    public PredictionTradingFee fetchTradingFee(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchTradingFee(symbol, params));
-        return new TradingFeeInterface(res);
+        return new PredictionTradingFee(res);
     }
-    public TradingFeeInterface fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
+    public PredictionTradingFee fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
-        return super.fetchTradingFee(symbol, params).thenApply(TradingFeeInterface::new);
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
+        return super.fetchTradingFee(symbol, params).thenApply(PredictionTradingFee::new);
     }
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public Currencies fetchConvertCurrencies(Map<String, Object> params) {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/HyperliquidCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/HyperliquidCore.java
@@ -595,9 +595,7 @@ public class HyperliquidCore extends HyperliquidApi
         Object outcomes = new java.util.ArrayList<Object>(java.util.Arrays.asList(new java.util.HashMap<String, Object>() {{
     put( "id", HyperliquidCore.this.outcomeCoin(yesEncoding) );
     put( "outcomeId", HyperliquidCore.this.outcomeCoin(yesEncoding) );
-    put( "symbol", yesOutcomeSymbol );
     put( "outcome", yesOutcomeSymbol );
-    put( "marketSymbol", finalParentSymbol );
     put( "market", finalParentSymbol );
     put( "label", yesLabel );
     put( "active", active );
@@ -616,9 +614,7 @@ public class HyperliquidCore extends HyperliquidApi
 }}, new java.util.HashMap<String, Object>() {{
     put( "id", HyperliquidCore.this.outcomeCoin(noEncoding) );
     put( "outcomeId", HyperliquidCore.this.outcomeCoin(noEncoding) );
-    put( "symbol", noOutcomeSymbol );
     put( "outcome", noOutcomeSymbol );
-    put( "marketSymbol", finalParentSymbol );
     put( "market", finalParentSymbol );
     put( "label", noLabel );
     put( "active", active );
@@ -745,8 +741,7 @@ public class HyperliquidCore extends HyperliquidApi
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object coin = this.safeString(info, "coinName");
@@ -788,20 +783,18 @@ public class HyperliquidCore extends HyperliquidApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object outcomes = symbols;
-            (this.loadMarkets()).join();
             Object requestedOutcomeSymbols = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(outcomes)); i++)
                 {
                     Object requested = Helpers.GetValue(outcomes, i);
-                    this.checkEventsAndMarkets(requested);
+                    this.checkEvents(requested);
                     Object requestedOutcomeObj = this.outcome(requested);
-                    Object requestedSymbol = this.safeString(requestedOutcomeObj, "symbol", requested);
-                    Helpers.addElementToObject(requestedOutcomeSymbols, requestedSymbol, true);
+                    Object requestedOutcome = this.safeString(requestedOutcomeObj, "outcome", requested);
+                    Helpers.addElementToObject(requestedOutcomeSymbols, requestedOutcome, true);
                 }
             }
             Object response = (this.publicPostInfo(this.extend(new java.util.HashMap<String, Object>() {{
@@ -813,15 +806,15 @@ public class HyperliquidCore extends HyperliquidApi
             Object mids = this.safeDict(response, "mids", response);
             Object tickers = new java.util.HashMap<String, Object>() {{}};
             Object outcomesMap = ((Helpers.isTrue((!Helpers.isEqual(this.outcomes, null))))) ? this.outcomes : new java.util.HashMap<String, Object>() {{}};
-            Object outcomeSymbols = Helpers.objectKeys(outcomesMap);
-            for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(outcomeSymbols)); i++)
+            Object outcomeHandles = Helpers.objectKeys(outcomesMap);
+            for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(outcomeHandles)); i++)
             {
-                Object outcomeSymbol = Helpers.GetValue(outcomeSymbols, i);
-                if (Helpers.isTrue(Helpers.isTrue(!Helpers.isEqual(outcomes, null)) && !Helpers.isTrue((Helpers.inOp(requestedOutcomeSymbols, outcomeSymbol)))))
+                Object outcomeHandle = Helpers.GetValue(outcomeHandles, i);
+                if (Helpers.isTrue(Helpers.isTrue(!Helpers.isEqual(outcomes, null)) && !Helpers.isTrue((Helpers.inOp(requestedOutcomeSymbols, outcomeHandle)))))
                 {
                     continue;
                 }
-                Object outcomeObj = this.safeDict(outcomesMap, outcomeSymbol, new java.util.HashMap<String, Object>() {{}});
+                Object outcomeObj = this.safeDict(outcomesMap, outcomeHandle, new java.util.HashMap<String, Object>() {{}});
                 Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
                 Object coin = this.safeString(info, "coinName");
                 Object mid = this.safeNumber(mids, coin);
@@ -836,7 +829,7 @@ public class HyperliquidCore extends HyperliquidApi
                     put( "mid", finalMid );
                     put( "time", HyperliquidCore.this.milliseconds() );
                 }}, ((Object)outcomeObj));
-                Helpers.addElementToObject(tickers, outcomeSymbol, ticker);
+                Helpers.addElementToObject(tickers, outcomeHandle, ticker);
             }
             return tickers;
         });
@@ -886,7 +879,7 @@ public class HyperliquidCore extends HyperliquidApi
             mid = Helpers.divide(this.sum(bid, ask), 2);
         }
         // day volume lives on the parent market's ctx; resolve it from the outcome's marketSymbol
-        Object parentSymbol = this.safeString(mkt, "marketSymbol");
+        Object parentSymbol = this.safeString(mkt, "outcome");
         Object parentMarket = ((Helpers.isTrue((!Helpers.isEqual(parentSymbol, null))))) ? this.safeMarket(parentSymbol) : null;
         Object ctx = ((Helpers.isTrue((!Helpers.isEqual(parentMarket, null))))) ? this.safeDict(this.safeDict(((Object)parentMarket), "info", new java.util.HashMap<String, Object>() {{}}), "ctx", new java.util.HashMap<String, Object>() {{}}) : new java.util.HashMap<String, Object>() {{}};
         Object dayVolume = this.safeNumber(ctx, "dayNtlVlm");
@@ -897,7 +890,7 @@ public class HyperliquidCore extends HyperliquidApi
             put( "symbol", symbol );
             put( "outcomeId", HyperliquidCore.this.safeString(mkt, "id") );
             put( "label", HyperliquidCore.this.safeString(mkt, "label") );
-            put( "market", HyperliquidCore.this.safeString(mkt, "marketSymbol") );
+            put( "market", HyperliquidCore.this.safeString(mkt, "outcome") );
             put( "timestamp", timestamp );
             put( "datetime", HyperliquidCore.this.iso8601(timestamp) );
             put( "high", null );
@@ -938,8 +931,7 @@ public class HyperliquidCore extends HyperliquidApi
             Object limit = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object request = new java.util.HashMap<String, Object>() {{
@@ -973,10 +965,13 @@ public class HyperliquidCore extends HyperliquidApi
                 Object entry = Helpers.GetValue(rawAsks, i);
                 ((java.util.List<Object>)asks).add(new java.util.ArrayList<Object>(java.util.Arrays.asList(this.safeNumber(entry, "px"), this.safeNumber(entry, "sz"))));
             }
-            return this.parseOrderBook(new java.util.HashMap<String, Object>() {{
+            Object orderbook = this.parseOrderBook(new java.util.HashMap<String, Object>() {{
                 put( "bids", bids );
                 put( "asks", asks );
             }}, this.safeString(outcomeObj, "symbol", outcome), timestamp);
+            Helpers.addElementToObject(orderbook, "outcome", this.safeString(outcomeObj, "outcome"));
+            Helpers.addElementToObject(orderbook, "outcomeId", this.safeString(outcomeObj, "outcomeId"));
+            return orderbook;
         });
 
     }
@@ -1004,10 +999,9 @@ public class HyperliquidCore extends HyperliquidApi
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
-            Object market = this.market(this.safeString(outcomeObj, "marketSymbol"));
+            Object market = this.market(this.safeString(outcomeObj, "outcome"));
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object until = this.safeInteger(parameters, "until", this.milliseconds());
             Object startTime = since;
@@ -1152,20 +1146,18 @@ public class HyperliquidCore extends HyperliquidApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object outcomes = symbols;
-            (this.loadMarkets()).join();
             Object requestedOutcomeSymbols = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(outcomes)); i++)
                 {
                     Object requested = Helpers.GetValue(outcomes, i);
-                    this.checkEventsAndMarkets(requested);
+                    this.checkEvents(requested);
                     Object requestedOutcomeObj = this.outcome(requested);
-                    Object requestedSymbol = this.safeString(requestedOutcomeObj, "symbol", requested);
-                    Helpers.addElementToObject(requestedOutcomeSymbols, requestedSymbol, true);
+                    Object requestedOutcome = this.safeString(requestedOutcomeObj, "outcome", requested);
+                    Helpers.addElementToObject(requestedOutcomeSymbols, requestedOutcome, true);
                 }
             }
             Object userAddress = null;
@@ -1199,8 +1191,8 @@ public class HyperliquidCore extends HyperliquidApi
                 Object outcomeObj = this.safeOutcome(outcomeId);
                 if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
                 {
-                    Object outcomeSymbol = this.safeString(outcomeObj, "symbol");
-                    if (Helpers.isTrue(Helpers.isTrue(Helpers.isEqual(outcomeSymbol, null)) || !Helpers.isTrue((Helpers.inOp(requestedOutcomeSymbols, outcomeSymbol)))))
+                    Object outcomeHandle = this.safeString(outcomeObj, "outcome");
+                    if (Helpers.isTrue(Helpers.isTrue(Helpers.isEqual(outcomeHandle, null)) || !Helpers.isTrue((Helpers.inOp(requestedOutcomeSymbols, outcomeHandle)))))
                     {
                         continue;
                     }
@@ -1244,7 +1236,7 @@ public class HyperliquidCore extends HyperliquidApi
             put( "symbol", HyperliquidCore.this.safeString(outcomeObj, "symbol") );
             put( "outcomeId", HyperliquidCore.this.safeString(outcomeObj, "id") );
             put( "label", HyperliquidCore.this.safeString(outcomeObj, "label") );
-            put( "market", HyperliquidCore.this.safeString(outcomeObj, "marketSymbol") );
+            put( "market", HyperliquidCore.this.safeString(outcomeObj, "outcome") );
             put( "timestamp", null );
             put( "datetime", null );
             put( "isolated", false );
@@ -1419,11 +1411,10 @@ public class HyperliquidCore extends HyperliquidApi
             Object price = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             (this.initializeClient()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
-            Object market = this.market(this.safeString(outcomeObj, "marketSymbol"));
+            Object market = this.market(this.safeString(outcomeObj, "outcome"));
             Object outcomeInfo = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object nonce = this.milliseconds();
             Object isBuy = (Helpers.isEqual(((String)side).toUpperCase(), "BUY"));
@@ -1453,12 +1444,12 @@ public class HyperliquidCore extends HyperliquidApi
             {
                 Object priceStr = this.numberToString(price);
                 px = ((Helpers.isTrue(isBuy))) ? Precise.stringMul(priceStr, Precise.stringAdd("1", slippage)) : Precise.stringMul(priceStr, Precise.stringSub("1", slippage));
-                px = this.priceToPrecision(this.safeString(outcomeObj, "marketSymbol"), px);
+                px = this.priceToPrecision(this.safeString(outcomeObj, "outcome"), px);
             } else
             {
-                px = this.priceToPrecision(this.safeString(outcomeObj, "marketSymbol"), price);
+                px = this.priceToPrecision(this.safeString(outcomeObj, "outcome"), price);
             }
-            Object sz = this.amountToPrecision(this.safeString(outcomeObj, "marketSymbol"), amount);
+            Object sz = this.amountToPrecision(this.safeString(outcomeObj, "outcome"), amount);
             Object orderType = new java.util.HashMap<String, Object>() {{
                 put( "limit", new java.util.HashMap<String, Object>() {{
                     put( "tif", tif );
@@ -1530,10 +1521,10 @@ public class HyperliquidCore extends HyperliquidApi
                 put( "timestamp", nonce );
                 put( "datetime", HyperliquidCore.this.iso8601(nonce) );
                 put( "status", finalOrderStatus );
-                put( "symbol", HyperliquidCore.this.safeString(outcomeObj, "symbol", outcome) );
+                put( "outcome", HyperliquidCore.this.safeString(outcomeObj, "outcome", outcome) );
                 put( "outcomeId", HyperliquidCore.this.safeString(outcomeObj, "id") );
                 put( "label", HyperliquidCore.this.safeString(outcomeObj, "label") );
-                put( "market", HyperliquidCore.this.safeString(outcomeObj, "marketSymbol") );
+                put( "market", HyperliquidCore.this.safeString(outcomeObj, "outcome") );
                 put( "type", type );
                 put( "side", side );
                 put( "price", finalPrice );
@@ -1597,9 +1588,8 @@ public class HyperliquidCore extends HyperliquidApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " cancelOrders() requires an outcome argument")) ;
             }
-            (this.loadMarkets()).join();
             (this.initializeClient()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object outcomeInfo = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object assetId = this.safeInteger(outcomeInfo, "assetId");
@@ -1655,7 +1645,7 @@ public class HyperliquidCore extends HyperliquidApi
             Object innerResponse = this.safeDict(response, "response");
             Object data = this.safeDict(innerResponse, "data");
             Object statuses = this.safeList(data, "statuses", new java.util.ArrayList<Object>(java.util.Arrays.asList()));
-            Object outcomeSymbol = this.safeString(outcomeObj, "symbol", outcome);
+            Object outcomeSymbol = this.safeString(outcomeObj, "outcome", outcome);
             Object requestIds = ids;
             if (Helpers.isTrue(!Helpers.isEqual(clientOrderId, null)))
             {
@@ -1689,11 +1679,10 @@ public class HyperliquidCore extends HyperliquidApi
                     put( "clientOrderId", ((Helpers.isTrue((!Helpers.isEqual(finalClientOrderId, null))))) ? requestId : null );
                     put( "info", finalStatus );
                     put( "status", "canceled" );
-                    put( "symbol", outcomeSymbol );
                     put( "outcome", outcomeSymbol );
                     put( "outcomeId", HyperliquidCore.this.safeString(outcomeObj, "id") );
                     put( "label", HyperliquidCore.this.safeString(outcomeObj, "label") );
-                    put( "market", HyperliquidCore.this.safeString(outcomeObj, "marketSymbol") );
+                    put( "market", HyperliquidCore.this.safeString(outcomeObj, "outcome") );
                     put( "timestamp", HyperliquidCore.this.milliseconds() );
                     put( "datetime", HyperliquidCore.this.iso8601(HyperliquidCore.this.milliseconds()) );
                 }};
@@ -1727,7 +1716,6 @@ public class HyperliquidCore extends HyperliquidApi
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object userAddress = null;
             var userAddressparametersVariable = this.handlePublicAddress("fetchOpenOrders", parameters);
             userAddress = ((java.util.List<Object>) userAddressparametersVariable).get(0);
@@ -1755,9 +1743,9 @@ public class HyperliquidCore extends HyperliquidApi
             Object outcomeHandle = null;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
                 Object outcomeObj = this.outcome(outcome);
-                outcomeHandle = this.safeString(outcomeObj, "symbol");
+                outcomeHandle = this.safeString(outcomeObj, "outcome");
             }
             return this.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit);
         });
@@ -1786,7 +1774,6 @@ public class HyperliquidCore extends HyperliquidApi
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object userAddress = null;
             var userAddressparametersVariable = this.handlePublicAddress("fetchOrders", parameters);
             userAddress = ((java.util.List<Object>) userAddressparametersVariable).get(0);
@@ -1829,9 +1816,9 @@ public class HyperliquidCore extends HyperliquidApi
             Object outcomeHandle = null;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
                 Object outcomeObj = this.outcome(outcome);
-                outcomeHandle = this.safeString(outcomeObj, "symbol");
+                outcomeHandle = this.safeString(outcomeObj, "outcome");
             }
             return this.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit);
         });
@@ -1858,7 +1845,6 @@ public class HyperliquidCore extends HyperliquidApi
             Object symbol = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object userAddress = null;
             var userAddressparametersVariable = this.handlePublicAddress("fetchOrder", parameters);
             userAddress = ((java.util.List<Object>) userAddressparametersVariable).get(0);
@@ -1883,9 +1869,9 @@ public class HyperliquidCore extends HyperliquidApi
             Object parsed = this.parseOrder(orderWrapper, null);
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
                 Object outcomeObj = this.outcome(outcome);
-                Object expected = this.safeString(outcomeObj, "symbol");
+                Object expected = this.safeString(outcomeObj, "outcome");
                 if (Helpers.isTrue(!Helpers.isEqual(this.safeString(parsed, "outcome"), expected)))
                 {
                     throw new OrderNotFound((String)Helpers.add(Helpers.add(Helpers.add(Helpers.add(this.id, " fetchOrder() order "), id), " is not in outcome "), expected)) ;
@@ -1931,7 +1917,7 @@ public class HyperliquidCore extends HyperliquidApi
         Object status = this.parseOrderStatus(this.safeString2(order, "ccxtStatus", "status"));
         Object coin = this.safeString(entry, "coin");
         Object outcomeObj = this.safeOutcome(coin, ((Object)market));
-        Object marketSymbol = this.safeString(outcomeObj, "marketSymbol");
+        Object marketSymbol = this.safeString(outcomeObj, "outcome");
         Object resolvedMarket = ((Helpers.isTrue(marketSymbol))) ? this.safeMarket(marketSymbol, ((Object)market)) : market;
         Object sideRaw = this.safeString(entry, "side");
         Object side = ((Helpers.isTrue((Helpers.isEqual(sideRaw, "B"))))) ? "buy" : "sell";
@@ -1958,10 +1944,10 @@ public class HyperliquidCore extends HyperliquidApi
             put( "datetime", HyperliquidCore.this.iso8601(timestamp) );
             put( "lastTradeTimestamp", null );
             put( "status", status );
-            put( "symbol", HyperliquidCore.this.safeString(outcomeObj, "symbol") );
+            put( "outcome", HyperliquidCore.this.safeString(outcomeObj, "outcome") );
             put( "outcomeId", HyperliquidCore.this.safeString(outcomeObj, "id") );
             put( "label", HyperliquidCore.this.safeString(outcomeObj, "label") );
-            put( "market", HyperliquidCore.this.safeString(outcomeObj, "marketSymbol") );
+            put( "market", HyperliquidCore.this.safeString(outcomeObj, "outcome") );
             put( "type", HyperliquidCore.this.parseOrderType(HyperliquidCore.this.safeString(entry, "orderType", "limit")) );
             put( "timeInForce", finalTif );
             put( "postOnly", postOnly );
@@ -2049,7 +2035,6 @@ public class HyperliquidCore extends HyperliquidApi
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object userAddress = null;
             var userAddressparametersVariable = this.handlePublicAddress("fetchMyTrades", parameters);
             userAddress = ((java.util.List<Object>) userAddressparametersVariable).get(0);
@@ -2077,9 +2062,9 @@ public class HyperliquidCore extends HyperliquidApi
             Object outcomeHandle = null;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
                 Object outcomeObj = this.outcome(outcome);
-                outcomeHandle = this.safeString(outcomeObj, "symbol");
+                outcomeHandle = this.safeString(outcomeObj, "outcome");
             }
             return this.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit);
         });
@@ -2122,13 +2107,13 @@ public class HyperliquidCore extends HyperliquidApi
         Object amount = this.safeString(trade, "sz");
         Object coin = this.safeString(trade, "coin");
         Object outcomeObj = this.safeOutcome(coin, ((Object)market));
-        Object marketSymbol = this.safeString(outcomeObj, "marketSymbol");
+        Object marketSymbol = this.safeString(outcomeObj, "outcome");
         Object resolvedMarket = ((Helpers.isTrue(marketSymbol))) ? this.safeMarket(marketSymbol, ((Object)market)) : market;
         Object rawSide = this.safeString(trade, "side");
         Object side = ((Helpers.isTrue((Helpers.isEqual(rawSide, "B"))))) ? "buy" : "sell";
         Object fee = this.safeNumber(trade, "fee");
         Object feeCurrency = this.safeString(trade, "feeToken", "USDC");
-        Object outcomeSymbol = this.safeString(outcomeObj, "symbol");
+        Object outcomeSymbol = this.safeString(outcomeObj, "outcome");
         Object feeObject = null;
         if (Helpers.isTrue(!Helpers.isEqual(fee, null)))
         {
@@ -2152,11 +2137,10 @@ public class HyperliquidCore extends HyperliquidApi
             put( "info", trade );
             put( "timestamp", timestamp );
             put( "datetime", HyperliquidCore.this.iso8601(timestamp) );
-            put( "symbol", outcomeSymbol );
             put( "outcome", outcomeSymbol );
             put( "outcomeId", HyperliquidCore.this.safeString(outcomeObj, "id") );
             put( "label", HyperliquidCore.this.safeString(outcomeObj, "label") );
-            put( "market", HyperliquidCore.this.safeString(outcomeObj, "marketSymbol") );
+            put( "market", HyperliquidCore.this.safeString(outcomeObj, "outcome") );
             put( "order", HyperliquidCore.this.safeString(trade, "oid") );
             put( "type", "limit" );
             put( "side", side );
@@ -2184,7 +2168,6 @@ public class HyperliquidCore extends HyperliquidApi
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object queries = this.parseSearchQueries(parameters);
-            (this.loadMarkets()).join();
             Object marketValues = Helpers.objectValues(this.markets);
             // Group markets by parentSymbol
             Object groupMap = new java.util.HashMap<String, Object>() {{}};
@@ -2251,7 +2234,7 @@ public class HyperliquidCore extends HyperliquidApi
                 Object ev = Helpers.GetValue(events, i);
                 Helpers.addElementToObject(this.events, Helpers.GetValue(ev, "symbol"), ev);
             }
-            return events;
+            return this.applyEventFetchParams(events, parameters, queries);
         });
 
     }

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/HyperliquidCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/HyperliquidCore.java
@@ -783,8 +783,9 @@ public class HyperliquidCore extends HyperliquidApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
+            Object symbols = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
+            Object outcomes = symbols;
             Object requestedOutcomeSymbols = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {
@@ -969,9 +970,7 @@ public class HyperliquidCore extends HyperliquidApi
                 put( "bids", bids );
                 put( "asks", asks );
             }}, this.safeString(outcomeObj, "symbol", outcome), timestamp);
-            Helpers.addElementToObject(orderbook, "outcome", this.safeString(outcomeObj, "outcome"));
-            Helpers.addElementToObject(orderbook, "outcomeId", this.safeString(outcomeObj, "outcomeId"));
-            return orderbook;
+            return this.safePredictionOrderBook(orderbook, outcomeObj);
         });
 
     }
@@ -1146,8 +1145,9 @@ public class HyperliquidCore extends HyperliquidApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
+            Object symbols = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
+            Object outcomes = symbols;
             Object requestedOutcomeSymbols = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/HyperliquidCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/HyperliquidCore.java
@@ -783,9 +783,8 @@ public class HyperliquidCore extends HyperliquidApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object outcomes = symbols;
             Object requestedOutcomeSymbols = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {
@@ -1145,9 +1144,8 @@ public class HyperliquidCore extends HyperliquidApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object outcomes = symbols;
             Object requestedOutcomeSymbols = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Kalshi.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Kalshi.java
@@ -110,18 +110,18 @@ public class Kalshi extends KalshiCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesAsync(String[] codes, Map<String, Object> params) { return fetchDepositAddressesAsync(codes == null ? null : java.util.Arrays.asList(codes), params); }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchOrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchOrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public MarginMode fetchMarginMode(String symbol, Map<String, Object> params) {
@@ -336,34 +336,34 @@ public class Kalshi extends KalshiCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesByNetworkAsync(String code) { return fetchDepositAddressesByNetworkAsync(code, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params));
-        return toTypedList(res, OpenInterest::new);
+        return toTypedList(res, PredictionOpenInterest::new);
     }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
-        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, OpenInterest::new));
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, PredictionOpenInterest::new));
     }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public OpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
+    public PredictionOpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterest(symbol, params));
-        return new OpenInterest(res);
+        return new PredictionOpenInterest(res);
     }
-    public OpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
+    public PredictionOpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
-        return super.fetchOpenInterest(symbol, params).thenApply(OpenInterest::new);
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
+        return super.fetchOpenInterest(symbol, params).thenApply(PredictionOpenInterest::new);
     }
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public OpenInterests fetchOpenInterests(List<String> symbols, Map<String, Object> params) {
@@ -1484,18 +1484,18 @@ public class Kalshi extends KalshiCore {
     }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchL3OrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchL3OrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchL3OrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public DepositAddress fetchDepositAddress(String code, Map<String, Object> params) {
@@ -1698,16 +1698,16 @@ public class Kalshi extends KalshiCore {
     }
 
     @SuppressWarnings("unchecked")
-    public TradingFeeInterface fetchTradingFee(String symbol, Map<String, Object> params) {
+    public PredictionTradingFee fetchTradingFee(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchTradingFee(symbol, params));
-        return new TradingFeeInterface(res);
+        return new PredictionTradingFee(res);
     }
-    public TradingFeeInterface fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
+    public PredictionTradingFee fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
-        return super.fetchTradingFee(symbol, params).thenApply(TradingFeeInterface::new);
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
+        return super.fetchTradingFee(symbol, params).thenApply(PredictionTradingFee::new);
     }
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public Currencies fetchConvertCurrencies(Map<String, Object> params) {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/KalshiCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/KalshiCore.java
@@ -397,9 +397,7 @@ final Object finalOi = oi;
                         ((java.util.List<Object>)outcomes).add(new java.util.HashMap<String, Object>() {{
                 put( "id", Helpers.GetValue(outcomeIds, finalOi) );
                 put( "outcomeId", Helpers.GetValue(outcomeIds, finalOi) );
-                put( "symbol", outcomeHandle );
                 put( "outcome", outcomeHandle );
-                put( "marketSymbol", finalMarketSymbol );
                 put( "market", finalMarketSymbol );
                 put( "label", label );
                 put( "active", active );
@@ -501,8 +499,7 @@ final Object finalOi = oi;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object ticker = this.safeString(Helpers.GetValue(outcomeObj, "info"), "ticker");
             Object request = new java.util.HashMap<String, Object>() {{
@@ -616,8 +613,7 @@ final Object finalOi = oi;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object ticker = this.safeString(Helpers.GetValue(outcomeObj, "info"), "ticker");
             Object request = new java.util.HashMap<String, Object>() {{
@@ -637,7 +633,7 @@ final Object finalOi = oi;
         //
         Object market = Helpers.getArg(optionalArgs, 0, null);
         Object timestamp = this.milliseconds();
-        return this.safeOpenInterest(new java.util.HashMap<String, Object>() {{
+        Object openInterest = this.safeOpenInterest(new java.util.HashMap<String, Object>() {{
             put( "symbol", KalshiCore.this.safeSymbol(null, market) );
             put( "openInterestAmount", KalshiCore.this.safeNumber2(interest, "open_interest_fp", "open_interest") );
             put( "openInterestValue", null );
@@ -647,6 +643,10 @@ final Object finalOi = oi;
             put( "datetime", KalshiCore.this.iso8601(timestamp) );
             put( "info", interest );
         }}, market);
+        Helpers.addElementToObject(openInterest, "outcome", this.safeOutcomeSymbol(null, market));
+        Helpers.addElementToObject(openInterest, "outcomeId", this.safeString(market, "outcomeId"));
+        ((java.util.Map<String,Object>)openInterest).remove((String)"symbol");
+        return openInterest;
     }
 
     /**
@@ -717,11 +717,11 @@ final Object finalOi = oi;
         //
         Object market = Helpers.getArg(optionalArgs, 0, null);
         Object marketAny = ((Object)market);
-        Object outcomeObj = this.safeOutcome(this.safeString(marketAny, "symbol"), marketAny);
+        Object outcomeObj = this.safeOutcome(this.safeString(marketAny, "outcome"), marketAny);
         Object outcomeLabel = ((Helpers.isTrue(market))) ? this.safeString(market, "label", this.safeString(Helpers.GetValue(market, "info"), "outcomeLabel", "YES")) : "YES";
         Object isNo = Helpers.isEqual(((String)outcomeLabel).toUpperCase(), "NO");
         Object now = this.milliseconds();
-        Object symbol = this.safeString(outcomeObj, "symbol");
+        Object symbol = this.safeString(outcomeObj, "outcome");
         Object yesAsk = this.safeNumber(raw, "yes_ask_dollars");
         Object yesBid = this.safeNumber(raw, "yes_bid_dollars");
         Object noAsk = this.safeNumber(raw, "no_ask_dollars");
@@ -754,10 +754,10 @@ final Object finalOi = oi;
         final Object finalClose = close;
         final Object finalAverage = average;
         return this.safePredictionTicker(new java.util.HashMap<String, Object>() {{
-            put( "symbol", symbol );
+            put( "outcome", symbol );
             put( "outcomeId", KalshiCore.this.safeString2(outcomeObj, "outcomeId", "id") );
             put( "label", KalshiCore.this.safeString(outcomeObj, "label") );
-            put( "market", KalshiCore.this.safeString2(outcomeObj, "market", "marketSymbol") );
+            put( "market", KalshiCore.this.safeString2(outcomeObj, "market", "outcome") );
             put( "timestamp", now );
             put( "datetime", KalshiCore.this.iso8601(now) );
             put( "high", null );
@@ -796,18 +796,17 @@ final Object finalOi = oi;
 
             Object symbols = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             Object targets = new java.util.ArrayList<Object>(java.util.Arrays.asList());
             if (Helpers.isTrue(!Helpers.isEqual(symbols, null)))
             {
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(symbols)); i++)
                 {
-                    this.checkEventsAndMarkets(Helpers.GetValue(symbols, i));
+                    this.checkEvents(Helpers.GetValue(symbols, i));
                     ((java.util.List<Object>)targets).add(Helpers.GetValue(symbols, i));
                 }
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
                 Object allKeys = Helpers.objectKeys(this.outcomes);
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(allKeys)); i++)
                 {
@@ -901,8 +900,7 @@ final Object finalOi = oi;
             Object limit = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object ticker = this.safeString(Helpers.GetValue(outcomeObj, "info"), "ticker");
             Object isNo = Helpers.isEqual(Helpers.GetValue(outcomeObj, "label"), "NO");
@@ -983,7 +981,7 @@ final Object finalOi = oi;
         final Object finalBids = bids;
         final Object finalAsks = asks;
         return new java.util.HashMap<String, Object>() {{
-            put( "symbol", symbol );
+            put( "outcome", symbol );
             put( "bids", finalBids );
             put( "asks", finalAsks );
             put( "timestamp", timestamp );
@@ -1014,8 +1012,7 @@ final Object finalOi = oi;
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object ticker = this.safeString(Helpers.GetValue(outcomeObj, "info"), "ticker");
             Object seriesTicker = this.safeString(Helpers.GetValue(outcomeObj, "info"), "seriesTicker", ticker);
@@ -1163,8 +1160,7 @@ final Object finalOi = oi;
             Object limit = Helpers.getArg(optionalArgs, 1, null);
             Object parameters = Helpers.getArg(optionalArgs, 2, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object ticker = this.safeString(Helpers.GetValue(outcomeObj, "info"), "ticker");
             Object request = new java.util.HashMap<String, Object>() {{
@@ -1219,10 +1215,10 @@ final Object finalOi = oi;
         Object amount = this.safeNumber(trade, "count", amountFp);
         Object rawSide = this.safeStringLower(trade, "taker_side");
         Object marketAny = ((Object)market);
-        Object outcomeObj = this.safeOutcome(this.safeString(marketAny, "symbol"), marketAny);
+        Object outcomeObj = this.safeOutcome(this.safeString(marketAny, "outcome"), marketAny);
         Object marketInfo = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
         Object requestedOutcomeLabel = this.safeStringLower(outcomeObj, "label", this.safeStringLower(marketInfo, "outcomeLabel"));
-        Object outcomeSymbol = this.safeString(outcomeObj, "symbol");
+        Object outcomeSymbol = this.safeString(outcomeObj, "outcome");
         Object outcomeId = this.safeString2(outcomeObj, "outcomeId", "id");
         Object side = null;
         if (Helpers.isTrue(Helpers.isTrue(Helpers.isEqual(rawSide, "yes")) || Helpers.isTrue(Helpers.isEqual(rawSide, "no"))))
@@ -1249,11 +1245,10 @@ final Object finalOi = oi;
             put( "info", trade );
             put( "timestamp", ts );
             put( "datetime", KalshiCore.this.iso8601(ts) );
-            put( "symbol", outcomeSymbol );
             put( "outcome", outcomeSymbol );
             put( "outcomeId", outcomeId );
             put( "label", KalshiCore.this.safeString(outcomeObj, "label") );
-            put( "market", KalshiCore.this.safeString2(outcomeObj, "market", "marketSymbol") );
+            put( "market", KalshiCore.this.safeString2(outcomeObj, "market", "outcome") );
             put( "order", null );
             put( "type", null );
             put( "side", finalSide );
@@ -1279,7 +1274,7 @@ final Object finalOi = oi;
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
-            this.checkEventsAndMarkets();
+            this.checkEvents();
             Object response = (this.kalshiPrivateGetPortfolioBalance(parameters)).join();
             return this.parseBalance(response);
         });
@@ -1341,11 +1336,11 @@ final Object finalOi = oi;
             {
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(outcomes)); i++)
                 {
-                    this.checkEventsAndMarkets(Helpers.GetValue(outcomes, i));
+                    this.checkEvents(Helpers.GetValue(outcomes, i));
                 }
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object response = (this.kalshiPrivateGetPortfolioPositions(parameters)).join();
             Object positions = (java.util.List<Object>)(this.safeList(response, "market_positions", new java.util.ArrayList<Object>(java.util.Arrays.asList())));
@@ -1380,10 +1375,10 @@ final Object finalOi = oi;
         final Object finalPositionSide = positionSide;
         return this.safePredictionPosition(new java.util.HashMap<String, Object>() {{
             put( "id", null );
-            put( "symbol", KalshiCore.this.safeString(outcomeObj, "symbol", ticker) );
+            put( "outcome", KalshiCore.this.safeString(outcomeObj, "outcome", ticker) );
             put( "outcomeId", KalshiCore.this.safeString2(outcomeObj, "outcomeId", "id") );
             put( "label", KalshiCore.this.safeString(outcomeObj, "label") );
-            put( "market", KalshiCore.this.safeString2(outcomeObj, "market", "marketSymbol") );
+            put( "market", KalshiCore.this.safeString2(outcomeObj, "market", "outcome") );
             put( "timestamp", null );
             put( "datetime", null );
             put( "contracts", finalContractsValue );
@@ -1433,10 +1428,10 @@ final Object finalOi = oi;
             Object outcome = symbol;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object request = new java.util.HashMap<String, Object>() {{
                 put( "status", "resting" );
@@ -1473,10 +1468,10 @@ final Object finalOi = oi;
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             if (Helpers.isTrue(!Helpers.isEqual(symbol, null)))
             {
-                this.checkEventsAndMarkets(symbol);
+                this.checkEvents(symbol);
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object response = (this.kalshiPrivateGetPortfolioOrdersOrderId(this.extend(new java.util.HashMap<String, Object>() {{
                 put( "order_id", id );
@@ -1530,10 +1525,10 @@ final Object finalOi = oi;
             put( "datetime", KalshiCore.this.iso8601(ts) );
             put( "lastTradeTimestamp", null );
             put( "status", status );
-            put( "symbol", KalshiCore.this.safeString(mkt, "symbol") );
+            put( "outcome", KalshiCore.this.safeString(mkt, "outcome") );
             put( "outcomeId", KalshiCore.this.safeString2(mkt, "outcomeId", "id") );
             put( "label", KalshiCore.this.safeString(mkt, "label") );
-            put( "market", KalshiCore.this.safeString2(mkt, "market", "marketSymbol") );
+            put( "market", KalshiCore.this.safeString2(mkt, "market", "outcome") );
             put( "type", KalshiCore.this.safeStringLower(order, "type", "limit") );
             put( "timeInForce", "GTC" );
             put( "postOnly", null );
@@ -1591,8 +1586,7 @@ final Object finalOi = oi;
             Object price = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object ticker = this.safeString(Helpers.GetValue(outcomeObj, "info"), "ticker");
             Object outcomeLabel = Helpers.GetValue(outcomeObj, "label");
@@ -1640,10 +1634,10 @@ final Object finalOi = oi;
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             if (Helpers.isTrue(!Helpers.isEqual(symbol, null)))
             {
-                this.checkEventsAndMarkets(symbol);
+                this.checkEvents(symbol);
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object response = (this.kalshiPrivateDeletePortfolioOrdersOrderId(this.extend(new java.util.HashMap<String, Object>() {{
                 put( "order_id", id );
@@ -1672,15 +1666,14 @@ final Object finalOi = oi;
             Object outcome = symbol;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object request = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                (this.loadMarkets()).join();
                 Object outcomeObj = this.outcome(outcome);
                 Helpers.addElementToObject(request, "ticker", this.safeString(Helpers.GetValue(outcomeObj, "info"), "ticker"));
             }
@@ -1711,10 +1704,16 @@ final Object finalOi = oi;
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object queries = this.parseSearchQueries(parameters);
             parameters = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("query", "queries")));
-            Object status = this.safeString(parameters, "status", this.safeString(this.options, "defaultEventStatus", "open"));
+            // map the unified status onto the kalshi event status (open / closed) so it is pushed server-side
+            Object requestedStatus = this.safeString(parameters, "status", this.safeString(this.options, "defaultEventStatus", "active"));
+            Object status = "open";
+            if (Helpers.isTrue(Helpers.isTrue((Helpers.isEqual(requestedStatus, "closed"))) || Helpers.isTrue((Helpers.isEqual(requestedStatus, "inactive")))))
+            {
+                status = "closed";
+            }
             Object pageLimit = this.safeInteger(parameters, "limit", 200);
             Object maxPages = this.safeInteger(parameters, "maxPages", 50);
-            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("status", "limit", "maxPages")));
+            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("status", "limit", "maxPages", "sort", "searchIn", "eventId", "slug")));
             if (!Helpers.isTrue(this.events))
             {
                 this.events = new java.util.HashMap<String, Object>() {{}};
@@ -1735,8 +1734,9 @@ final Object finalOi = oi;
             Object page = 0;
             while (Helpers.isLessThan(page, maxPages))
             {
+                final Object finalStatus = status;
                 Object request = new java.util.HashMap<String, Object>() {{
-                    put( "status", status );
+                    put( "status", finalStatus );
                     put( "limit", pageLimit );
                     put( "with_nested_markets", true );
                 }};
@@ -1842,19 +1842,19 @@ final Object finalOi = oi;
                 for (var j = 0; Helpers.isLessThan(j, Helpers.getArrayLength(outcomesList)); j++)
                 {
                     Object oc = Helpers.GetValue(outcomesList, j);
-                    Object ocSymbol = this.safeString(oc, "symbol");
+                    Object ocSymbol = this.safeString(oc, "outcome");
                     if (Helpers.isTrue(!Helpers.isEqual(ocSymbol, null)))
                     {
                         Helpers.addElementToObject(this.outcomes, ocSymbol, oc);
                     }
-                    Object ocId = this.safeString(oc, "id");
+                    Object ocId = this.safeString(oc, "outcomeId");
                     if (Helpers.isTrue(!Helpers.isEqual(ocId, null)))
                     {
                         Helpers.addElementToObject(this.outcomes_by_id, ocId, oc);
                     }
                 }
             }
-            return result;
+            return this.applyEventFetchParams(result, parameters, queries);
         });
 
     }
@@ -1967,23 +1967,44 @@ final Object finalOi = oi;
         // }
         Object rawMarkets = (java.util.List<Object>)(this.safeList(rawEvent, "markets", new java.util.ArrayList<Object>(java.util.Arrays.asList())));
         Object marketsList = new java.util.ArrayList<Object>(java.util.Arrays.asList());
+        // aggregate volume/liquidity from the markets and derive the creation time so sort works
+        Object totalVolume = 0;
+        Object totalLiquidity = 0;
+        Object earliestCreated = null;
         for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(rawMarkets)); i++)
         {
             Object rawMarket = Helpers.GetValue(rawMarkets, i);
             Object parsed = this.parseMarket(rawMarket);
             ((java.util.List<Object>)marketsList).add(parsed);
+            totalVolume = this.sum(totalVolume, this.safeNumber2(rawMarket, "volume_fp", "volume", 0));
+            totalLiquidity = this.sum(totalLiquidity, this.safeNumber2(rawMarket, "liquidity_dollars", "liquidity", 0));
+            Object marketCreated = this.parse8601(this.safeString(rawMarket, "open_time"));
+            if (Helpers.isTrue(Helpers.isTrue((!Helpers.isEqual(marketCreated, null))) && Helpers.isTrue((Helpers.isTrue((Helpers.isEqual(earliestCreated, null))) || Helpers.isTrue((Helpers.isLessThan(marketCreated, earliestCreated)))))))
+            {
+                earliestCreated = marketCreated;
+            }
         }
         Object ticker = this.safeString(rawEvent, "event_ticker");
         Object title = this.safeString(rawEvent, "title");
+        Object created = this.parse8601(this.safeString(rawEvent, "created_date_iso"));
+        if (Helpers.isTrue(Helpers.isEqual(created, null)))
+        {
+            created = earliestCreated;
+        }
+        final Object finalTotalVolume = totalVolume;
+        final Object finalTotalLiquidity = totalLiquidity;
+        final Object finalCreated = created;
         return this.extend(new java.util.HashMap<String, Object>() {{
             put( "id", ticker );
             put( "slug", ticker );
             put( "symbol", ((Helpers.isTrue(title))) ? KalshiCore.this.shortenSlug(title) : null );
             put( "title", title );
             put( "markets", marketsList );
+            put( "volume", finalTotalVolume );
+            put( "liquidity", finalTotalLiquidity );
             put( "url", KalshiCore.this.safeString(rawEvent, "url") );
             put( "image", KalshiCore.this.safeString(rawEvent, "image_url") );
-            put( "created", KalshiCore.this.parse8601(KalshiCore.this.safeString(rawEvent, "created_date_iso")) );
+            put( "created", finalCreated );
             put( "createdDatetime", KalshiCore.this.safeString(rawEvent, "created_date_iso") );
             put( "end", KalshiCore.this.parse8601(KalshiCore.this.safeString(rawEvent, "end_date_iso")) );
             put( "endDatetime", KalshiCore.this.safeString(rawEvent, "end_date_iso") );

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/KalshiCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/KalshiCore.java
@@ -957,7 +957,7 @@ final Object finalOi = oi;
                     ((java.util.List<Object>)asks).add(new java.util.ArrayList<Object>(java.util.Arrays.asList(price, this.safeNumber(Helpers.GetValue(rawNo, ai), 1))));
                 }
             }
-            return this.sortedOrders(this.safeString(outcomeObj, "symbol", outcome), timestamp, bids, asks);
+            return this.safePredictionOrderBook(this.sortedOrders(this.safeString(outcomeObj, "outcome", outcome), timestamp, bids, asks), outcomeObj);
         });
 
     }

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/KalshiCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/KalshiCore.java
@@ -794,8 +794,9 @@ final Object finalOi = oi;
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
+            Object symbols = outcomes;
             Object targets = new java.util.ArrayList<Object>(java.util.Arrays.asList());
             if (Helpers.isTrue(!Helpers.isEqual(symbols, null)))
             {
@@ -1324,9 +1325,8 @@ final Object finalOi = oi;
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object outcomes = symbols;
             Object outcomesLength = 0;
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Limitless.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Limitless.java
@@ -110,18 +110,18 @@ public class Limitless extends LimitlessCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesAsync(String[] codes, Map<String, Object> params) { return fetchDepositAddressesAsync(codes == null ? null : java.util.Arrays.asList(codes), params); }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchOrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchOrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public MarginMode fetchMarginMode(String symbol, Map<String, Object> params) {
@@ -336,34 +336,34 @@ public class Limitless extends LimitlessCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesByNetworkAsync(String code) { return fetchDepositAddressesByNetworkAsync(code, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params));
-        return toTypedList(res, OpenInterest::new);
+        return toTypedList(res, PredictionOpenInterest::new);
     }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
-        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, OpenInterest::new));
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, PredictionOpenInterest::new));
     }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public OpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
+    public PredictionOpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterest(symbol, params));
-        return new OpenInterest(res);
+        return new PredictionOpenInterest(res);
     }
-    public OpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
+    public PredictionOpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
-        return super.fetchOpenInterest(symbol, params).thenApply(OpenInterest::new);
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
+        return super.fetchOpenInterest(symbol, params).thenApply(PredictionOpenInterest::new);
     }
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public OpenInterests fetchOpenInterests(List<String> symbols, Map<String, Object> params) {
@@ -1484,18 +1484,18 @@ public class Limitless extends LimitlessCore {
     }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchL3OrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchL3OrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchL3OrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public DepositAddress fetchDepositAddress(String code, Map<String, Object> params) {
@@ -1698,16 +1698,16 @@ public class Limitless extends LimitlessCore {
     }
 
     @SuppressWarnings("unchecked")
-    public TradingFeeInterface fetchTradingFee(String symbol, Map<String, Object> params) {
+    public PredictionTradingFee fetchTradingFee(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchTradingFee(symbol, params));
-        return new TradingFeeInterface(res);
+        return new PredictionTradingFee(res);
     }
-    public TradingFeeInterface fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
+    public PredictionTradingFee fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
-        return super.fetchTradingFee(symbol, params).thenApply(TradingFeeInterface::new);
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
+        return super.fetchTradingFee(symbol, params).thenApply(PredictionTradingFee::new);
     }
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public Currencies fetchConvertCurrencies(Map<String, Object> params) {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/LimitlessCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/LimitlessCore.java
@@ -1084,7 +1084,7 @@ public class LimitlessCore extends LimitlessApi
         final Object finalMidStr = midStr;
         final Object finalVolumeStr = volumeStr;
         return this.safePredictionTicker(new java.util.HashMap<String, Object>() {{
-            put( "symbol", outcomeSymbol );
+            put( "outcome", outcomeSymbol );
             put( "outcomeId", LimitlessCore.this.safeString(finalMarket, "outcomeId") );
             put( "label", LimitlessCore.this.safeString(finalMarket, "label") );
             put( "market", LimitlessCore.this.safeString(finalMarket, "market") );
@@ -1364,14 +1364,15 @@ public class LimitlessCore extends LimitlessApi
                 }
                 ((java.util.List<Object>)asks).add(new java.util.ArrayList<Object>(java.util.Arrays.asList(this.parseNumber(priceStr), this.parseNumber(sizeStr))));
             }
-            return new java.util.HashMap<String, Object>() {{
-                put( "symbol", LimitlessCore.this.safeOutcomeSymbol(outcome, outcomeObj) );
+            Object orderbook = new java.util.HashMap<String, Object>() {{
+                put( "outcome", LimitlessCore.this.safeOutcomeSymbol(outcome, outcomeObj) );
                 put( "bids", LimitlessCore.this.sortBy(bids, 0, true) );
                 put( "asks", LimitlessCore.this.sortBy(asks, 0) );
                 put( "timestamp", timestamp );
                 put( "datetime", LimitlessCore.this.iso8601(timestamp) );
                 put( "nonce", null );
             }};
+            return this.safePredictionOrderBook(orderbook, outcomeObj);
         });
 
     }
@@ -2017,7 +2018,6 @@ public class LimitlessCore extends LimitlessApi
             put( "datetime", datetime );
             put( "lastTradeTimestamp", null );
             put( "status", LimitlessCore.this.parseOrderStatus(finalRawStatus) );
-            put( "symbol", outcomeSymbol );
             put( "outcome", outcomeSymbol );
             put( "outcomeId", LimitlessCore.this.safeString(mkt, "outcomeId") );
             put( "label", LimitlessCore.this.safeString(mkt, "label") );
@@ -2701,7 +2701,6 @@ public class LimitlessCore extends LimitlessApi
                 put( "info", trade );
                 put( "timestamp", ts );
                 put( "datetime", LimitlessCore.this.iso8601(ts) );
-                put( "symbol", feedOutcome );
                 put( "outcome", feedOutcome );
                 put( "outcomeId", LimitlessCore.this.safeString(market, "outcomeId") );
                 put( "label", LimitlessCore.this.safeString(market, "label") );
@@ -2779,7 +2778,6 @@ public class LimitlessCore extends LimitlessApi
             put( "info", trade );
             put( "timestamp", timestamp );
             put( "datetime", LimitlessCore.this.iso8601(timestamp) );
-            put( "symbol", tradeOutcome );
             put( "outcome", tradeOutcome );
             put( "outcomeId", LimitlessCore.this.safeString(trade, "asset") );
             put( "label", LimitlessCore.this.safeString(outcome, "label") );
@@ -3005,7 +3003,6 @@ public class LimitlessCore extends LimitlessApi
         Object entryPrice = this.applyScale(this.safeString(position, "fillPrice"));
         return new java.util.HashMap<String, Object>() {{
             put( "id", null );
-            put( "symbol", outcomeSymbol );
             put( "outcome", outcomeSymbol );
             put( "outcomeId", LimitlessCore.this.safeString(market, "outcomeId") );
             put( "label", LimitlessCore.this.safeString(market, "label") );
@@ -3152,12 +3149,12 @@ public class LimitlessCore extends LimitlessApi
             for (var j = 0; Helpers.isLessThan(j, Helpers.getArrayLength(outcomesList)); j++)
             {
                 Object oc = Helpers.GetValue(outcomesList, j);
-                Object ocSymbol = this.safeString(oc, "symbol");
+                Object ocSymbol = this.safeString(oc, "outcome");
                 if (Helpers.isTrue(!Helpers.isEqual(ocSymbol, null)))
                 {
                     Helpers.addElementToObject(this.outcomes, ocSymbol, oc);
                 }
-                Object ocId = this.safeString(oc, "id");
+                Object ocId = this.safeString(oc, "outcomeId");
                 if (Helpers.isTrue(!Helpers.isEqual(ocId, null)))
                 {
                     Helpers.addElementToObject(this.outcomes_by_id, ocId, oc);

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/LimitlessCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/LimitlessCore.java
@@ -1125,8 +1125,9 @@ public class LimitlessCore extends LimitlessApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
+            Object symbols = outcomes;
             Object result = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(Helpers.isEqual(symbols, null)))
             {
@@ -2824,8 +2825,9 @@ public class LimitlessCore extends LimitlessApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
+            Object symbols = outcomes;
             Object symbolsLength = 0;
             if (Helpers.isTrue(!Helpers.isEqual(symbols, null)))
             {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/LimitlessCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/LimitlessCore.java
@@ -773,6 +773,8 @@ public class LimitlessCore extends LimitlessApi
         Object title = this.safeString(eventVar, "title", groupId);
         Object markets = new java.util.ArrayList<Object>(java.util.Arrays.asList());
         Object rawMarkets = this.safeList(eventVar, "markets", new java.util.ArrayList<Object>(java.util.Arrays.asList()));
+        // aggregate 24h volume across the markets so sort by volume works
+        Object totalVolume = 0;
         for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(rawMarkets)); i++)
         {
             Object rawMarket = Helpers.GetValue(rawMarkets, i);
@@ -785,7 +787,10 @@ public class LimitlessCore extends LimitlessApi
             {
                 ((java.util.List<Object>)markets).add(this.parseMarket(rawMarket));
             }
+            Object marketInfo = this.safeDict(rawMarket, "info", rawMarket);
+            totalVolume = this.sum(totalVolume, this.safeNumber2(marketInfo, "volume24h", "volume", 0));
         }
+        final Object finalTotalVolume = totalVolume;
         return this.extend(new java.util.HashMap<String, Object>() {{
             put( "id", groupId );
             put( "slug", groupId );
@@ -793,6 +798,8 @@ public class LimitlessCore extends LimitlessApi
             put( "title", title );
             put( "description", LimitlessCore.this.safeString(eventVar, "description") );
             put( "markets", markets );
+            put( "volume", finalTotalVolume );
+            put( "liquidity", LimitlessCore.this.safeNumber(eventVar, "liquidity") );
             put( "url", LimitlessCore.this.safeString(eventVar, "url") );
             put( "image", LimitlessCore.this.safeString(eventVar, "imageUrl", LimitlessCore.this.safeString(eventVar, "image")) );
             put( "active", LimitlessCore.this.safeBool(eventVar, "active", true) );
@@ -826,8 +833,7 @@ public class LimitlessCore extends LimitlessApi
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object slug = this.safeString(Helpers.GetValue(outcomeObj, "info"), "slug");
             Object request = new java.util.HashMap<String, Object>() {{
@@ -1121,7 +1127,6 @@ public class LimitlessCore extends LimitlessApi
 
             Object symbols = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             Object result = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(Helpers.isEqual(symbols, null)))
             {
@@ -1149,7 +1154,7 @@ public class LimitlessCore extends LimitlessApi
             Object slugs = new java.util.ArrayList<Object>(java.util.Arrays.asList());
             for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(symbols)); i++)
             {
-                this.checkEventsAndMarkets(Helpers.GetValue(symbols, i));
+                this.checkEvents(Helpers.GetValue(symbols, i));
                 Object outcomeObj = this.outcome(Helpers.GetValue(symbols, i));
                 Object slug = this.safeString(Helpers.GetValue(outcomeObj, "info"), "slug");
                 if (!Helpers.isTrue((Helpers.inOp(outcomesBySlug, slug))))
@@ -1220,8 +1225,7 @@ public class LimitlessCore extends LimitlessApi
             Object since = Helpers.getArg(optionalArgs, 0, null);
             Object limit = Helpers.getArg(optionalArgs, 1, null);
             Object parameters = Helpers.getArg(optionalArgs, 2, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(symbol);
+            this.checkEvents(symbol);
             Object outcomeObj = this.outcome(symbol);
             Object slug = this.safeString(Helpers.GetValue(outcomeObj, "info"), "slug");
             Object tokenId = this.safeString(outcomeObj, "outcomeId");
@@ -1292,8 +1296,7 @@ public class LimitlessCore extends LimitlessApi
             Object limit = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object slug = this.safeString(Helpers.GetValue(outcomeObj, "info"), "slug");
             Object request = new java.util.HashMap<String, Object>() {{
@@ -1394,8 +1397,7 @@ public class LimitlessCore extends LimitlessApi
             Object since = Helpers.getArg(optionalArgs, 1, null);
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(symbol);
+            this.checkEvents(symbol);
             Object outcomeObj = this.outcome(symbol);
             Object slug = this.safeString(Helpers.GetValue(outcomeObj, "info"), "slug");
             Object outcomeLabel = this.safeStringUpper(Helpers.GetValue(outcomeObj, "info"), "outcomeLabel");
@@ -1539,8 +1541,7 @@ public class LimitlessCore extends LimitlessApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " fetchOrders requires an outcome argument")) ;
             }
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object info = this.safeDict(outcomeObj, "info");
             Object request = new java.util.HashMap<String, Object>() {{
@@ -1604,8 +1605,7 @@ public class LimitlessCore extends LimitlessApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " fetchOpenOrders requires an outcome argument")) ;
             }
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             parameters = this.extend(parameters, new java.util.HashMap<String, Object>() {{
                 put( "statuses", new java.util.ArrayList<Object>(java.util.Arrays.asList("LIVE")) );
             }});
@@ -1639,8 +1639,7 @@ public class LimitlessCore extends LimitlessApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " fetchClosedOrders requires an outcome argument")) ;
             }
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             parameters = this.extend(parameters, new java.util.HashMap<String, Object>() {{
                 put( "statuses", new java.util.ArrayList<Object>(java.util.Arrays.asList("MATCHED")) );
             }});
@@ -1667,8 +1666,7 @@ public class LimitlessCore extends LimitlessApi
             Object symbol = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object length = Helpers.getArrayLength(ids);
             if (Helpers.isTrue(Helpers.isGreaterThan(length, 50)))
             {
@@ -1817,8 +1815,7 @@ public class LimitlessCore extends LimitlessApi
             Object symbol = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object orders = (this.fetchOrdersByIds(new java.util.ArrayList<Object>(java.util.Arrays.asList(id)), outcome, parameters)).join();
             Object order = this.safeDict(orders, 0);
             if (Helpers.isTrue(Helpers.isEqual(order, null)))
@@ -2137,7 +2134,6 @@ public class LimitlessCore extends LimitlessApi
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             Object response = (this.limitlessPrivateGetProfilesMe(parameters)).join();
             Object responseList = new java.util.ArrayList<Object>(java.util.Arrays.asList(response));
             return this.parseAccounts(responseList);
@@ -2168,9 +2164,8 @@ public class LimitlessCore extends LimitlessApi
             Object price = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object accounts = (this.loadAccounts()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object account = this.safeDict(accounts, 0);
             Object accountInfo = this.safeDict(account, "info");
@@ -2440,8 +2435,7 @@ public class LimitlessCore extends LimitlessApi
             Object symbol = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object request = new java.util.HashMap<String, Object>() {{
                 put( "order_id", id );
             }};
@@ -2469,8 +2463,7 @@ public class LimitlessCore extends LimitlessApi
             Object symbol = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object request = new java.util.HashMap<String, Object>() {{
                 put( "orderIds", ids );
             }};
@@ -2507,8 +2500,7 @@ public class LimitlessCore extends LimitlessApi
             Object symbol = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
                 Object warn = true;
@@ -2564,8 +2556,7 @@ public class LimitlessCore extends LimitlessApi
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object paginate = false;
             Object maxLimit = 100;
             var paginateparametersVariable = this.handleOptionAndParams(parameters, "fetchMyTrades", "paginate", paginate);
@@ -2846,11 +2837,11 @@ public class LimitlessCore extends LimitlessApi
             {
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(symbols)); i++)
                 {
-                    this.checkEventsAndMarkets(Helpers.GetValue(symbols, i));
+                    this.checkEvents(Helpers.GetValue(symbols, i));
                 }
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object response = (this.limitlessPrivateGetPortfolioPositions(parameters)).join();
             //
@@ -3067,12 +3058,11 @@ public class LimitlessCore extends LimitlessApi
             Object queriesLength = Helpers.getArrayLength(queries);
             if (Helpers.isTrue(!Helpers.isTrue(queries) || Helpers.isTrue(Helpers.isEqual(queriesLength, 0))))
             {
-                (this.loadMarkets()).join();
                 result = (java.util.List<Object>)(Helpers.objectValues(this.events));
             } else
             {
                 Object limit = this.safeInteger(parameters, "limit", 50);
-                Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("query", "queries", "limit")));
+                Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("query", "queries", "limit", "sort", "searchIn", "eventId", "slug", "status")));
                 Object seen = new java.util.HashMap<String, Object>() {{}};
                 Object rawMarkets = new java.util.ArrayList<Object>(java.util.Arrays.asList());
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(queries)); i++)
@@ -3137,7 +3127,7 @@ public class LimitlessCore extends LimitlessApi
                 }
             }
             this.rebuildOutcomes();
-            return result;
+            return this.applyEventFetchParams(result, parameters, queries);
         });
 
     }

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Myriad.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Myriad.java
@@ -110,18 +110,18 @@ public class Myriad extends MyriadCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesAsync(String[] codes, Map<String, Object> params) { return fetchDepositAddressesAsync(codes == null ? null : java.util.Arrays.asList(codes), params); }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchOrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchOrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public MarginMode fetchMarginMode(String symbol, Map<String, Object> params) {
@@ -336,34 +336,34 @@ public class Myriad extends MyriadCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesByNetworkAsync(String code) { return fetchDepositAddressesByNetworkAsync(code, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params));
-        return toTypedList(res, OpenInterest::new);
+        return toTypedList(res, PredictionOpenInterest::new);
     }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
-        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, OpenInterest::new));
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, PredictionOpenInterest::new));
     }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public OpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
+    public PredictionOpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterest(symbol, params));
-        return new OpenInterest(res);
+        return new PredictionOpenInterest(res);
     }
-    public OpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
+    public PredictionOpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
-        return super.fetchOpenInterest(symbol, params).thenApply(OpenInterest::new);
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
+        return super.fetchOpenInterest(symbol, params).thenApply(PredictionOpenInterest::new);
     }
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public OpenInterests fetchOpenInterests(List<String> symbols, Map<String, Object> params) {
@@ -1484,18 +1484,18 @@ public class Myriad extends MyriadCore {
     }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchL3OrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchL3OrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchL3OrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public DepositAddress fetchDepositAddress(String code, Map<String, Object> params) {
@@ -1698,16 +1698,16 @@ public class Myriad extends MyriadCore {
     }
 
     @SuppressWarnings("unchecked")
-    public TradingFeeInterface fetchTradingFee(String symbol, Map<String, Object> params) {
+    public PredictionTradingFee fetchTradingFee(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchTradingFee(symbol, params));
-        return new TradingFeeInterface(res);
+        return new PredictionTradingFee(res);
     }
-    public TradingFeeInterface fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
+    public PredictionTradingFee fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
-        return super.fetchTradingFee(symbol, params).thenApply(TradingFeeInterface::new);
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
+        return super.fetchTradingFee(symbol, params).thenApply(PredictionTradingFee::new);
     }
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public Currencies fetchConvertCurrencies(Map<String, Object> params) {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/MyriadCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/MyriadCore.java
@@ -511,7 +511,7 @@ public class MyriadCore extends MyriadApi
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
-            this.checkEventsAndMarkets(symbol);
+            this.checkEvents(symbol);
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object networkId = this.safeString(info, "networkId");
@@ -810,7 +810,6 @@ public class MyriadCore extends MyriadApi
 
             Object price = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -1003,7 +1002,6 @@ public class MyriadCore extends MyriadApi
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object ordersLength = Helpers.getArrayLength(orders);
             Object result = new java.util.ArrayList<Object>(java.util.Arrays.asList());
@@ -1047,7 +1045,6 @@ public class MyriadCore extends MyriadApi
             Object amount = Helpers.getArg(optionalArgs, 0, null);
             Object price = Helpers.getArg(optionalArgs, 1, null);
             Object parameters = Helpers.getArg(optionalArgs, 2, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             (this.cancelOrder(id, symbol)).join();
             return (this.createOrderbookOrder(symbol, type, side, amount, price, parameters)).join();
@@ -1073,7 +1070,7 @@ public class MyriadCore extends MyriadApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " createOrder() requires a privateKey to sign the on-chain transaction")) ;
             }
-            this.checkEventsAndMarkets(symbol);
+            this.checkEvents(symbol);
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object networkId = this.safeString(info, "networkId");
@@ -1311,7 +1308,7 @@ public class MyriadCore extends MyriadApi
             put( "symbol", finalSymbol );
             put( "outcomeId", MyriadCore.this.safeString(finalOutcomeObj, "id") );
             put( "label", MyriadCore.this.safeString(finalOutcomeObj, "label") );
-            put( "market", MyriadCore.this.safeString(finalOutcomeObj, "marketSymbol") );
+            put( "market", MyriadCore.this.safeString(finalOutcomeObj, "outcome") );
             put( "type", ((Helpers.isTrue(isMarketTif))) ? "market" : "limit" );
             put( "timeInForce", finalTif );
             put( "postOnly", (Helpers.isEqual(finalTif, "PO")) );
@@ -1350,7 +1347,6 @@ public class MyriadCore extends MyriadApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " cancelOrder() requires a privateKey to sign the cancellation")) ;
             }
-            (this.loadMarkets()).join();
             Object fetched = (this.myriadPublicGetOrdersHash(this.extend(new java.util.HashMap<String, Object>() {{
                 put( "hash", id );
             }}, parameters))).join();
@@ -1401,7 +1397,6 @@ public class MyriadCore extends MyriadApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " cancelAllOrders() requires a privateKey to sign the cancellation")) ;
             }
-            (this.loadMarkets()).join();
             Object trader = this.ethGetAddressFromPrivateKey(this.privateKey);
             Object marketId = this.safeString(parameters, "market_id", "0");
             Object networkId = this.safeString(parameters, "network_id", this.safeString(this.options, "defaultNetworkId", "56"));
@@ -1456,7 +1451,6 @@ public class MyriadCore extends MyriadApi
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " cancelOrders() requires a privateKey to sign the cancellations")) ;
             }
-            (this.loadMarkets()).join();
             Object idsLength = Helpers.getArrayLength(ids);
             Object signedOrders = new java.util.ArrayList<Object>(java.util.Arrays.asList());
             Object wrappers = new java.util.ArrayList<Object>(java.util.Arrays.asList());
@@ -1509,7 +1503,6 @@ public class MyriadCore extends MyriadApi
 
             Object symbol = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             Object response = (this.myriadPublicGetOrdersHash(this.extend(new java.util.HashMap<String, Object>() {{
                 put( "hash", id );
             }}, parameters))).join();
@@ -1546,7 +1539,6 @@ public class MyriadCore extends MyriadApi
             Object since = Helpers.getArg(optionalArgs, 1, null);
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             Object request = new java.util.HashMap<String, Object>() {{}};
             Object trader = this.safeString(parameters, "trader");
             if (Helpers.isTrue(Helpers.isEqual(trader, null)))
@@ -1833,7 +1825,7 @@ public class MyriadCore extends MyriadApi
             put( "symbol", MyriadCore.this.safeString(market, "symbol") );
             put( "outcomeId", MyriadCore.this.safeString(market, "id") );
             put( "label", MyriadCore.this.safeString(market, "label") );
-            put( "market", MyriadCore.this.safeString(market, "marketSymbol") );
+            put( "market", MyriadCore.this.safeString(market, "outcome") );
             put( "type", "market" );
             put( "side", side );
             put( "price", MyriadCore.this.safeNumber(quote, "priceAverage") );
@@ -1867,6 +1859,8 @@ public class MyriadCore extends MyriadApi
             put( "title", MyriadCore.this.safeString2(raw, "title", "shortName") );
             put( "description", MyriadCore.this.safeString(raw, "description") );
             put( "markets", new java.util.ArrayList<Object>(java.util.Arrays.asList(market)) );
+            put( "volume", MyriadCore.this.safeNumber2(raw, "volumeNotional24h", "volume24h") );
+            put( "liquidity", MyriadCore.this.safeNumber(raw, "liquidity") );
             put( "url", null );
             put( "image", MyriadCore.this.safeString(raw, "imageUrl") );
             put( "active", (Helpers.isEqual(finalState, "open")) );
@@ -1932,7 +1926,6 @@ final Object finalNetworkId = networkId;
                 put( "outcomeId", outcomeCompositeId );
                 put( "symbol", outcomeHandle );
                 put( "outcome", outcomeHandle );
-                put( "marketSymbol", marketSymbol );
                 put( "market", marketSymbol );
                 put( "label", outcomeLabel );
                 put( "active", active );
@@ -2043,7 +2036,6 @@ final Object finalNetworkId = networkId;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(outcome);
             Object networkId = this.safeString(Helpers.GetValue(outcomeObj, "info"), "networkId");
@@ -2147,7 +2139,6 @@ final Object finalNetworkId = networkId;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(outcome);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -2170,6 +2161,8 @@ final Object finalNetworkId = networkId;
             return new java.util.HashMap<String, Object>() {{
                 put( "info", response );
                 put( "symbol", MyriadCore.this.safeSymbol(null, ((Object)outcomeObj)) );
+                put( "outcome", MyriadCore.this.safeOutcomeSymbol(null, ((Object)outcomeObj)) );
+                put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "outcomeId") );
                 put( "maker", MyriadCore.this.safeNumber(sell, "fee") );
                 put( "taker", MyriadCore.this.safeNumber(buy, "fee") );
                 put( "percentage", true );
@@ -2285,7 +2278,7 @@ final Object finalNetworkId = networkId;
             put( "symbol", MyriadCore.this.safeString(market, "symbol") );
             put( "outcomeId", MyriadCore.this.safeString(market, "id") );
             put( "label", MyriadCore.this.safeString(market, "label") );
-            put( "market", MyriadCore.this.safeString(market, "marketSymbol") );
+            put( "market", MyriadCore.this.safeString(market, "outcome") );
             put( "timestamp", now );
             put( "datetime", MyriadCore.this.iso8601(now) );
             put( "high", null );
@@ -2326,7 +2319,6 @@ final Object finalNetworkId = networkId;
             Object limit = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(outcome);
             Object networkId = this.safeString(Helpers.GetValue(outcomeObj, "info"), "networkId");
@@ -2538,7 +2530,6 @@ final Object finalNetworkId = networkId;
             Object since = Helpers.getArg(optionalArgs, 1, null);
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(symbol);
             Object outcomeInfo = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -2697,7 +2688,6 @@ final Object finalNetworkId = networkId;
 
             Object symbols = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object result = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(Helpers.isEqual(symbols, null)))
@@ -2793,7 +2783,6 @@ final Object finalNetworkId = networkId;
             Object since = Helpers.getArg(optionalArgs, 0, null);
             Object limit = Helpers.getArg(optionalArgs, 1, null);
             Object parameters = Helpers.getArg(optionalArgs, 2, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -2885,7 +2874,7 @@ final Object finalNetworkId = networkId;
             put( "symbol", MyriadCore.this.safeString(market, "symbol") );
             put( "outcomeId", MyriadCore.this.safeString(market, "id") );
             put( "label", MyriadCore.this.safeString(market, "label") );
-            put( "market", MyriadCore.this.safeString(market, "marketSymbol") );
+            put( "market", MyriadCore.this.safeString(market, "outcome") );
             put( "order", null );
             put( "type", null );
             put( "side", MyriadCore.this.safeString(trade, "action") );
@@ -2916,13 +2905,12 @@ final Object finalNetworkId = networkId;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object queries = this.parseSearchQueries(parameters);
-            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("query", "queries")));
+            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("query", "queries", "sort", "searchIn", "eventId", "slug", "status")));
             Object queriesLength = Helpers.getArrayLength(queries);
             if (Helpers.isTrue(Helpers.isEqual(queriesLength, 0)))
             {
-                (this.loadMarkets()).join();
                 this.populateOutcomes();
-                return Helpers.objectValues(this.events);
+                return this.applyEventFetchParams((java.util.List<Object>)(Helpers.objectValues(this.events)), parameters, queries);
             }
             Object rawMarkets = (this.fetchRawMarketsBySearch(queries, rest)).join();
             if (!Helpers.isTrue(this.events))
@@ -2948,7 +2936,7 @@ final Object finalNetworkId = networkId;
                 }
             }
             this.populateOutcomes();
-            return result;
+            return this.applyEventFetchParams(result, parameters, queries);
         });
 
     }
@@ -3027,6 +3015,8 @@ final Object finalNetworkId = networkId;
             put( "title", MyriadCore.this.safeString(rawEvent, "title") );
             put( "description", MyriadCore.this.safeString(rawEvent, "description") );
             put( "markets", marketsList );
+            put( "volume", MyriadCore.this.safeNumber2(rawEvent, "volumeNotional24h", "volume24h") );
+            put( "liquidity", MyriadCore.this.safeNumber(rawEvent, "liquidity") );
             put( "url", MyriadCore.this.safeString(rawEvent, "url") );
             put( "image", MyriadCore.this.safeString(rawEvent, "imageUrl", MyriadCore.this.safeString(rawEvent, "image")) );
             put( "active", MyriadCore.this.safeBool(rawEvent, "active") );
@@ -3235,7 +3225,6 @@ final Object finalNetworkId = networkId;
 
             Object limit = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -3349,7 +3338,6 @@ final Object finalNetworkId = networkId;
             Object since = Helpers.getArg(optionalArgs, 0, null);
             Object limit = Helpers.getArg(optionalArgs, 1, null);
             Object parameters = Helpers.getArg(optionalArgs, 2, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -3389,7 +3377,6 @@ final Object finalNetworkId = networkId;
             {
                 throw new ArgumentsRequired((String)Helpers.add(this.id, " watchMyTrades() requires a symbol (the trades channel is per-market)")) ;
             }
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -3445,7 +3432,7 @@ final Object finalNetworkId = networkId;
             put( "symbol", finalSym );
             put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "id") );
             put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
-            put( "market", MyriadCore.this.safeString(outcomeObj, "marketSymbol") );
+            put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );
             put( "order", MyriadCore.this.safeString(taker, "orderHash") );
             put( "type", null );
             put( "side", MyriadCore.this.safeStringLower(taker, "side") );
@@ -3500,7 +3487,7 @@ final Object finalNetworkId = networkId;
                         put( "symbol", makerSym );
                         put( "outcomeId", MyriadCore.this.safeString(makerOutcomeObj, "id") );
                         put( "label", MyriadCore.this.safeString(makerOutcomeObj, "label") );
-                        put( "market", MyriadCore.this.safeString(makerOutcomeObj, "marketSymbol") );
+                        put( "market", MyriadCore.this.safeString(makerOutcomeObj, "outcome") );
                         put( "order", MyriadCore.this.safeString(maker, "orderHash") );
                         put( "type", null );
                         put( "side", MyriadCore.this.safeStringLower(maker, "side") );
@@ -3549,7 +3536,6 @@ final Object finalNetworkId = networkId;
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object outcomeObj = this.outcome(symbol);
             Object info = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -3579,7 +3565,6 @@ final Object finalNetworkId = networkId;
 
             Object symbols = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             if (Helpers.isTrue(Helpers.isEqual(symbols, null)))
             {
@@ -3682,7 +3667,7 @@ final Object finalNetworkId = networkId;
                 put( "symbol", finalSym );
                 put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "id") );
                 put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
-                put( "market", MyriadCore.this.safeString(outcomeObj, "marketSymbol") );
+                put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );
                 put( "timestamp", ts );
                 put( "datetime", MyriadCore.this.iso8601(ts) );
                 put( "high", null );
@@ -3729,7 +3714,6 @@ final Object finalNetworkId = networkId;
             Object since = Helpers.getArg(optionalArgs, 1, null);
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object trader = this.walletAddressFromKeys();
             Object networkId = this.safeString(this.options, "defaultNetworkId", "56");
@@ -3778,7 +3762,7 @@ final Object finalNetworkId = networkId;
             put( "symbol", finalSym );
             put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "id") );
             put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
-            put( "market", MyriadCore.this.safeString(outcomeObj, "marketSymbol") );
+            put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );
             put( "type", ((Helpers.isTrue(isMarketTif))) ? "market" : "limit" );
             put( "timeInForce", finalTif );
             put( "side", MyriadCore.this.safeStringLower(data, "side") );
@@ -3821,7 +3805,6 @@ final Object finalNetworkId = networkId;
             Object since = Helpers.getArg(optionalArgs, 1, null);
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             this.ensureOutcomesLoaded();
             Object trader = this.walletAddressFromKeys();
             Object networkId = this.safeString(this.options, "defaultNetworkId", "56");
@@ -3921,7 +3904,7 @@ final Object finalNetworkId = networkId;
             put( "symbol", sym );
             put( "outcomeId", finalPosId );
             put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
-            put( "market", MyriadCore.this.safeString(outcomeObj, "marketSymbol") );
+            put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );
             put( "timestamp", ts );
             put( "datetime", MyriadCore.this.iso8601(ts) );
             put( "side", "long" );

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/MyriadCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/MyriadCore.java
@@ -422,8 +422,9 @@ public class MyriadCore extends MyriadApi
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
+            Object symbols = outcomes;
             Object address = this.safeString2(parameters, "address", "user", this.walletAddress);
             if (Helpers.isTrue(Helpers.isEqual(address, null)))
             {
@@ -2685,8 +2686,9 @@ final Object finalNetworkId = networkId;
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
+            Object symbols = outcomes;
             this.ensureOutcomesLoaded();
             Object result = new java.util.HashMap<String, Object>() {{}};
             if (Helpers.isTrue(Helpers.isEqual(symbols, null)))

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/MyriadCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/MyriadCore.java
@@ -478,7 +478,7 @@ public class MyriadCore extends MyriadApi
         return this.safePredictionPosition(new java.util.HashMap<String, Object>() {{
             put( "info", position );
             put( "id", id );
-            put( "symbol", symbol );
+            put( "outcome", symbol );
             put( "outcomeId", outcomeId );
             put( "label", outcomeTitle );
             put( "market", marketSymbol );
@@ -553,7 +553,7 @@ public class MyriadCore extends MyriadApi
     {
         Object market = Helpers.getArg(optionalArgs, 0, null);
         return new java.util.HashMap<String, Object>() {{
-            put( "symbol", MyriadCore.this.safeString(market, "symbol") );
+            put( "outcome", MyriadCore.this.safeString(market, "outcome") );
             put( "side", MyriadCore.this.safeStringLower(quote, "action") );
             put( "value", MyriadCore.this.safeNumber(quote, "value") );
             put( "shares", MyriadCore.this.safeNumber(quote, "shares") );
@@ -1293,7 +1293,7 @@ public class MyriadCore extends MyriadApi
                 composite = Helpers.add(Helpers.add(Helpers.add(Helpers.add(networkId, ":"), marketId), "/"), outcomeId);
             }
             outcomeObj = this.safeOutcome(composite, ((Object)market));
-            symbol = this.safeString(outcomeObj, "symbol");
+            symbol = this.safeString(outcomeObj, "outcome");
         }
         final Object finalSymbol = symbol;
         final Object finalOutcomeObj = outcomeObj;
@@ -1305,7 +1305,7 @@ public class MyriadCore extends MyriadApi
             put( "timestamp", timestamp );
             put( "datetime", MyriadCore.this.iso8601(timestamp) );
             put( "lastTradeTimestamp", null );
-            put( "symbol", finalSymbol );
+            put( "outcome", finalSymbol );
             put( "outcomeId", MyriadCore.this.safeString(finalOutcomeObj, "id") );
             put( "label", MyriadCore.this.safeString(finalOutcomeObj, "label") );
             put( "market", MyriadCore.this.safeString(finalOutcomeObj, "outcome") );
@@ -1710,7 +1710,7 @@ public class MyriadCore extends MyriadApi
             put( "info", MyriadCore.this.safeDict(order, "info", new java.util.HashMap<String, Object>() {{}}) );
             put( "timestamp", timestamp );
             put( "datetime", MyriadCore.this.iso8601(timestamp) );
-            put( "symbol", MyriadCore.this.safeString(order, "outcome") );
+            put( "outcome", MyriadCore.this.safeString(order, "outcome") );
             put( "outcomeId", MyriadCore.this.safeString(order, "outcomeId") );
             put( "label", MyriadCore.this.safeString(order, "label") );
             put( "market", MyriadCore.this.safeString(order, "market") );
@@ -1822,7 +1822,7 @@ public class MyriadCore extends MyriadApi
             put( "info", MyriadCore.this.extend(new java.util.HashMap<String, Object>() {{
                 put( "transactionHash", txHash );
             }}, MyriadCore.this.safeDict(quote, "info", new java.util.HashMap<String, Object>() {{}})) );
-            put( "symbol", MyriadCore.this.safeString(market, "symbol") );
+            put( "outcome", MyriadCore.this.safeString(market, "outcome") );
             put( "outcomeId", MyriadCore.this.safeString(market, "id") );
             put( "label", MyriadCore.this.safeString(market, "label") );
             put( "market", MyriadCore.this.safeString(market, "outcome") );
@@ -1924,7 +1924,6 @@ final Object finalNetworkId = networkId;
                         ((java.util.List<Object>)outcomes).add(new java.util.HashMap<String, Object>() {{
                 put( "id", outcomeCompositeId );
                 put( "outcomeId", outcomeCompositeId );
-                put( "symbol", outcomeHandle );
                 put( "outcome", outcomeHandle );
                 put( "market", marketSymbol );
                 put( "label", outcomeLabel );
@@ -2160,7 +2159,6 @@ final Object finalNetworkId = networkId;
             Object sell = this.safeDict(fees, "sell", new java.util.HashMap<String, Object>() {{}});
             return new java.util.HashMap<String, Object>() {{
                 put( "info", response );
-                put( "symbol", MyriadCore.this.safeSymbol(null, ((Object)outcomeObj)) );
                 put( "outcome", MyriadCore.this.safeOutcomeSymbol(null, ((Object)outcomeObj)) );
                 put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "outcomeId") );
                 put( "maker", MyriadCore.this.safeNumber(sell, "fee") );
@@ -2275,7 +2273,7 @@ final Object finalNetworkId = networkId;
         final Object finalPrice = price;
         final Object finalChange = change;
         return this.safePredictionTicker(new java.util.HashMap<String, Object>() {{
-            put( "symbol", MyriadCore.this.safeString(market, "symbol") );
+            put( "outcome", MyriadCore.this.safeString(market, "outcome") );
             put( "outcomeId", MyriadCore.this.safeString(market, "id") );
             put( "label", MyriadCore.this.safeString(market, "label") );
             put( "market", MyriadCore.this.safeString(market, "outcome") );
@@ -2339,7 +2337,7 @@ final Object finalNetworkId = networkId;
                 //         "asks": [ [ "990000000000000000", "151975683890577539072" ] ]
                 //     }
                 //
-                return this.parseWeiOrderBook(obResponse, this.safeOutcomeSymbol(outcome, outcomeObj));
+                return this.safePredictionOrderBook(this.parseWeiOrderBook(obResponse, this.safeOutcomeSymbol(outcome, outcomeObj)), outcomeObj);
             }
             Object request = new java.util.HashMap<String, Object>() {{
                 put( "id", marketId );
@@ -2457,14 +2455,15 @@ final Object finalNetworkId = networkId;
             {
                 ((java.util.List<Object>)asks).add(new java.util.ArrayList<Object>(java.util.Arrays.asList(ask, synthSize)));
             }
-            return new java.util.HashMap<String, Object>() {{
-                put( "symbol", MyriadCore.this.safeOutcomeSymbol(outcome, outcomeObj) );
+            Object orderbook = new java.util.HashMap<String, Object>() {{
+                put( "outcome", MyriadCore.this.safeOutcomeSymbol(outcome, outcomeObj) );
                 put( "bids", bids );
                 put( "asks", asks );
                 put( "timestamp", timestamp );
                 put( "datetime", MyriadCore.this.iso8601(timestamp) );
                 put( "nonce", null );
             }};
+            return this.safePredictionOrderBook(orderbook, outcomeObj);
         });
 
     }
@@ -2500,7 +2499,7 @@ final Object finalNetworkId = networkId;
         }
         Object timestamp = this.milliseconds();
         return new java.util.HashMap<String, Object>() {{
-            put( "symbol", symbol );
+            put( "outcome", symbol );
             put( "bids", MyriadCore.this.sortBy(bids, 0, true) );
             put( "asks", MyriadCore.this.sortBy(asks, 0) );
             put( "timestamp", timestamp );
@@ -2871,7 +2870,7 @@ final Object finalNetworkId = networkId;
             put( "info", trade );
             put( "timestamp", timestamp );
             put( "datetime", MyriadCore.this.iso8601(timestamp) );
-            put( "symbol", MyriadCore.this.safeString(market, "symbol") );
+            put( "outcome", MyriadCore.this.safeString(market, "outcome") );
             put( "outcomeId", MyriadCore.this.safeString(market, "id") );
             put( "label", MyriadCore.this.safeString(market, "label") );
             put( "market", MyriadCore.this.safeString(market, "outcome") );
@@ -2910,7 +2909,9 @@ final Object finalNetworkId = networkId;
             if (Helpers.isTrue(Helpers.isEqual(queriesLength, 0)))
             {
                 this.populateOutcomes();
-                return this.applyEventFetchParams((java.util.List<Object>)(Helpers.objectValues(this.events)), parameters, queries);
+                // hoist Object.values to a local — inline as a call argument breaks the php regex transpiler
+                Object existingEvents = (java.util.List<Object>)(Helpers.objectValues(this.events));
+                return this.applyEventFetchParams(existingEvents, parameters, queries);
             }
             Object rawMarkets = (this.fetchRawMarketsBySearch(queries, rest)).join();
             if (!Helpers.isTrue(this.events))
@@ -2975,12 +2976,17 @@ final Object finalNetworkId = networkId;
             for (var j = 0; Helpers.isLessThan(j, Helpers.getArrayLength(outcomesList)); j++)
             {
                 Object oc = Helpers.GetValue(outcomesList, j);
-                Object ocSymbol = this.safeString(oc, "symbol");
+                // accept the legacy symbol/id keys too: in Go/C#/Java the prediction
+                // setMarkets override is not dispatched, so oc is not pre-normalized
+                Object ocSymbol = this.safeString2(oc, "outcome", "symbol");
+                Object ocId = this.safeString2(oc, "outcomeId", "id");
+                Helpers.addElementToObject(oc, "outcome", ocSymbol);
+                Helpers.addElementToObject(oc, "outcomeId", ocId);
+                Helpers.addElementToObject(oc, "market", this.safeString2(oc, "market", "marketSymbol"));
                 if (Helpers.isTrue(!Helpers.isEqual(ocSymbol, null)))
                 {
                     Helpers.addElementToObject(this.outcomes, ocSymbol, oc);
                 }
-                Object ocId = this.safeString(oc, "id");
                 if (Helpers.isTrue(!Helpers.isEqual(ocId, null)))
                 {
                     Helpers.addElementToObject(this.outcomes_by_id, ocId, oc);
@@ -3065,7 +3071,7 @@ final Object finalNetworkId = networkId;
         }
         Object ocId = Helpers.add(Helpers.add(Helpers.add(Helpers.add(networkId, ":"), marketId), "/"), outcomeId);
         Object outcomeObj = this.safeDict(this.outcomes_by_id, ocId);
-        return this.safeString(outcomeObj, "symbol");
+        return this.safeString(outcomeObj, "outcome");
     }
 
     public java.util.concurrent.CompletableFuture<Object> connectCentrifugo(Object url)
@@ -3429,7 +3435,7 @@ final Object finalNetworkId = networkId;
             put( "info", data );
             put( "timestamp", ts );
             put( "datetime", MyriadCore.this.iso8601(ts) );
-            put( "symbol", finalSym );
+            put( "outcome", finalSym );
             put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "id") );
             put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
             put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );
@@ -3484,7 +3490,7 @@ final Object finalNetworkId = networkId;
                         put( "info", maker );
                         put( "timestamp", ts );
                         put( "datetime", MyriadCore.this.iso8601(ts) );
-                        put( "symbol", makerSym );
+                        put( "outcome", makerSym );
                         put( "outcomeId", MyriadCore.this.safeString(makerOutcomeObj, "id") );
                         put( "label", MyriadCore.this.safeString(makerOutcomeObj, "label") );
                         put( "market", MyriadCore.this.safeString(makerOutcomeObj, "outcome") );
@@ -3664,7 +3670,7 @@ final Object finalNetworkId = networkId;
             Object last = this.fromWei(this.safeString(oc, "last"));
             final Object finalSym = sym;
             Object ticker = this.safePredictionTicker(new java.util.HashMap<String, Object>() {{
-                put( "symbol", finalSym );
+                put( "outcome", finalSym );
                 put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "id") );
                 put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
                 put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );
@@ -3759,7 +3765,7 @@ final Object finalNetworkId = networkId;
             put( "info", data );
             put( "timestamp", timestamp );
             put( "datetime", MyriadCore.this.iso8601(timestamp) );
-            put( "symbol", finalSym );
+            put( "outcome", finalSym );
             put( "outcomeId", MyriadCore.this.safeString(outcomeObj, "id") );
             put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
             put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );
@@ -3901,7 +3907,7 @@ final Object finalNetworkId = networkId;
         Object parsed = this.safePredictionPosition(new java.util.HashMap<String, Object>() {{
             put( "info", data );
             put( "id", finalPosId );
-            put( "symbol", sym );
+            put( "outcome", sym );
             put( "outcomeId", finalPosId );
             put( "label", MyriadCore.this.safeString(outcomeObj, "label") );
             put( "market", MyriadCore.this.safeString(outcomeObj, "outcome") );

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Polymarket.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/Polymarket.java
@@ -110,18 +110,18 @@ public class Polymarket extends PolymarketCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesAsync(String[] codes, Map<String, Object> params) { return fetchDepositAddressesAsync(codes == null ? null : java.util.Arrays.asList(codes), params); }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol) { return fetchOrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchOrderBook(String symbol, Long limit) { return fetchOrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchOrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchOrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol) { return fetchOrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchOrderBookAsync(String symbol, Long limit) { return fetchOrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public MarginMode fetchMarginMode(String symbol, Map<String, Object> params) {
@@ -336,34 +336,34 @@ public class Polymarket extends PolymarketCore {
     public CompletableFuture<List<DepositAddress>> fetchDepositAddressesByNetworkAsync(String code) { return fetchDepositAddressesByNetworkAsync(code, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params));
-        return toTypedList(res, OpenInterest::new);
+        return toTypedList(res, PredictionOpenInterest::new);
     }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public List<OpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol) { return fetchOpenInterestHistory(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe) { return fetchOpenInterestHistory(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since) { return fetchOpenInterestHistory(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public List<PredictionOpenInterest> fetchOpenInterestHistory(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistory(symbol, timeframe, since, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
-        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, OpenInterest::new));
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit, Map<String, Object> params) {
+        return super.fetchOpenInterestHistory(symbol, timeframe, since, limit, params).thenApply(res -> toTypedList(res, PredictionOpenInterest::new));
     }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<List<OpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol) { return fetchOpenInterestHistoryAsync(symbol, "1h", (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe) { return fetchOpenInterestHistoryAsync(symbol, timeframe, (Long) null, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<List<PredictionOpenInterest>> fetchOpenInterestHistoryAsync(String symbol, String timeframe, Long since, Long limit) { return fetchOpenInterestHistoryAsync(symbol, timeframe, since, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
-    public OpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
+    public PredictionOpenInterest fetchOpenInterest(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchOpenInterest(symbol, params));
-        return new OpenInterest(res);
+        return new PredictionOpenInterest(res);
     }
-    public OpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
+    public PredictionOpenInterest fetchOpenInterest(String symbol) { return fetchOpenInterest(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
-        return super.fetchOpenInterest(symbol, params).thenApply(OpenInterest::new);
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol, Map<String, Object> params) {
+        return super.fetchOpenInterest(symbol, params).thenApply(PredictionOpenInterest::new);
     }
-    public CompletableFuture<OpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOpenInterest> fetchOpenInterestAsync(String symbol) { return fetchOpenInterestAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public OpenInterests fetchOpenInterests(List<String> symbols, Map<String, Object> params) {
@@ -1484,18 +1484,18 @@ public class Polymarket extends PolymarketCore {
     }
 
     @SuppressWarnings("unchecked")
-    public OrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchL3OrderBook(symbol, limit, params));
-        return new OrderBook(res);
+        return new PredictionOrderBook(res);
     }
-    public OrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
-    public OrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol) { return fetchL3OrderBook(symbol, (Long) null, (Map<String, Object>) null); }
+    public PredictionOrderBook fetchL3OrderBook(String symbol, Long limit) { return fetchL3OrderBook(symbol, limit, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
-        return super.fetchL3OrderBook(symbol, limit, params).thenApply(OrderBook::new);
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit, Map<String, Object> params) {
+        return super.fetchL3OrderBook(symbol, limit, params).thenApply(PredictionOrderBook::new);
     }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
-    public CompletableFuture<OrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol) { return fetchL3OrderBookAsync(symbol, (Long) null, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionOrderBook> fetchL3OrderBookAsync(String symbol, Long limit) { return fetchL3OrderBookAsync(symbol, limit, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public DepositAddress fetchDepositAddress(String code, Map<String, Object> params) {
@@ -1698,16 +1698,16 @@ public class Polymarket extends PolymarketCore {
     }
 
     @SuppressWarnings("unchecked")
-    public TradingFeeInterface fetchTradingFee(String symbol, Map<String, Object> params) {
+    public PredictionTradingFee fetchTradingFee(String symbol, Map<String, Object> params) {
         Object res = Helpers.joinUnwrapped(super.fetchTradingFee(symbol, params));
-        return new TradingFeeInterface(res);
+        return new PredictionTradingFee(res);
     }
-    public TradingFeeInterface fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
+    public PredictionTradingFee fetchTradingFee(String symbol) { return fetchTradingFee(symbol, (Map<String, Object>) null); }
     @SuppressWarnings("unchecked")
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
-        return super.fetchTradingFee(symbol, params).thenApply(TradingFeeInterface::new);
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol, Map<String, Object> params) {
+        return super.fetchTradingFee(symbol, params).thenApply(PredictionTradingFee::new);
     }
-    public CompletableFuture<TradingFeeInterface> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
+    public CompletableFuture<PredictionTradingFee> fetchTradingFeeAsync(String symbol) { return fetchTradingFeeAsync(symbol, (Map<String, Object>) null); }
 
     @SuppressWarnings("unchecked")
     public Currencies fetchConvertCurrencies(Map<String, Object> params) {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
@@ -1406,7 +1406,11 @@ final Object finalMarketSymbol = marketSymbol;
                     ((java.util.List<Object>)filteredTrades).add(trade);
                 }
             }
-            return this.parseTrades(filteredTrades, outcomeObj, since, limit);
+            // the trades are already narrowed to this outcome by asset id above; pass no market so the
+            // base parseTrades doesn't apply its symbol filter (prediction trades carry `outcome`, not
+            // `symbol`, so a symbol-bearing outcome object would drop them all). parseTrade resolves the
+            // outcome from each trade's asset id.
+            return this.parseTrades(filteredTrades, null, since, limit);
         });
 
     }

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
@@ -361,17 +361,42 @@ public class PolymarketCore extends PolymarketApi
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object pageSize = this.safeInteger(parameters, "limit", 50);
-            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("limit")));
+            // map the unified sort/status onto the gamma search params
+            Object sort = this.safeString(parameters, "sort");
+            Object sortParam = "volume";
+            if (Helpers.isTrue(Helpers.isEqual(sort, "liquidity")))
+            {
+                sortParam = "liquidity";
+            } else if (Helpers.isTrue(Helpers.isEqual(sort, "newest")))
+            {
+                sortParam = "startDate";
+            }
+            Object status = this.safeString(parameters, "status", "active");
+            Object eventsStatus = "active";
+            if (Helpers.isTrue(Helpers.isTrue((Helpers.isEqual(status, "closed"))) || Helpers.isTrue((Helpers.isEqual(status, "inactive")))))
+            {
+                eventsStatus = "closed";
+            } else if (Helpers.isTrue(Helpers.isEqual(status, "all")))
+            {
+                eventsStatus = null;
+            }
+            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("limit", "sort", "status", "searchIn", "eventId", "slug", "query", "queries")));
             Object seen = new java.util.HashMap<String, Object>() {{}};
             Object rawEvents = new java.util.ArrayList<Object>(java.util.Arrays.asList());
             for (var qi = 0; Helpers.isLessThan(qi, Helpers.getArrayLength(queries)); qi++)
             {
                 Object q = Helpers.GetValue(queries, qi);
+                final Object finalSortParam = sortParam;
                 Object baseRequest = new java.util.HashMap<String, Object>() {{
                     put( "q", q );
                     put( "limit_per_type", pageSize );
-                    put( "events_status", "active" );
+                    put( "sort", finalSortParam );
+                    put( "ascending", false );
                 }};
+                if (Helpers.isTrue(!Helpers.isEqual(eventsStatus, null)))
+                {
+                    Helpers.addElementToObject(baseRequest, "events_status", eventsStatus);
+                }
                 Object firstRequest = new java.util.HashMap<String, Object>() {{
                     put( "page", 1 );
                 }};
@@ -450,20 +475,34 @@ public class PolymarketCore extends PolymarketApi
             Object limit = this.safeInteger(parameters, "limit", this.safeInteger(this.options, "fetchMarketsLimit", 1000));
             Object maxPages = Math.ceil(Double.parseDouble(Helpers.toString(Helpers.divide(limit, pageSize))));
             Object status = this.safeString(parameters, "status", this.safeString(this.options, "defaultEventStatus", "active"));
-            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("status", "limit")));
+            // sort maps to the gamma `order` field; 'volume' is the default ranking
+            Object sort = this.safeString(parameters, "sort");
+            Object order = "volume";
+            if (Helpers.isTrue(Helpers.isEqual(sort, "liquidity")))
+            {
+                order = "liquidity";
+            } else if (Helpers.isTrue(Helpers.isEqual(sort, "newest")))
+            {
+                order = "startDate";
+            }
+            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("status", "limit", "sort", "searchIn", "eventId", "slug", "query", "queries")));
+            final Object finalOrder = order;
             Object baseRequest = new java.util.HashMap<String, Object>() {{
                 put( "limit", pageSize );
-                put( "order", "volume24hr" );
+                put( "order", finalOrder );
                 put( "ascending", false );
             }};
             baseRequest = this.extend(baseRequest, rest);
             if (Helpers.isTrue(Helpers.isEqual(status, "active")))
             {
                 Helpers.addElementToObject(baseRequest, "active", true);
-            } else if (Helpers.isTrue(Helpers.isEqual(status, "closed")))
+                Helpers.addElementToObject(baseRequest, "closed", false);
+            } else if (Helpers.isTrue(Helpers.isTrue((Helpers.isEqual(status, "closed"))) || Helpers.isTrue((Helpers.isEqual(status, "inactive")))))
             {
+                Helpers.addElementToObject(baseRequest, "active", false);
                 Helpers.addElementToObject(baseRequest, "closed", true);
             }
+            // 'all' — no active/closed filter
             // fetch page 1 first; if full, fire remaining pages in parallel
             Object firstPageRequest = new java.util.HashMap<String, Object>() {{
                 put( "offset", 0 );
@@ -771,7 +810,7 @@ final Object finalMarketSymbol = marketSymbol;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = Helpers.GetValue(outcomeObj, "outcomeId");
             Object promises = new java.util.ArrayList<Object>(java.util.Arrays.asList(this.clobPublicGetMidpoint(new java.util.HashMap<String, Object>() {{
@@ -847,11 +886,11 @@ final Object finalMarketSymbol = marketSymbol;
             {
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(outcomes)); i++)
                 {
-                    this.checkEventsAndMarkets(Helpers.GetValue(outcomes, i));
+                    this.checkEvents(Helpers.GetValue(outcomes, i));
                 }
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object outcomesMap = ((Helpers.isTrue((!Helpers.isEqual(this.outcomes, null))))) ? this.outcomes : new java.util.HashMap<String, Object>() {{}};
             Object targets = new java.util.ArrayList<Object>(java.util.Arrays.asList());
@@ -995,7 +1034,7 @@ final Object finalMarketSymbol = marketSymbol;
         final Object finalMarket = market;
         final Object finalQuoteVolume = quoteVolume;
         return this.safePredictionTicker(new java.util.HashMap<String, Object>() {{
-            put( "symbol", symbol );
+            put( "outcome", symbol );
             put( "outcomeId", PolymarketCore.this.safeString(finalMarket, "outcomeId") );
             put( "label", PolymarketCore.this.safeString(finalMarket, "label") );
             put( "market", PolymarketCore.this.safeString(finalMarket, "market") );
@@ -1039,7 +1078,7 @@ final Object finalMarketSymbol = marketSymbol;
             Object limit = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = ((String)Helpers.GetValue(outcomeObj, "outcomeId"));
             Object request = new java.util.HashMap<String, Object>() {{
@@ -1098,7 +1137,7 @@ final Object finalMarketSymbol = marketSymbol;
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = ((String)Helpers.GetValue(outcomeObj, "outcomeId"));
             Object fidelityMin = this.safeInteger(this.timeframes, timeframe, 1); // fidelity in minutes
@@ -1275,7 +1314,7 @@ final Object finalMarketSymbol = marketSymbol;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object outcomeInfo = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
             Object conditionId = this.safeString(outcomeInfo, "conditionId");
@@ -1304,7 +1343,7 @@ final Object finalMarketSymbol = marketSymbol;
         //
         Object market = Helpers.getArg(optionalArgs, 0, null);
         Object timestamp = this.milliseconds();
-        return this.safeOpenInterest(new java.util.HashMap<String, Object>() {{
+        Object openInterest = this.safeOpenInterest(new java.util.HashMap<String, Object>() {{
             put( "symbol", PolymarketCore.this.safeOutcomeSymbol(null, market) );
             put( "openInterestAmount", null );
             put( "openInterestValue", PolymarketCore.this.safeNumber(interest, "value") );
@@ -1314,6 +1353,10 @@ final Object finalMarketSymbol = marketSymbol;
             put( "datetime", PolymarketCore.this.iso8601(timestamp) );
             put( "info", interest );
         }}, market);
+        Helpers.addElementToObject(openInterest, "outcome", this.safeOutcomeSymbol(null, market));
+        Helpers.addElementToObject(openInterest, "outcomeId", this.safeString(market, "outcomeId"));
+        ((java.util.Map<String,Object>)openInterest).remove((String)"symbol");
+        return openInterest;
     }
 
     /**
@@ -1332,7 +1375,7 @@ final Object finalMarketSymbol = marketSymbol;
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = this.safeString(outcomeObj, "outcomeId");
             Object request = new java.util.HashMap<String, Object>() {{
@@ -1346,7 +1389,8 @@ final Object finalMarketSymbol = marketSymbol;
             Object rate = ((Helpers.isTrue((!Helpers.isEqual(baseFeeBps, null))))) ? this.parseNumber(Precise.stringDiv(baseFeeBps, "10000")) : null;
             return new java.util.HashMap<String, Object>() {{
                 put( "info", response );
-                put( "symbol", PolymarketCore.this.safeOutcomeSymbol(null, ((Object)outcomeObj)) );
+                put( "outcome", PolymarketCore.this.safeOutcomeSymbol(null, ((Object)outcomeObj)) );
+                put( "outcomeId", PolymarketCore.this.safeString(outcomeObj, "outcomeId") );
                 put( "maker", rate );
                 put( "taker", rate );
                 put( "percentage", true );
@@ -1376,7 +1420,7 @@ final Object finalMarketSymbol = marketSymbol;
             Object limit = Helpers.getArg(optionalArgs, 1, null);
             Object parameters = Helpers.getArg(optionalArgs, 2, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            this.checkEventsAndMarkets(outcome);
+            this.checkEvents(outcome);
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = ((String)Helpers.GetValue(outcomeObj, "outcomeId"));
             Object outcomeInfo = this.safeDict(outcomeObj, "info", new java.util.HashMap<String, Object>() {{}});
@@ -1440,7 +1484,7 @@ final Object finalMarketSymbol = marketSymbol;
             Object outcomeObj = null;
             if (Helpers.isTrue(!Helpers.isEqual(symbol, null)))
             {
-                this.checkEventsAndMarkets(symbol);
+                this.checkEvents(symbol);
                 outcomeObj = this.outcome(symbol);
                 Helpers.addElementToObject(request, "asset_id", Helpers.GetValue(outcomeObj, "outcomeId"));
             }
@@ -1545,7 +1589,6 @@ final Object finalMarketSymbol = marketSymbol;
             put( "info", trade );
             put( "timestamp", finalTimestamp );
             put( "datetime", PolymarketCore.this.iso8601(finalTimestamp) );
-            put( "symbol", symbol );
             put( "outcome", symbol );
             put( "outcomeId", assetId );
             put( "label", PolymarketCore.this.safeString(mkt, "label") );
@@ -1645,11 +1688,11 @@ final Object finalMarketSymbol = marketSymbol;
             {
                 for (var i = 0; Helpers.isLessThan(i, Helpers.getArrayLength(outcomes)); i++)
                 {
-                    this.checkEventsAndMarkets(Helpers.GetValue(outcomes, i));
+                    this.checkEvents(Helpers.GetValue(outcomes, i));
                 }
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             if (Helpers.isTrue(Helpers.isEqual(this.walletAddress, null)))
             {
@@ -1737,7 +1780,7 @@ final Object finalMarketSymbol = marketSymbol;
         final Object finalCurPrice = curPrice;
         return this.safePredictionPosition(new java.util.HashMap<String, Object>() {{
             put( "id", PolymarketCore.this.safeString(position, "id") );
-            put( "symbol", Helpers.GetValue(marketData, "outcome") );
+            put( "outcome", Helpers.GetValue(marketData, "outcome") );
             put( "outcomeId", Helpers.GetValue(marketData, "outcomeId") );
             put( "market", Helpers.GetValue(marketData, "market") );
             put( "label", Helpers.GetValue(marketData, "label") );
@@ -1792,10 +1835,10 @@ final Object finalMarketSymbol = marketSymbol;
             Object outcome = symbol;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object request = new java.util.HashMap<String, Object>() {{}};
             Object outcomeObj = null;
@@ -1832,10 +1875,10 @@ final Object finalMarketSymbol = marketSymbol;
             Object outcome = symbol;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
             } else
             {
-                this.checkEventsAndMarkets();
+                this.checkEvents();
             }
             Object request = new java.util.HashMap<String, Object>() {{
                 put( "id", id );
@@ -1886,7 +1929,7 @@ final Object finalMarketSymbol = marketSymbol;
             put( "datetime", PolymarketCore.this.iso8601(ts) );
             put( "lastTradeTimestamp", null );
             put( "status", status );
-            put( "symbol", Helpers.GetValue(mkt, "outcome") );
+            put( "outcome", Helpers.GetValue(mkt, "outcome") );
             put( "outcomeId", PolymarketCore.this.safeString(mkt, "outcomeId") );
             put( "label", PolymarketCore.this.safeString(mkt, "label") );
             put( "market", PolymarketCore.this.safeString(mkt, "market") );
@@ -2438,7 +2481,7 @@ final Object finalMarketSymbol = marketSymbol;
             if (Helpers.isTrue(!Helpers.isEqual(outcome, null)))
             {
                 // scope to a single outcome token via DELETE /cancel-market-orders { asset_id }
-                this.checkEventsAndMarkets(outcome);
+                this.checkEvents(outcome);
                 Object outcomeObj = this.outcome(outcome);
                 Object request = new java.util.HashMap<String, Object>() {{
                     put( "asset_id", Helpers.GetValue(outcomeObj, "outcomeId") );
@@ -2473,9 +2516,14 @@ final Object finalMarketSymbol = marketSymbol;
      * @see https://docs.polymarket.com/api-reference/search/search-markets-events-and-profiles
      * @see https://docs.polymarket.com/api-reference/events/list-events
      * @param {object} [params] extra exchange-specific parameters
-     * @param {string} [params.query] a single search term; when omitted (and no queries) the most active events are returned (capped)
+     * @param {string} [params.query] a single keyword search term
      * @param {string[]} [params.queries] multiple search terms (alternative to query)
-     * @param {int} [params.limit] when searching, page size per query (default 50); when omitted, max events to fetch (default options.fetchMarketsLimit, 1000), ordered by 24h volume
+     * @param {int} [params.limit] max number of events to return
+     * @param {string} [params.sort] 'volume' (default), 'liquidity' or 'newest' — mapped to the gamma order field
+     * @param {string} [params.status] 'active' (default), 'inactive', 'closed' or 'all' ('inactive' and 'closed' are interchangeable)
+     * @param {string} [params.searchIn] when searching, restrict the match to 'title' (default), 'description' or 'both'
+     * @param {string} [params.eventId] direct lookup by event id (short-circuits the listing/search)
+     * @param {string} [params.slug] direct lookup by event slug
      * @returns {object[]} an array of event structures
      */
     public java.util.concurrent.CompletableFuture<Object> fetchEvents(Object... optionalArgs)
@@ -2484,11 +2532,26 @@ final Object finalMarketSymbol = marketSymbol;
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
+            Object requestedEventId = this.safeString(parameters, "eventId");
+            Object requestedSlug = this.safeString(parameters, "slug");
             Object queries = this.parseSearchQueries(parameters);
-            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("query", "queries")));
+            Object rest = this.omit(parameters, new java.util.ArrayList<Object>(java.util.Arrays.asList("query", "queries", "eventId", "slug")));
             Object queriesLength = Helpers.getArrayLength(queries);
             Object rawEvents = new java.util.ArrayList<Object>(java.util.Arrays.asList());
-            if (Helpers.isTrue(Helpers.isGreaterThan(queriesLength, 0)))
+            if (Helpers.isTrue(Helpers.isTrue((!Helpers.isEqual(requestedEventId, null))) || Helpers.isTrue((!Helpers.isEqual(requestedSlug, null)))))
+            {
+                // direct lookup by event id or slug via the events endpoint (returns a list)
+                Object lookup = new java.util.HashMap<String, Object>() {{}};
+                if (Helpers.isTrue(!Helpers.isEqual(requestedEventId, null)))
+                {
+                    Helpers.addElementToObject(lookup, "id", requestedEventId);
+                } else
+                {
+                    Helpers.addElementToObject(lookup, "slug", requestedSlug);
+                }
+                Object response = (this.gammaPublicGetEvents(lookup)).join();
+                rawEvents = ((Helpers.isTrue((!Helpers.isEqual(response, null))))) ? response : new java.util.ArrayList<Object>(java.util.Arrays.asList());
+            } else if (Helpers.isTrue(Helpers.isGreaterThan(queriesLength, 0)))
             {
                 rawEvents = (this.fetchRawEventsBySearch(queries, rest)).join();
             } else
@@ -2560,19 +2623,32 @@ final Object finalMarketSymbol = marketSymbol;
                 for (var j = 0; Helpers.isLessThan(j, Helpers.getArrayLength(outcomesList)); j++)
                 {
                     Object oc = Helpers.GetValue(outcomesList, j);
-                    Object ocSymbol = this.safeString(oc, "symbol");
+                    Object ocSymbol = this.safeString(oc, "outcome");
                     if (Helpers.isTrue(!Helpers.isEqual(ocSymbol, null)))
                     {
                         Helpers.addElementToObject(this.outcomes, ocSymbol, oc);
                     }
-                    Object ocId = this.safeString(oc, "id");
+                    Object ocId = this.safeString(oc, "outcomeId");
                     if (Helpers.isTrue(!Helpers.isEqual(ocId, null)))
                     {
                         Helpers.addElementToObject(this.outcomes_by_id, ocId, oc);
                     }
                 }
             }
-            return result;
+            // the gamma search endpoint is fuzzy, so refine the search path by status and searchIn
+            // client-side (searchIn defaults to 'title', matching the reference behaviour)
+            Object filtered = result;
+            if (Helpers.isTrue(Helpers.isGreaterThan(queriesLength, 0)))
+            {
+                filtered = this.filterEventsByStatus(filtered, this.safeString(parameters, "status", "active"));
+                filtered = this.filterEventsBySearchIn(filtered, queries, this.safeString(parameters, "searchIn", "title"));
+            }
+            Object finalLimit = this.safeInteger(parameters, "limit");
+            if (Helpers.isTrue(!Helpers.isEqual(finalLimit, null)))
+            {
+                filtered = this.arraySlice(filtered, 0, finalLimit);
+            }
+            return filtered;
         });
 
     }
@@ -3114,7 +3190,7 @@ final Object finalSymbol = symbol;
             put( "asks", asks );
             put( "timestamp", timestamp );
             put( "datetime", PolymarketCore.this.iso8601(timestamp) );
-            put( "symbol", finalSymbol );
+            put( "outcome", finalSymbol );
         }}});
         client.resolve(orderbook, Helpers.add("orderbook::", symbol));
         client.resolve(orderbook, Helpers.add("ticker::", symbol));
@@ -3174,7 +3250,7 @@ final Object finalSymbol = symbol;
             put( "info", eventVar );
             put( "timestamp", timestamp );
             put( "datetime", PolymarketCore.this.iso8601(timestamp) );
-            put( "symbol", finalSymbol );
+            put( "outcome", finalSymbol );
             put( "outcomeId", PolymarketCore.this.safeString(market, "outcomeId") );
             put( "label", PolymarketCore.this.safeString(market, "label") );
             put( "market", PolymarketCore.this.safeString(market, "market") );
@@ -3219,7 +3295,6 @@ final Object finalSymbol = symbol;
             Object limit = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = this.safeString(outcomeObj, "outcomeId");
             symbol = this.safeString(outcomeObj, "outcome");
@@ -3255,7 +3330,6 @@ final Object finalSymbol = symbol;
             Object limit = Helpers.getArg(optionalArgs, 1, null);
             Object parameters = Helpers.getArg(optionalArgs, 2, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = this.safeString(outcomeObj, "outcomeId");
             symbol = this.safeString(outcomeObj, "outcome");
@@ -3287,7 +3361,6 @@ final Object finalSymbol = symbol;
             Object symbol = symbol3;
             Object parameters = Helpers.getArg(optionalArgs, 0, new java.util.HashMap<String, Object>() {{}});
             Object outcome = symbol;
-            (this.loadMarkets()).join();
             Object outcomeObj = this.outcome(outcome);
             Object tokenId = this.safeString(outcomeObj, "outcomeId");
             symbol = this.safeString(outcomeObj, "outcome");
@@ -3349,7 +3422,7 @@ final Object finalSymbol = symbol;
             final Object finalBestAskVolume = bestAskVolume;
             final Object finalMid = mid;
             return this.safePredictionTicker(new java.util.HashMap<String, Object>() {{
-                put( "symbol", finalSymbol );
+                put( "outcome", finalSymbol );
                 put( "outcomeId", PolymarketCore.this.safeString(market, "outcomeId") );
                 put( "label", PolymarketCore.this.safeString(market, "label") );
                 put( "market", PolymarketCore.this.safeString(market, "market") );
@@ -3397,7 +3470,6 @@ final Object finalSymbol = symbol;
             Object since = Helpers.getArg(optionalArgs, 1, null);
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             (this.loadApiCredentials()).join();
             Object messageHash = "orders";
             if (Helpers.isTrue(!Helpers.isEqual(symbol, null)))
@@ -3436,7 +3508,6 @@ final Object finalSymbol = symbol;
             Object since = Helpers.getArg(optionalArgs, 1, null);
             Object limit = Helpers.getArg(optionalArgs, 2, null);
             Object parameters = Helpers.getArg(optionalArgs, 3, new java.util.HashMap<String, Object>() {{}});
-            (this.loadMarkets()).join();
             (this.loadApiCredentials()).join();
             Object messageHash = "myTrades";
             if (Helpers.isTrue(!Helpers.isEqual(symbol, null)))

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
@@ -874,9 +874,8 @@ final Object finalMarketSymbol = marketSymbol;
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object outcomes = symbols;
             Object outcomesLength = 0;
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {
@@ -1673,9 +1672,8 @@ final Object finalMarketSymbol = marketSymbol;
 
         return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
 
-            Object symbols = Helpers.getArg(optionalArgs, 0, null);
+            Object outcomes = Helpers.getArg(optionalArgs, 0, null);
             Object parameters = Helpers.getArg(optionalArgs, 1, new java.util.HashMap<String, Object>() {{}});
-            Object outcomes = symbols;
             Object outcomesLength = 0;
             if (Helpers.isTrue(!Helpers.isEqual(outcomes, null)))
             {

--- a/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
+++ b/java/lib/src/main/java/io/github/ccxt/exchanges/prediction/PolymarketCore.java
@@ -1107,10 +1107,7 @@ final Object finalMarketSymbol = marketSymbol;
             //
             Object timestamp = this.safeInteger(response, "timestamp");
             Object orderbook = this.parseOrderBook(response, this.safeOutcomeSymbol(outcome, outcomeObj), timestamp, "bids", "asks", "price", "size");
-            Helpers.addElementToObject(orderbook, "outcome", this.safeString(outcomeObj, "outcome"));
-            Helpers.addElementToObject(orderbook, "outcomeId", this.safeString(outcomeObj, "outcomeId"));
-            Helpers.addElementToObject(orderbook, "market", this.safeString(outcomeObj, "market"));
-            return orderbook;
+            return this.safePredictionOrderBook(orderbook, outcomeObj);
         });
 
     }

--- a/java/lib/src/main/java/io/github/ccxt/types/PredictionOpenInterest.java
+++ b/java/lib/src/main/java/io/github/ccxt/types/PredictionOpenInterest.java
@@ -1,0 +1,39 @@
+package io.github.ccxt.types;
+
+import java.util.Map;
+
+// Native dedicated prediction-market type. The base OpenInterest is final, so this
+// duplicates its fields (flat typed access) and adds the prediction identity
+// fields. The inherited `symbol` is left unpopulated — `outcome` (the
+// "MARKET:LABEL" handle) is the canonical identity. Mirrors the
+// `PredictionOpenInterest extends OpenInterest` interface in ts/src/base/types.ts.
+public final class PredictionOpenInterest {
+    public String symbol;
+    public Double openInterestAmount;
+    public Double openInterestValue;
+    public Double baseVolume;
+    public Double quoteVolume;
+    public Long timestamp;
+    public String datetime;
+    // prediction-specific
+    public String outcome;
+    public String outcomeId;
+    public String market;
+    public Map<String, Object> info;
+
+    @SuppressWarnings("unchecked")
+    public PredictionOpenInterest(Object raw) {
+        Map<String, Object> data = TypeHelper.toMap(raw);
+        this.symbol = TypeHelper.safeString(data, "symbol");
+        this.openInterestAmount = TypeHelper.safeFloat(data, "openInterestAmount");
+        this.openInterestValue = TypeHelper.safeFloat(data, "openInterestValue");
+        this.baseVolume = TypeHelper.safeFloat(data, "baseVolume");
+        this.quoteVolume = TypeHelper.safeFloat(data, "quoteVolume");
+        this.timestamp = TypeHelper.safeInteger(data, "timestamp");
+        this.datetime = TypeHelper.safeString(data, "datetime");
+        this.outcome = TypeHelper.safeString(data, "outcome");
+        this.outcomeId = TypeHelper.safeString(data, "outcomeId");
+        this.market = TypeHelper.safeString(data, "market");
+        this.info = TypeHelper.getInfo(data);
+    }
+}

--- a/java/lib/src/main/java/io/github/ccxt/types/PredictionOrderBook.java
+++ b/java/lib/src/main/java/io/github/ccxt/types/PredictionOrderBook.java
@@ -1,0 +1,61 @@
+package io.github.ccxt.types;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+// Native dedicated prediction-market type. The base OrderBook is final, so this
+// duplicates its fields (flat typed access) and adds the prediction identity
+// fields. The inherited `symbol` is left unpopulated — `outcome` (the
+// "MARKET:LABEL" handle) is the canonical identity. Mirrors the
+// `PredictionOrderBook extends OrderBook` interface in ts/src/base/types.ts.
+public final class PredictionOrderBook {
+    public List<List<Double>> bids;
+    public List<List<Double>> asks;
+    public String symbol;
+    public Long timestamp;
+    public String datetime;
+    public Long nonce;
+    // prediction-specific
+    public String outcome;
+    public String outcomeId;
+    public String market;
+    public Map<String, Object> info;
+
+    @SuppressWarnings("unchecked")
+    public PredictionOrderBook(Object raw) {
+        Map<String, Object> data = TypeHelper.toMap(raw);
+        this.bids = parseEntries(data.get("bids"));
+        this.asks = parseEntries(data.get("asks"));
+        this.symbol = TypeHelper.safeString(data, "symbol");
+        this.timestamp = TypeHelper.safeInteger(data, "timestamp");
+        this.datetime = TypeHelper.safeString(data, "datetime");
+        this.nonce = TypeHelper.safeInteger(data, "nonce");
+        this.outcome = TypeHelper.safeString(data, "outcome");
+        this.outcomeId = TypeHelper.safeString(data, "outcomeId");
+        this.market = TypeHelper.safeString(data, "market");
+        this.info = TypeHelper.getInfo(data);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<List<Double>> parseEntries(Object raw) {
+        if (raw == null) return new ArrayList<>();
+        List<Object> entries = (List<Object>) raw;
+        List<List<Double>> result = new ArrayList<>(entries.size());
+        for (Object entry : entries) {
+            List<Object> pair = (List<Object>) entry;
+            List<Double> parsed = new ArrayList<>(pair.size());
+            for (Object val : pair) {
+                if (val instanceof Number n) {
+                    parsed.add(n.doubleValue());
+                } else if (val != null) {
+                    try { parsed.add(Double.parseDouble(String.valueOf(val))); } catch (Exception e) { parsed.add(null); }
+                } else {
+                    parsed.add(null);
+                }
+            }
+            result.add(parsed);
+        }
+        return result;
+    }
+}

--- a/java/lib/src/main/java/io/github/ccxt/types/PredictionTradingFee.java
+++ b/java/lib/src/main/java/io/github/ccxt/types/PredictionTradingFee.java
@@ -1,0 +1,35 @@
+package io.github.ccxt.types;
+
+import java.util.Map;
+
+// Native dedicated prediction-market type. The base TradingFeeInterface is final,
+// so this duplicates its fields (flat typed access) and adds the prediction
+// identity fields. The inherited `symbol` is left unpopulated — `outcome` (the
+// "MARKET:LABEL" handle) is the canonical identity. Mirrors the
+// `PredictionTradingFee extends TradingFeeInterface` interface in ts/src/base/types.ts.
+public final class PredictionTradingFee {
+    public String symbol;
+    public Double maker;
+    public Double taker;
+    public Boolean percentage;
+    public Boolean tierBased;
+    // prediction-specific
+    public String outcome;
+    public String outcomeId;
+    public String market;
+    public Map<String, Object> info;
+
+    @SuppressWarnings("unchecked")
+    public PredictionTradingFee(Object raw) {
+        Map<String, Object> data = TypeHelper.toMap(raw);
+        this.symbol = TypeHelper.safeString(data, "symbol");
+        this.maker = TypeHelper.safeFloat(data, "maker");
+        this.taker = TypeHelper.safeFloat(data, "taker");
+        this.percentage = TypeHelper.safeBool(data, "percentage");
+        this.tierBased = TypeHelper.safeBool(data, "tierBased");
+        this.outcome = TypeHelper.safeString(data, "outcome");
+        this.outcomeId = TypeHelper.safeString(data, "outcomeId");
+        this.market = TypeHelper.safeString(data, "market");
+        this.info = TypeHelper.getInfo(data);
+    }
+}

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3552,7 +3552,9 @@ class Exchange {
             $result = [ ];
             for ($i = 0; $i < count($parsedArray); $i++) {
                 $entry = $parsedArray[$i];
-                $entryFiledEqualValue = $entry[$field] === $value;
+                // safeValue (not $entry[$field]) so a missing $field is a non-match, not a
+                // KeyError in python/php — prediction structures $key on outcome, not symbol
+                $entryFiledEqualValue = $this->safe_value($entry, $field) === $value;
                 $firstCondition = $valueIsDefined ? $entryFiledEqualValue : true;
                 $entryKeyValue = $this->safe_value($entry, $key);
                 $entryKeyGESince = ($entryKeyValue) && ($since !== null) && ($entryKeyValue >= $since);
@@ -5680,18 +5682,22 @@ class Exchange {
         ));
     }
 
-    public function filter_by_symbol($objects, ?string $symbol = null) {
-        if ($symbol === null) {
+    public function filter_by_key($objects, int|string $key, ?string $value = null) {
+        if ($value === null) {
             return $objects;
         }
         $result = array();
         for ($i = 0; $i < count($objects); $i++) {
-            $objectSymbol = $this->safe_string($objects[$i], 'symbol');
-            if ($objectSymbol === $symbol) {
+            $objectValue = $this->safe_string($objects[$i], $key);
+            if ($objectValue === $value) {
                 $result[] = $objects[$i];
             }
         }
         return $result;
+    }
+
+    public function filter_by_symbol($objects, ?string $symbol = null) {
+        return $this->filter_by_key($objects, 'symbol', $symbol);
     }
 
     public function parse_ohlcv($ohlcv, ?array $market = null): array {

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -1174,7 +1174,9 @@ class Exchange extends \ccxt\Exchange {
             $result = [ ];
             for ($i = 0; $i < count($parsedArray); $i++) {
                 $entry = $parsedArray[$i];
-                $entryFiledEqualValue = $entry[$field] === $value;
+                // safeValue (not $entry[$field]) so a missing $field is a non-match, not a
+                // KeyError in python/php — prediction structures $key on outcome, not symbol
+                $entryFiledEqualValue = $this->safe_value($entry, $field) === $value;
                 $firstCondition = $valueIsDefined ? $entryFiledEqualValue : true;
                 $entryKeyValue = $this->safe_value($entry, $key);
                 $entryKeyGESince = ($entryKeyValue) && ($since !== null) && ($entryKeyValue >= $since);
@@ -3318,18 +3320,22 @@ class Exchange extends \ccxt\Exchange {
         }) ();
     }
 
-    public function filter_by_symbol($objects, ?string $symbol = null) {
-        if ($symbol === null) {
+    public function filter_by_key($objects, int|string $key, ?string $value = null) {
+        if ($value === null) {
             return $objects;
         }
         $result = array();
         for ($i = 0; $i < count($objects); $i++) {
-            $objectSymbol = $this->safe_string($objects[$i], 'symbol');
-            if ($objectSymbol === $symbol) {
+            $objectValue = $this->safe_string($objects[$i], $key);
+            if ($objectValue === $value) {
                 $result[] = $objects[$i];
             }
         }
         return $result;
+    }
+
+    public function filter_by_symbol($objects, ?string $symbol = null) {
+        return $this->filter_by_key($objects, 'symbol', $symbol);
     }
 
     public function parse_ohlcv($ohlcv, ?array $market = null): array {

--- a/php/prediction/PredictionExchange.php
+++ b/php/prediction/PredictionExchange.php
@@ -30,17 +30,7 @@ class PredictionExchange extends \ccxt\async\Exchange {
         return $this->safe_bool($this->has, 'prediction', false);
     }
 
-    public function load_markets_and_events($reload = false, $params = array ()) {
-        return Async\async(function () use ($reload, $params) {
-            $res = Async\await(Promise\all(array( $this->load_markets($reload, $params), $this->load_events($reload, $params) )));
-            return array(
-                'markets' => $res[0],
-                'events' => $res[1],
-            );
-        }) ();
-    }
-
-    public function check_events_and_markets(?string $outcome = null) {
+    public function check_events(?string $outcome = null) {
         // pure synchronous guard (no I/O) — callers invoke it without await, so leaving it
         // async would make the coroutine never run in Python/PHP and silently skip validation.
         // outcomes are the real dependency for resolving a symbol; they are populated by
@@ -69,7 +59,99 @@ class PredictionExchange extends \ccxt\async\Exchange {
         return $this->safe_list($params, 'queries', array());
     }
 
-    public function fetch_events($params = array ()) {
+    public function apply_event_fetch_params(array $events, $params = array (), ?array $queries = null) {
+        // applies the unified fetchEvents options client-side (eventId/slug/status/searchIn/sort/limit)
+        // so exchanges whose API can't filter natively still support them consistently
+        $result = $events;
+        $eventId = $this->safe_string($params, 'eventId');
+        $slug = $this->safe_string($params, 'slug');
+        if (($eventId !== null) || ($slug !== null)) {
+            $filtered = array();
+            for ($i = 0; $i < count($result); $i++) {
+                $event = $result[$i];
+                $idMatch = ($eventId !== null) && ($this->safe_string($event, 'id') === $eventId);
+                $slugMatch = ($slug !== null) && ($this->safe_string($event, 'slug') === $slug);
+                if ($idMatch || $slugMatch) {
+                    $filtered[] = $event;
+                }
+            }
+            $result = $filtered;
+        }
+        $result = $this->filter_events_by_status($result, $this->safe_string($params, 'status'));
+        if (($queries !== null) && (strlen($queries) > 0)) {
+            $result = $this->filter_events_by_search_in($result, $queries, $this->safe_string($params, 'searchIn'));
+        }
+        $sort = $this->safe_string($params, 'sort');
+        if ($sort !== null) {
+            $sortKey = null;
+            if ($sort === 'volume') {
+                $sortKey = 'volume';
+            } elseif ($sort === 'liquidity') {
+                $sortKey = 'liquidity';
+            } elseif ($sort === 'newest') {
+                $sortKey = 'created';
+            }
+            if ($sortKey !== null) {
+                $result = $this->sort_by($result, $sortKey, true, 0);
+            }
+        }
+        $limit = $this->safe_integer($params, 'limit');
+        if ($limit !== null) {
+            $result = $this->array_slice($result, 0, $limit);
+        }
+        return $result;
+    }
+
+    public function filter_events_by_status(array $events, ?string $status = null) {
+        // 'active' | 'inactive' | 'closed' | 'all' — 'inactive' and 'closed' are interchangeable
+        if (($status === null) || ($status === 'all')) {
+            return $events;
+        }
+        $wantActive = ($status === 'active');
+        $result = array();
+        for ($i = 0; $i < count($events); $i++) {
+            $event = $events[$i];
+            $isActive = $this->safe_bool($event, 'active');
+            // keep $events whose $status is unknown (already filtered server-side, no `active` field)
+            if (($isActive === null) || ($isActive === $wantActive)) {
+                $result[] = $event;
+            }
+        }
+        return $result;
+    }
+
+    public function filter_events_by_search_in(array $events, array $queries, ?string $searchIn = null) {
+        // keep $events whose $title and/or $description contains one of the $queries ($searchIn defaults to 'both')
+        if (($searchIn === null) || ($queries === null) || (strlen($queries) === 0)) {
+            return $events;
+        }
+        $checkTitle = ($searchIn === 'title') || ($searchIn === 'both');
+        $checkDescription = ($searchIn === 'description') || ($searchIn === 'both');
+        $result = array();
+        for ($i = 0; $i < count($events); $i++) {
+            $event = $events[$i];
+            $title = $this->safe_string_lower($event, 'title', '');
+            $description = $this->safe_string_lower($event, 'description', '');
+            $matched = false;
+            for ($qi = 0; $qi < count($queries); $qi++) {
+                $q = strtolower($queries[$qi]);
+                if ($checkTitle && (mb_strpos($title, $q) !== false)) {
+                    $matched = true;
+                    break;
+                }
+                if ($checkDescription && (mb_strpos($description, $q) !== false)) {
+                    $matched = true;
+                    break;
+                }
+            }
+            if ($matched) {
+                $result[] = $event;
+            }
+        }
+        return $result;
+    }
+
+    public function fetch_events(array $params = array ()) {
         throw new NotSupported($this->id . ' fetchEvents() is not supported yet');
     }
 
@@ -333,6 +415,18 @@ class PredictionExchange extends \ccxt\async\Exchange {
         return $this->to_prediction_structure($parsed, $position);
     }
 
+    public function safe_prediction_order_book(array $orderbook, ?array $outcomeObj = null) {
+        // normalize a parsed order book to the prediction shape => replace the unified
+        // `symbol` with the `outcome` handle and attach the outcome identity fields
+        // (outcomeId / market) so books match the PredictionOrderBook structure.
+        $fallback = $this->safe_string_2($orderbook, 'outcome', 'symbol');
+        $orderbook['outcome'] = ($outcomeObj === null) ? $fallback : $this->safe_string($outcomeObj, 'outcome', $fallback);
+        $orderbook['outcomeId'] = ($outcomeObj === null) ? $this->safe_string($orderbook, 'outcomeId') : $this->safe_string($outcomeObj, 'outcomeId');
+        $orderbook['market'] = ($outcomeObj === null) ? $this->safe_string($orderbook, 'market') : $this->safe_string($outcomeObj, 'market');
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return $this->omit($orderbook, 'symbol');
+    }
+
     public function to_prediction_structure(array $parsed, array $raw) {
         // rename the unified `symbol` to the prediction `outcome` handle and attach the
         // prediction identity fields ($raw exchange id, label, parent market/event) that the
@@ -343,8 +437,8 @@ class PredictionExchange extends \ccxt\async\Exchange {
         $parsed['label'] = $this->safe_string($raw, 'label');
         $parsed['market'] = $this->safe_string($raw, 'market');
         $parsed['event'] = $this->safe_string($raw, 'event');
-        unset($parsed['symbol']);
-        return $parsed;
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return $this->omit($parsed, 'symbol');
     }
 
     public function filter_by_outcome_since_limit($array, ?string $outcome = null, ?int $since = null, ?int $limit = null, $tail = false) {

--- a/php/prediction/hyperliquid.php
+++ b/php/prediction/hyperliquid.php
@@ -500,16 +500,19 @@ class hyperliquid extends Exchange {
         $quoteCurrency = $this->safe_string($this->options, 'outcomeQuoteCurrency', 'USDH');
         $szDecimals = 4;  // $outcomes use 4 decimal places
         $active = true;
+        $outcomePrecision = array(
+            'amount' => (string) $this->parse_number($this->parse_precision($szDecimals)),
+            'price' => 0.0001,
+        );
         $outcomes = array(
             array(
                 'id' => $this->outcome_coin($yesEncoding),
                 'outcomeId' => $this->outcome_coin($yesEncoding),
-                'symbol' => $yesOutcomeSymbol,
                 'outcome' => $yesOutcomeSymbol,
-                'marketSymbol' => $parentSymbol,
                 'market' => $parentSymbol,
                 'label' => $yesLabel,
                 'active' => $active,
+                'precision' => $outcomePrecision,
                 'info' => array(
                     'encoding' => $yesEncoding,
                     'assetId' => $this->outcome_asset_id($yesEncoding),
@@ -525,12 +528,11 @@ class hyperliquid extends Exchange {
             array(
                 'id' => $this->outcome_coin($noEncoding),
                 'outcomeId' => $this->outcome_coin($noEncoding),
-                'symbol' => $noOutcomeSymbol,
                 'outcome' => $noOutcomeSymbol,
-                'marketSymbol' => $parentSymbol,
                 'market' => $parentSymbol,
                 'label' => $noLabel,
                 'active' => $active,
+                'precision' => $outcomePrecision,
                 'info' => array(
                     'encoding' => $noEncoding,
                     'assetId' => $this->outcome_asset_id($noEncoding),
@@ -576,10 +578,7 @@ class hyperliquid extends Exchange {
             'percentage' => true,
             'tierBased' => false,
             'feeSide' => 'get',
-            'precision' => array(
-                'amount' => (string) $this->parse_number($this->parse_precision($szDecimals)),
-                'price' => 0.0001,
-            ),
+            'precision' => $outcomePrecision,
             'limits' => array(
                 'leverage' => array( 'min' => null, 'max' => null ),
                 'amount' => array( 'min' => null, 'max' => null ),
@@ -634,8 +633,7 @@ class hyperliquid extends Exchange {
              * @return {array} a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $info = $this->safe_dict($outcomeObj, 'info', array());
             $coin = $this->safe_string($info, 'coinName');
@@ -672,15 +670,14 @@ class hyperliquid extends Exchange {
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure)
              */
             $outcomes = $symbols;
-            Async\await($this->load_markets());
             $requestedOutcomeSymbols = array();
             if ($outcomes !== null) {
                 for ($i = 0; $i < count($outcomes); $i++) {
                     $requested = $outcomes[$i];
-                    $this->checkEventsAndMarkets ($requested);
+                    $this->checkEvents ($requested);
                     $requestedOutcomeObj = $this->outcome ($requested);
-                    $requestedSymbol = $this->safe_string($requestedOutcomeObj, 'symbol', $requested);
-                    $requestedOutcomeSymbols[$requestedSymbol] = true;
+                    $requestedOutcome = $this->safe_string($requestedOutcomeObj, 'outcome', $requested);
+                    $requestedOutcomeSymbols[$requestedOutcome] = true;
                 }
             }
             $response = Async\await($this->publicPostInfo ($this->extend(array( 'type' => 'allMids' ), $params)));
@@ -690,13 +687,13 @@ class hyperliquid extends Exchange {
             $mids = $this->safe_dict($response, 'mids', $response);
             $tickers = array();
             $outcomesMap = ($this->outcomes !== null) ? $this->outcomes : array();
-            $outcomeSymbols = is_array($outcomesMap) ? array_keys($outcomesMap) : array();
-            for ($i = 0; $i < count($outcomeSymbols); $i++) {
-                $outcomeSymbol = $outcomeSymbols[$i];
-                if ($outcomes !== null && !(is_array($requestedOutcomeSymbols) && array_key_exists($outcomeSymbol, $requestedOutcomeSymbols))) {
+            $outcomeHandles = is_array($outcomesMap) ? array_keys($outcomesMap) : array();
+            for ($i = 0; $i < count($outcomeHandles); $i++) {
+                $outcomeHandle = $outcomeHandles[$i];
+                if ($outcomes !== null && !(is_array($requestedOutcomeSymbols) && array_key_exists($outcomeHandle, $requestedOutcomeSymbols))) {
                     continue;
                 }
-                $outcomeObj = $this->safe_dict($outcomesMap, $outcomeSymbol, array());
+                $outcomeObj = $this->safe_dict($outcomesMap, $outcomeHandle, array());
                 $info = $this->safe_dict($outcomeObj, 'info', array());
                 $coin = $this->safe_string($info, 'coinName');
                 $mid = $this->safe_number($mids, $coin);
@@ -705,7 +702,7 @@ class hyperliquid extends Exchange {
                 }
                 // Build minimal $ticker from $mid price
                 $ticker = $this->parse_ticker(array( 'levels' => array( array(), array() ), 'mid' => $mid, 'time' => $this->milliseconds() ), $outcomeObj);
-                $tickers[$outcomeSymbol] = $ticker;
+                $tickers[$outcomeHandle] = $ticker;
             }
             return $tickers;
         }) ();
@@ -749,7 +746,7 @@ class hyperliquid extends Exchange {
             $mid = $this->sum($bid, $ask) / 2;
         }
         // day volume lives on the parent market's $ctx; resolve it from the outcome's marketSymbol
-        $parentSymbol = $this->safe_string($mkt, 'marketSymbol');
+        $parentSymbol = $this->safe_string($mkt, 'outcome');
         $parentMarket = ($parentSymbol !== null) ? $this->safe_market($parentSymbol) : null;
         $ctx = ($parentMarket !== null) ? $this->safe_dict($this->safe_dict($parentMarket, 'info', array()), 'ctx', array()) : array();
         $dayVolume = $this->safe_number($ctx, 'dayNtlVlm');
@@ -757,7 +754,7 @@ class hyperliquid extends Exchange {
             'symbol' => $symbol,
             'outcomeId' => $this->safe_string($mkt, 'id'),
             'label' => $this->safe_string($mkt, 'label'),
-            'market' => $this->safe_string($mkt, 'marketSymbol'),
+            'market' => $this->safe_string($mkt, 'outcome'),
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
             'high' => null,
@@ -793,8 +790,7 @@ class hyperliquid extends Exchange {
              * @return {array} an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $info = $this->safe_dict($outcomeObj, 'info', array());
             $request = array(
@@ -826,7 +822,8 @@ class hyperliquid extends Exchange {
                 $entry = $rawAsks[$i];
                 $asks[] = array( $this->safe_number($entry, 'px'), $this->safe_number($entry, 'sz') );
             }
-            return $this->parse_order_book(array( 'bids' => $bids, 'asks' => $asks ), $this->safe_string($outcomeObj, 'symbol', $outcome), $timestamp);
+            $orderbook = $this->parse_order_book(array( 'bids' => $bids, 'asks' => $asks ), $this->safe_string($outcomeObj, 'symbol', $outcome), $timestamp);
+            return $this->safePredictionOrderBook ($orderbook, $outcomeObj);
         }) ();
     }
 
@@ -846,10 +843,9 @@ class hyperliquid extends Exchange {
              * @return {int[][]} a list of candles ordered, open, high, low, close, volume
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
-            $market = $this->market($this->safe_string($outcomeObj, 'marketSymbol'));
+            $market = $this->market($this->safe_string($outcomeObj, 'outcome'));
             $info = $this->safe_dict($outcomeObj, 'info', array());
             $until = $this->safe_integer($params, 'until', $this->milliseconds());
             $startTime = $since;
@@ -979,15 +975,14 @@ class hyperliquid extends Exchange {
              * @return {array[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
              */
             $outcomes = $symbols;
-            Async\await($this->load_markets());
             $requestedOutcomeSymbols = array();
             if ($outcomes !== null) {
                 for ($i = 0; $i < count($outcomes); $i++) {
                     $requested = $outcomes[$i];
-                    $this->checkEventsAndMarkets ($requested);
+                    $this->checkEvents ($requested);
                     $requestedOutcomeObj = $this->outcome ($requested);
-                    $requestedSymbol = $this->safe_string($requestedOutcomeObj, 'symbol', $requested);
-                    $requestedOutcomeSymbols[$requestedSymbol] = true;
+                    $requestedOutcome = $this->safe_string($requestedOutcomeObj, 'outcome', $requested);
+                    $requestedOutcomeSymbols[$requestedOutcome] = true;
                 }
             }
             list($userAddress, $params) = $this->handle_public_address('fetchPositions', $params);
@@ -1013,8 +1008,8 @@ class hyperliquid extends Exchange {
                 $outcomeId = '#' . mb_substr($coin, 1); // +10 -> #10
                 $outcomeObj = $this->safeOutcome ($outcomeId);
                 if ($outcomes !== null) {
-                    $outcomeSymbol = $this->safe_string($outcomeObj, 'symbol');
-                    if ($outcomeSymbol === null || !(is_array($requestedOutcomeSymbols) && array_key_exists($outcomeSymbol, $requestedOutcomeSymbols))) {
+                    $outcomeHandle = $this->safe_string($outcomeObj, 'outcome');
+                    if ($outcomeHandle === null || !(is_array($requestedOutcomeSymbols) && array_key_exists($outcomeHandle, $requestedOutcomeSymbols))) {
                         continue;
                     }
                 }
@@ -1048,7 +1043,7 @@ class hyperliquid extends Exchange {
             'symbol' => $this->safe_string($outcomeObj, 'symbol'),
             'outcomeId' => $this->safe_string($outcomeObj, 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+            'market' => $this->safe_string($outcomeObj, 'outcome'),
             'timestamp' => null,
             'datetime' => null,
             'isolated' => false,
@@ -1192,11 +1187,10 @@ class hyperliquid extends Exchange {
              * @return {array} an [order structure](https://docs.ccxt.com/#/?id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             Async\await($this->initialize_client());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
-            $market = $this->market($this->safe_string($outcomeObj, 'marketSymbol'));
+            $market = $this->market($this->safe_string($outcomeObj, 'outcome'));
             $outcomeInfo = $this->safe_dict($outcomeObj, 'info', array());
             $nonce = $this->milliseconds();
             $isBuy = (strtoupper($side) === 'BUY');
@@ -1221,11 +1215,11 @@ class hyperliquid extends Exchange {
             if ($isMarket) {
                 $priceStr = $this->number_to_string($price);
                 $px = $isBuy ? Precise::string_mul($priceStr, Precise::string_add('1', $slippage)) : Precise::string_mul($priceStr, Precise::string_sub('1', $slippage));
-                $px = $this->price_to_precision($this->safe_string($outcomeObj, 'marketSymbol'), $px);
+                $px = $this->price_to_precision($this->safe_string($outcomeObj, 'outcome'), $px);
             } else {
-                $px = $this->price_to_precision($this->safe_string($outcomeObj, 'marketSymbol'), $price);
+                $px = $this->price_to_precision($this->safe_string($outcomeObj, 'outcome'), $price);
             }
-            $sz = $this->amount_to_precision($this->safe_string($outcomeObj, 'marketSymbol'), $amount);
+            $sz = $this->amount_to_precision($this->safe_string($outcomeObj, 'outcome'), $amount);
             $orderType = array(
                 'limit' => array( 'tif' => $tif ),
             );
@@ -1286,10 +1280,10 @@ class hyperliquid extends Exchange {
                 'timestamp' => $nonce,
                 'datetime' => $this->iso8601($nonce),
                 'status' => $orderStatus,
-                'symbol' => $this->safe_string($outcomeObj, 'symbol', $outcome),
+                'outcome' => $this->safe_string($outcomeObj, 'outcome', $outcome),
                 'outcomeId' => $this->safe_string($outcomeObj, 'id'),
                 'label' => $this->safe_string($outcomeObj, 'label'),
-                'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+                'market' => $this->safe_string($outcomeObj, 'outcome'),
                 'type' => $type,
                 'side' => $side,
                 'price' => $price,
@@ -1340,9 +1334,8 @@ class hyperliquid extends Exchange {
             if ($outcome === null) {
                 throw new ArgumentsRequired($this->id . ' cancelOrders() requires an $outcome argument');
             }
-            Async\await($this->load_markets());
             Async\await($this->initialize_client());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $outcomeInfo = $this->safe_dict($outcomeObj, 'info', array());
             $assetId = $this->safe_integer($outcomeInfo, 'assetId');
@@ -1380,7 +1373,7 @@ class hyperliquid extends Exchange {
             $innerResponse = $this->safe_dict($response, 'response');
             $data = $this->safe_dict($innerResponse, 'data');
             $statuses = $this->safe_list($data, 'statuses', array());
-            $outcomeSymbol = $this->safe_string($outcomeObj, 'symbol', $outcome);
+            $outcomeSymbol = $this->safe_string($outcomeObj, 'outcome', $outcome);
             $requestIds = $ids;
             if ($clientOrderId !== null) {
                 if ((gettype($clientOrderId) === 'array' && array_keys($clientOrderId) === array_keys(array_keys($clientOrderId)))) {
@@ -1406,11 +1399,10 @@ class hyperliquid extends Exchange {
                     'clientOrderId' => ($clientOrderId !== null) ? $requestId : null,
                     'info' => $status,
                     'status' => 'canceled',
-                    'symbol' => $outcomeSymbol,
                     'outcome' => $outcomeSymbol,
                     'outcomeId' => $this->safe_string($outcomeObj, 'id'),
                     'label' => $this->safe_string($outcomeObj, 'label'),
-                    'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+                    'market' => $this->safe_string($outcomeObj, 'outcome'),
                     'timestamp' => $this->milliseconds(),
                     'datetime' => $this->iso8601($this->milliseconds()),
                 );
@@ -1436,7 +1428,6 @@ class hyperliquid extends Exchange {
              * @return {array[]} a list of [$order structures](https://docs.ccxt.com/#/?id=$order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             list($userAddress, $params) = $this->handle_public_address('fetchOpenOrders', $params);
             list($method, $params) = $this->handle_option_and_params($params, 'fetchOpenOrders', 'method', 'frontendOpenOrders');
             $request = array( 'type' => $method, 'user' => $userAddress );
@@ -1449,9 +1440,9 @@ class hyperliquid extends Exchange {
             $parsed = $this->parse_orders($ordersWithStatus, null, $since, null);
             $outcomeHandle = null;
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
                 $outcomeObj = $this->outcome ($outcome);
-                $outcomeHandle = $this->safe_string($outcomeObj, 'symbol');
+                $outcomeHandle = $this->safe_string($outcomeObj, 'outcome');
             }
             return $this->filterByOutcomeSinceLimit ($parsed, $outcomeHandle, $since, $limit);
         }) ();
@@ -1472,7 +1463,6 @@ class hyperliquid extends Exchange {
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             list($userAddress, $params) = $this->handle_public_address('fetchOrders', $params);
             $request = array( 'type' => 'historicalOrders', 'user' => $userAddress );
             $response = Async\await($this->publicPostInfo ($this->extend($request, $params)));
@@ -1501,9 +1491,9 @@ class hyperliquid extends Exchange {
             $parsed = $this->parse_orders($dedupedValues, null, $since, null);
             $outcomeHandle = null;
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
                 $outcomeObj = $this->outcome ($outcome);
-                $outcomeHandle = $this->safe_string($outcomeObj, 'symbol');
+                $outcomeHandle = $this->safe_string($outcomeObj, 'outcome');
             }
             return $this->filterByOutcomeSinceLimit ($parsed, $outcomeHandle, $since, $limit);
         }) ();
@@ -1524,7 +1514,6 @@ class hyperliquid extends Exchange {
              * @return {array} an [order structure](https://docs.ccxt.com/#/?$id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             list($userAddress, $params) = $this->handle_public_address('fetchOrder', $params);
             $clientOrderId = $this->safe_string($params, 'clientOrderId');
             $request = array( 'type' => 'orderStatus', 'user' => $userAddress );
@@ -1539,9 +1528,9 @@ class hyperliquid extends Exchange {
             $orderWrapper = $this->safe_dict($response, 'order', $response);
             $parsed = $this->parse_order($orderWrapper, null);
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
                 $outcomeObj = $this->outcome ($outcome);
-                $expected = $this->safe_string($outcomeObj, 'symbol');
+                $expected = $this->safe_string($outcomeObj, 'outcome');
                 if ($this->safe_string($parsed, 'outcome') !== $expected) {
                     throw new OrderNotFound($this->id . ' fetchOrder() order ' . $id . ' is not in $outcome ' . $expected);
                 }
@@ -1581,7 +1570,7 @@ class hyperliquid extends Exchange {
         $status = $this->parse_order_status($this->safe_string_2($order, 'ccxtStatus', 'status'));
         $coin = $this->safe_string($entry, 'coin');
         $outcomeObj = $this->safeOutcome ($coin, $market);
-        $marketSymbol = $this->safe_string($outcomeObj, 'marketSymbol');
+        $marketSymbol = $this->safe_string($outcomeObj, 'outcome');
         $resolvedMarket = $marketSymbol ? $this->safe_market($marketSymbol, $market) : $market;
         $sideRaw = $this->safe_string($entry, 'side');
         $side = ($sideRaw === 'B') ? 'buy' : 'sell';
@@ -1603,10 +1592,10 @@ class hyperliquid extends Exchange {
             'datetime' => $this->iso8601($timestamp),
             'lastTradeTimestamp' => null,
             'status' => $status,
-            'symbol' => $this->safe_string($outcomeObj, 'symbol'),
+            'outcome' => $this->safe_string($outcomeObj, 'outcome'),
             'outcomeId' => $this->safe_string($outcomeObj, 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+            'market' => $this->safe_string($outcomeObj, 'outcome'),
             'type' => $this->parse_order_type($this->safe_string($entry, 'orderType', 'limit')),
             'timeInForce' => $tif,
             'postOnly' => $postOnly,
@@ -1681,7 +1670,6 @@ class hyperliquid extends Exchange {
              * @return {array[]} a list of [trade structures](https://docs.ccxt.com/#/?id=trade-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             list($userAddress, $params) = $this->handle_public_address('fetchMyTrades', $params);
             $request = array( 'user' => $userAddress );
             if ($since !== null) {
@@ -1699,9 +1687,9 @@ class hyperliquid extends Exchange {
             $parsed = $this->parse_trades($response, null, $since, null);
             $outcomeHandle = null;
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
                 $outcomeObj = $this->outcome ($outcome);
-                $outcomeHandle = $this->safe_string($outcomeObj, 'symbol');
+                $outcomeHandle = $this->safe_string($outcomeObj, 'outcome');
             }
             return $this->filterByOutcomeSinceLimit ($parsed, $outcomeHandle, $since, $limit);
         }) ();
@@ -1739,13 +1727,13 @@ class hyperliquid extends Exchange {
         $amount = $this->safe_string($trade, 'sz');
         $coin = $this->safe_string($trade, 'coin');
         $outcomeObj = $this->safeOutcome ($coin, $market);
-        $marketSymbol = $this->safe_string($outcomeObj, 'marketSymbol');
+        $marketSymbol = $this->safe_string($outcomeObj, 'outcome');
         $resolvedMarket = $marketSymbol ? $this->safe_market($marketSymbol, $market) : $market;
         $rawSide = $this->safe_string($trade, 'side');
         $side = ($rawSide === 'B') ? 'buy' : 'sell';
         $fee = $this->safe_number($trade, 'fee');
         $feeCurrency = $this->safe_string($trade, 'feeToken', 'USDC');
-        $outcomeSymbol = $this->safe_string($outcomeObj, 'symbol');
+        $outcomeSymbol = $this->safe_string($outcomeObj, 'outcome');
         $feeObject = null;
         if ($fee !== null) {
             $feeObject = array( 'cost' => $fee, 'currency' => $feeCurrency );
@@ -1759,11 +1747,10 @@ class hyperliquid extends Exchange {
             'info' => $trade,
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $outcomeSymbol,
             'outcome' => $outcomeSymbol,
             'outcomeId' => $this->safe_string($outcomeObj, 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+            'market' => $this->safe_string($outcomeObj, 'outcome'),
             'order' => $this->safe_string($trade, 'oid'),
             'type' => 'limit',
             'side' => $side,
@@ -1775,71 +1762,68 @@ class hyperliquid extends Exchange {
         ), $resolvedMarket);
     }
 
-    public function fetch_events($params = array ()): PromiseInterface {
-        return Async\async(function () use ($params) {
-            /**
-             * Groups outcome markets by their underlying (e.g. BTC-ABOVE-78213) into $event structures. Each $event contains both the YES and NO markets.
-             * @param {array} [$params] extra parameters
-             * @param {string} [$params->query] a single query string to filter by ($matches description/symbol)
-             * @param {string[]} [$params->queries] multiple query strings (alternative to query)
-             * @return {PredictionEvent[]} array of $event structures
-             */
-            $queries = $this->parseSearchQueries ($params);
-            Async\await($this->load_markets());
-            $marketValues = is_array($this->markets) ? array_values($this->markets) : array();
-            // Group markets by $parentSymbol
-            $groupMap = array();
-            $lowerQueries = array();
-            for ($i = 0; $i < count($queries); $i++) {
-                $queryString = $queries[$i];
-                $lowerQueries[] = strtolower($queryString);
+    public function fetch_events(array $params = array ()): PromiseInterface {
+        /**
+         * Groups outcome markets by their underlying (e.g. BTC-ABOVE-78213) into $event structures. Each $event contains both the YES and NO markets.
+         * @param {array} [$params] extra parameters
+         * @param {string} [$params->query] a single query string to filter by ($matches description/symbol)
+         * @param {string[]} [$params->queries] multiple query strings (alternative to query)
+         * @return {PredictionEvent[]} array of $event structures
+         */
+        $queries = $this->parseSearchQueries ($params);
+        $marketValues = is_array($this->markets) ? array_values($this->markets) : array();
+        // Group markets by $parentSymbol
+        $groupMap = array();
+        $lowerQueries = array();
+        for ($i = 0; $i < count($queries); $i++) {
+            $queryString = $queries[$i];
+            $lowerQueries[] = strtolower($queryString);
+        }
+        $lowerQueriesLength = count($lowerQueries);
+        for ($i = 0; $i < count($marketValues); $i++) {
+            $mkt = $marketValues[$i];
+            if (!$this->safe_bool($mkt, 'prediction', false)) {
+                continue;
             }
-            $lowerQueriesLength = count($lowerQueries);
-            for ($i = 0; $i < count($marketValues); $i++) {
-                $mkt = $marketValues[$i];
-                if (!$this->safe_bool($mkt, 'prediction', false)) {
+            $info = $this->safe_dict($mkt, 'info', array());
+            $parentSymbol = $this->safe_string($info, 'parentSymbol', $this->safe_string($mkt, 'symbol'));
+            // Apply query filter
+            if ($lowerQueriesLength > 0) {
+                $description = strtolower($this->safe_string($info, 'description', ''));
+                $parentSymbolOrEmpty = ($parentSymbol !== null) ? $parentSymbol : '';
+                $symLower = strtolower($parentSymbolOrEmpty);
+                $matches = false;
+                for ($qi = 0; $qi < count($lowerQueries); $qi++) {
+                    if (mb_strpos($description, $lowerQueries[$qi]) > -1 || mb_strpos($symLower, $lowerQueries[$qi]) > -1) {
+                        $matches = true;
+                        break;
+                    }
+                }
+                if (!$matches) {
                     continue;
                 }
-                $info = $this->safe_dict($mkt, 'info', array());
-                $parentSymbol = $this->safe_string($info, 'parentSymbol', $this->safe_string($mkt, 'symbol'));
-                // Apply query filter
-                if ($lowerQueriesLength > 0) {
-                    $description = strtolower($this->safe_string($info, 'description', ''));
-                    $parentSymbolOrEmpty = ($parentSymbol !== null) ? $parentSymbol : '';
-                    $symLower = strtolower($parentSymbolOrEmpty);
-                    $matches = false;
-                    for ($qi = 0; $qi < count($lowerQueries); $qi++) {
-                        if (mb_strpos($description, $lowerQueries[$qi]) > -1 || mb_strpos($symLower, $lowerQueries[$qi]) > -1) {
-                            $matches = true;
-                            break;
-                        }
-                    }
-                    if (!$matches) {
-                        continue;
-                    }
-                }
-                if (!(is_array($groupMap) && array_key_exists($parentSymbol, $groupMap))) {
-                    $groupMap[$parentSymbol] = array();
-                }
-                ($groupMap[$parentSymbol])[] = $mkt;
             }
-            $events = array();
-            $groupKeys = is_array($groupMap) ? array_keys($groupMap) : array();
-            for ($gi = 0; $gi < count($groupKeys); $gi++) {
-                $key = $groupKeys[$gi];
-                $groupMarkets = $groupMap[$key];
-                $event = $this->parse_event(array( 'parentSymbol' => $key, 'markets' => $groupMarkets ));
-                $events[] = $event;
+            if (!(is_array($groupMap) && array_key_exists($parentSymbol, $groupMap))) {
+                $groupMap[$parentSymbol] = array();
             }
-            if (!$this->events) {
-                $this->events = array();
-            }
-            for ($i = 0; $i < count($events); $i++) {
-                $ev = $events[$i];
-                $this->events[$ev['symbol']] = $ev;
-            }
-            return $events;
-        }) ();
+            ($groupMap[$parentSymbol])[] = $mkt;
+        }
+        $events = array();
+        $groupKeys = is_array($groupMap) ? array_keys($groupMap) : array();
+        for ($gi = 0; $gi < count($groupKeys); $gi++) {
+            $key = $groupKeys[$gi];
+            $groupMarkets = $groupMap[$key];
+            $event = $this->parse_event(array( 'parentSymbol' => $key, 'markets' => $groupMarkets ));
+            $events[] = $event;
+        }
+        if (!$this->events) {
+            $this->events = array();
+        }
+        for ($i = 0; $i < count($events); $i++) {
+            $ev = $events[$i];
+            $this->events[$ev['symbol']] = $ev;
+        }
+        return $this->applyEventFetchParams ($events, $params, $queries);
     }
 
     public function parse_event(array $raw): mixed {

--- a/php/prediction/hyperliquid.php
+++ b/php/prediction/hyperliquid.php
@@ -658,18 +658,17 @@ class hyperliquid extends Exchange {
         }) ();
     }
 
-    public function fetch_tickers(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_tickers(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
              * fetches all outcome market $tickers using allMids then optionally enriches with l2Book
              *
              * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#retrieve-all-$mids-for-all-actively-traded-coins
              *
-             * @param {string[]} [$symbols] filter by outcome ids or $symbols
+             * @param {string[]} [symbols] filter by outcome ids or symbols
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure)
              */
-            $outcomes = $symbols;
             $requestedOutcomeSymbols = array();
             if ($outcomes !== null) {
                 for ($i = 0; $i < count($outcomes); $i++) {
@@ -965,16 +964,15 @@ class hyperliquid extends Exchange {
         }) ();
     }
 
-    public function fetch_positions(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_positions(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
              * fetches outcome token $positions from spot clearinghouse state, outcome tokens appear token $balances starting with '+'
-             * @param {string[]} [$symbols] filter by outcome ids or $symbols
+             * @param {string[]} [symbols] filter by outcome ids or symbols
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @param {string} [$params->user] wallet address
              * @return {array[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
              */
-            $outcomes = $symbols;
             $requestedOutcomeSymbols = array();
             if ($outcomes !== null) {
                 for ($i = 0; $i < count($outcomes); $i++) {

--- a/php/prediction/kalshi.php
+++ b/php/prediction/kalshi.php
@@ -359,9 +359,7 @@ class kalshi extends Exchange {
             $outcomes[] = array(
                 'id' => $outcomeIds[$oi],
                 'outcomeId' => $outcomeIds[$oi],
-                'symbol' => $outcomeHandle,
                 'outcome' => $outcomeHandle,
-                'marketSymbol' => $marketSymbol,
                 'market' => $marketSymbol,
                 'label' => $label,
                 'active' => $active,
@@ -443,8 +441,7 @@ class kalshi extends Exchange {
              * @return {array} a [$ticker structure](https://docs.ccxt.com/#/?id=$ticker-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $ticker = $this->safe_string($outcomeObj['info'], 'ticker');
             $request = array(
@@ -548,8 +545,7 @@ class kalshi extends Exchange {
              * @return {array} an [open interest structure](https://docs.ccxt.com/#/?id=open-interest-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $ticker = $this->safe_string($outcomeObj['info'], 'ticker');
             $request = array( 'ticker' => $ticker );
@@ -559,12 +555,12 @@ class kalshi extends Exchange {
         }) ();
     }
 
-    public function parse_open_interest($interest, ?array $market = null): OpenInterest {
+    public function parse_open_interest($interest, ?array $market = null): PredictionOpenInterest {
         //
         //     array( "ticker" => "...", "open_interest_fp" => "60802.01", ... )   // open $interest in contracts
         //
         $timestamp = $this->milliseconds();
-        return $this->safe_open_interest(array(
+        $openInterest = $this->safe_open_interest(array(
             'symbol' => $this->safe_symbol(null, $market),
             'openInterestAmount' => $this->safe_number_2($interest, 'open_interest_fp', 'open_interest'),
             'openInterestValue' => null,
@@ -574,6 +570,10 @@ class kalshi extends Exchange {
             'datetime' => $this->iso8601($timestamp),
             'info' => $interest,
         ), $market);
+        $openInterest['outcome'] = $this->safeOutcomeSymbol (null, $market);
+        $openInterest['outcomeId'] = $this->safe_string($market, 'outcomeId');
+        unset($openInterest['symbol']);
+        return $openInterest;
     }
 
     public function parse_ticker(array $raw, ?array $market = null): array {
@@ -640,11 +640,11 @@ class kalshi extends Exchange {
         //     }
         //
         $marketAny = $market;
-        $outcomeObj = $this->safeOutcome ($this->safe_string($marketAny, 'symbol'), $marketAny);
+        $outcomeObj = $this->safeOutcome ($this->safe_string($marketAny, 'outcome'), $marketAny);
         $outcomeLabel = $market ? $this->safe_string($market, 'label', $this->safe_string($market['info'], 'outcomeLabel', 'YES')) : 'YES';
         $isNo = strtoupper($outcomeLabel) === 'NO';
         $now = $this->milliseconds();
-        $symbol = $this->safe_string($outcomeObj, 'symbol');
+        $symbol = $this->safe_string($outcomeObj, 'outcome');
         $yesAsk = $this->safe_number($raw, 'yes_ask_dollars');
         $yesBid = $this->safe_number($raw, 'yes_bid_dollars');
         $noAsk = $this->safe_number($raw, 'no_ask_dollars');
@@ -667,10 +667,10 @@ class kalshi extends Exchange {
             $average = $this->parse_number(Precise::string_div(Precise::string_add($this->number_to_string($bid), $this->number_to_string($ask)), '2'));
         }
         return $this->safePredictionTicker (array(
-            'symbol' => $symbol,
+            'outcome' => $symbol,
             'outcomeId' => $this->safe_string_2($outcomeObj, 'outcomeId', 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string_2($outcomeObj, 'market', 'marketSymbol'),
+            'market' => $this->safe_string_2($outcomeObj, 'market', 'outcome'),
             'timestamp' => $now,
             'datetime' => $this->iso8601($now),
             'high' => null,
@@ -704,15 +704,14 @@ class kalshi extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure) indexed by outcome symbol
              */
-            Async\await($this->load_markets());
             $targets = array();
             if ($symbols !== null) {
                 for ($i = 0; $i < count($symbols); $i++) {
-                    $this->checkEventsAndMarkets ($symbols[$i]);
+                    $this->checkEvents ($symbols[$i]);
                     $targets[] = $symbols[$i];
                 }
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
                 $allKeys = is_array($this->outcomes) ? array_keys($this->outcomes) : array();
                 for ($i = 0; $i < count($allKeys); $i++) {
                     $targets[] = $allKeys[$i];
@@ -789,8 +788,7 @@ class kalshi extends Exchange {
              * @return {array} an [order $book structure](https://docs.ccxt.com/#/?id=order-$book-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $ticker = $this->safe_string($outcomeObj['info'], 'ticker');
             $isNo = $outcomeObj['label'] === 'NO';
@@ -841,7 +839,7 @@ class kalshi extends Exchange {
                     $asks[] = [ $price, $this->safe_number($rawNo[$ai], 1) ];
                 }
             }
-            return $this->sorted_orders($this->safe_string($outcomeObj, 'symbol', $outcome), $timestamp, $bids, $asks);
+            return $this->safePredictionOrderBook ($this->sorted_orders($this->safe_string($outcomeObj, 'outcome', $outcome), $timestamp, $bids, $asks), $outcomeObj);
         }) ();
     }
 
@@ -859,7 +857,7 @@ class kalshi extends Exchange {
         $bids = $this->sort_by($bids, 0, true);
         $asks = $this->sort_by($asks, 0);
         return array(
-            'symbol' => $symbol,
+            'outcome' => $symbol,
             'bids' => $bids,
             'asks' => $asks,
             'timestamp' => $timestamp,
@@ -883,8 +881,7 @@ class kalshi extends Exchange {
              * @return {int[][]} a list of $candles ordered, open, high, low, close, volume
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $ticker = $this->safe_string($outcomeObj['info'], 'ticker');
             $seriesTicker = $this->safe_string($outcomeObj['info'], 'seriesTicker', $ticker);
@@ -1025,8 +1022,7 @@ class kalshi extends Exchange {
              * @return {array[]} a list of [$trade structures](https://docs.ccxt.com/#/?id=public-$trades)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $ticker = $this->safe_string($outcomeObj['info'], 'ticker');
             $request = array( 'ticker' => $ticker );
@@ -1069,10 +1065,10 @@ class kalshi extends Exchange {
         $amount = $this->safe_number($trade, 'count', $amountFp);
         $rawSide = $this->safe_string_lower($trade, 'taker_side');
         $marketAny = $market;
-        $outcomeObj = $this->safeOutcome ($this->safe_string($marketAny, 'symbol'), $marketAny);
+        $outcomeObj = $this->safeOutcome ($this->safe_string($marketAny, 'outcome'), $marketAny);
         $marketInfo = $this->safe_dict($outcomeObj, 'info', array());
         $requestedOutcomeLabel = $this->safe_string_lower($outcomeObj, 'label', $this->safe_string_lower($marketInfo, 'outcomeLabel'));
-        $outcomeSymbol = $this->safe_string($outcomeObj, 'symbol');
+        $outcomeSymbol = $this->safe_string($outcomeObj, 'outcome');
         $outcomeId = $this->safe_string_2($outcomeObj, 'outcomeId', 'id');
         if ($rawSide === 'yes' || $rawSide === 'no') {
             if ($requestedOutcomeLabel === 'yes' || $requestedOutcomeLabel === 'no') {
@@ -1090,11 +1086,10 @@ class kalshi extends Exchange {
             'info' => $trade,
             'timestamp' => $ts,
             'datetime' => $this->iso8601($ts),
-            'symbol' => $outcomeSymbol,
             'outcome' => $outcomeSymbol,
             'outcomeId' => $outcomeId,
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string_2($outcomeObj, 'market', 'marketSymbol'),
+            'market' => $this->safe_string_2($outcomeObj, 'market', 'outcome'),
             'order' => null,
             'type' => null,
             'side' => $side,
@@ -1116,7 +1111,7 @@ class kalshi extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a [balance structure](https://docs.ccxt.com/#/?id=balance-structure)
              */
-            $this->checkEventsAndMarkets ();
+            $this->checkEvents ();
             $response = Async\await($this->kalshiPrivateGetPortfolioBalance ($params));
             return $this->parse_balance($response);
         }) ();
@@ -1158,10 +1153,10 @@ class kalshi extends Exchange {
             }
             if ($outcomesLength > 0) {
                 for ($i = 0; $i < count($outcomes); $i++) {
-                    $this->checkEventsAndMarkets ($outcomes[$i]);
+                    $this->checkEvents ($outcomes[$i]);
                 }
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $response = Async\await($this->kalshiPrivateGetPortfolioPositions ($params));
             $positions = $this->safe_list($response, 'market_positions', array());
@@ -1187,10 +1182,10 @@ class kalshi extends Exchange {
         }
         return $this->safePredictionPosition (array(
             'id' => null,
-            'symbol' => $this->safe_string($outcomeObj, 'symbol', $ticker),
+            'outcome' => $this->safe_string($outcomeObj, 'outcome', $ticker),
             'outcomeId' => $this->safe_string_2($outcomeObj, 'outcomeId', 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string_2($outcomeObj, 'market', 'marketSymbol'),
+            'market' => $this->safe_string_2($outcomeObj, 'market', 'outcome'),
             'timestamp' => null,
             'datetime' => null,
             'contracts' => $contractsValue,
@@ -1232,9 +1227,9 @@ class kalshi extends Exchange {
              */
             $outcome = $symbol;
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $request = array( 'status' => 'resting' );
             $outcomeObj = null;
@@ -1261,9 +1256,9 @@ class kalshi extends Exchange {
              * @return {array} an [order structure](https://docs.ccxt.com/#/?$id=order-structure)
              */
             if ($symbol !== null) {
-                $this->checkEventsAndMarkets ($symbol);
+                $this->checkEvents ($symbol);
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $response = Async\await($this->kalshiPrivateGetPortfolioOrdersOrderId ($this->extend(array( 'order_id' => $id ), $params)));
             return $this->parse_order($this->safe_value($response, 'order', $response));
@@ -1304,10 +1299,10 @@ class kalshi extends Exchange {
             'datetime' => $this->iso8601($ts),
             'lastTradeTimestamp' => null,
             'status' => $status,
-            'symbol' => $this->safe_string($mkt, 'symbol'),
+            'outcome' => $this->safe_string($mkt, 'outcome'),
             'outcomeId' => $this->safe_string_2($mkt, 'outcomeId', 'id'),
             'label' => $this->safe_string($mkt, 'label'),
-            'market' => $this->safe_string_2($mkt, 'market', 'marketSymbol'),
+            'market' => $this->safe_string_2($mkt, 'market', 'outcome'),
             'type' => $this->safe_string_lower($order, 'type', 'limit'),
             'timeInForce' => 'GTC',
             'postOnly' => null,
@@ -1357,8 +1352,7 @@ class kalshi extends Exchange {
              * @return {array} an [order structure](https://docs.ccxt.com/#/?id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $ticker = $this->safe_string($outcomeObj['info'], 'ticker');
             $outcomeLabel = $outcomeObj['label'];
@@ -1395,9 +1389,9 @@ class kalshi extends Exchange {
              * @return {array} an [order structure](https://docs.ccxt.com/#/?$id=order-structure)
              */
             if ($symbol !== null) {
-                $this->checkEventsAndMarkets ($symbol);
+                $this->checkEvents ($symbol);
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $response = Async\await($this->kalshiPrivateDeletePortfolioOrdersOrderId ($this->extend(array( 'order_id' => $id ), $params)));
             return $this->parse_order($this->safe_value($response, 'order', $response));
@@ -1417,13 +1411,12 @@ class kalshi extends Exchange {
              */
             $outcome = $symbol;
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $request = array();
             if ($outcome !== null) {
-                Async\await($this->load_markets());
                 $outcomeObj = $this->outcome ($outcome);
                 $request['ticker'] = $this->safe_string($outcomeObj['info'], 'ticker');
             }
@@ -1432,7 +1425,7 @@ class kalshi extends Exchange {
         }) ();
     }
 
-    public function fetch_events($params = array ()): PromiseInterface {
+    public function fetch_events(array $params = array ()): PromiseInterface {
         return Async\async(function () use ($params) {
             /**
              * fetches kalshi events via $cursor-paginated /events, filters client-side by query strings, then fetches full event details with nested markets in parallel and caches in $this->events
@@ -1449,10 +1442,15 @@ class kalshi extends Exchange {
              */
             $queries = $this->parseSearchQueries ($params);
             $params = $this->omit($params, array( 'query', 'queries' ));
-            $status = $this->safe_string($params, 'status', $this->safe_string($this->options, 'defaultEventStatus', 'open'));
+            // map the unified $status onto the kalshi event $status (open / closed) so it is pushed server-side
+            $requestedStatus = $this->safe_string($params, 'status', $this->safe_string($this->options, 'defaultEventStatus', 'active'));
+            $status = 'open';
+            if (($requestedStatus === 'closed') || ($requestedStatus === 'inactive')) {
+                $status = 'closed';
+            }
             $pageLimit = $this->safe_integer($params, 'limit', 200);
             $maxPages = $this->safe_integer($params, 'maxPages', 50);
-            $rest = $this->omit($params, array( 'status', 'limit', 'maxPages' ));
+            $rest = $this->omit($params, array( 'status', 'limit', 'maxPages', 'sort', 'searchIn', 'eventId', 'slug' ));
             if (!$this->events) {
                 $this->events = array();
             }
@@ -1554,17 +1552,17 @@ class kalshi extends Exchange {
                 $outcomesList = $this->safe_list($market, 'outcomes', array());
                 for ($j = 0; $j < count($outcomesList); $j++) {
                     $oc = $outcomesList[$j];
-                    $ocSymbol = $this->safe_string($oc, 'symbol');
+                    $ocSymbol = $this->safe_string($oc, 'outcome');
                     if ($ocSymbol !== null) {
                         $this->outcomes[$ocSymbol] = $oc;
                     }
-                    $ocId = $this->safe_string($oc, 'id');
+                    $ocId = $this->safe_string($oc, 'outcomeId');
                     if ($ocId !== null) {
                         $this->outcomes_by_id[$ocId] = $oc;
                     }
                 }
             }
-            return $result;
+            return $this->applyEventFetchParams ($result, $params, $queries);
         }) ();
     }
 
@@ -1664,22 +1662,38 @@ class kalshi extends Exchange {
         // }
         $rawMarkets = $this->safe_list($rawEvent, 'markets', array());
         $marketsList = array();
+        // aggregate volume/liquidity from the markets and derive the creation time so sort works
+        $totalVolume = 0;
+        $totalLiquidity = 0;
+        $earliestCreated = null;
         for ($i = 0; $i < count($rawMarkets); $i++) {
             $rawMarket = $rawMarkets[$i];
             $parsed = $this->parse_market($rawMarket);
             $marketsList[] = $parsed;
+            $totalVolume = $this->sum($totalVolume, $this->safe_number_2($rawMarket, 'volume_fp', 'volume', 0));
+            $totalLiquidity = $this->sum($totalLiquidity, $this->safe_number_2($rawMarket, 'liquidity_dollars', 'liquidity', 0));
+            $marketCreated = $this->parse8601($this->safe_string($rawMarket, 'open_time'));
+            if (($marketCreated !== null) && (($earliestCreated === null) || ($marketCreated < $earliestCreated))) {
+                $earliestCreated = $marketCreated;
+            }
         }
         $ticker = $this->safe_string($rawEvent, 'event_ticker');
         $title = $this->safe_string($rawEvent, 'title');
+        $created = $this->parse8601($this->safe_string($rawEvent, 'created_date_iso'));
+        if ($created === null) {
+            $created = $earliestCreated;
+        }
         return $this->extend(array(
             'id' => $ticker,
             'slug' => $ticker,
             'symbol' => $title ? $this->shortenSlug ($title) : null,
             'title' => $title,
             'markets' => $marketsList,
+            'volume' => $totalVolume,
+            'liquidity' => $totalLiquidity,
             'url' => $this->safe_string($rawEvent, 'url'),
             'image' => $this->safe_string($rawEvent, 'image_url'),
-            'created' => $this->parse8601($this->safe_string($rawEvent, 'created_date_iso')),
+            'created' => $created,
             'createdDatetime' => $this->safe_string($rawEvent, 'created_date_iso'),
             'end' => $this->parse8601($this->safe_string($rawEvent, 'end_date_iso')),
             'endDatetime' => $this->safe_string($rawEvent, 'end_date_iso'),

--- a/php/prediction/kalshi.php
+++ b/php/prediction/kalshi.php
@@ -693,17 +693,18 @@ class kalshi extends Exchange {
         ), $market);
     }
 
-    public function fetch_tickers(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_tickers(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
-             * fetches $tickers for multiple outcomes at once, batching their market $tickers through the markets endpoint
+             * fetches $tickers for multiple $outcomes at once, batching their market $tickers through the markets endpoint
              *
              * @see https://docs.kalshi.com/api-reference/market/get-markets
              *
-             * @param {string[]} [$symbols] unified outcome $symbols, fetches $tickers for all loaded outcomes when omitted
+             * @param {string[]} [$symbols] unified outcome $symbols, fetches $tickers for all loaded $outcomes when omitted
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure) indexed by outcome symbol
              */
+            $symbols = $outcomes;
             $targets = array();
             if ($symbols !== null) {
                 for ($i = 0; $i < count($symbols); $i++) {
@@ -717,7 +718,7 @@ class kalshi extends Exchange {
                     $targets[] = $allKeys[$i];
                 }
             }
-            // group requested outcomes by their market $ticker, yes and no outcomes share one market
+            // group requested $outcomes by their market $ticker, yes and no $outcomes share one market
             $outcomesByTicker = array();
             $tickers = array();
             for ($i = 0; $i < count($targets); $i++) {
@@ -1135,18 +1136,17 @@ class kalshi extends Exchange {
         return $result;
     }
 
-    public function fetch_positions(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_positions(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
              * fetches open market $positions for the authenticated kalshi user
              *
              * @see https://trading-api.readme.io/reference/getportfoliopositions
              *
-             * @param {string[]} [$symbols] filter by outcome ids or $symbols
+             * @param {string[]} [symbols] filter by outcome ids or symbols
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
              */
-            $outcomes = $symbols;
             $outcomesLength = 0;
             if ($outcomes !== null) {
                 $outcomesLength = count($outcomes);

--- a/php/prediction/limitless.php
+++ b/php/prediction/limitless.php
@@ -1018,10 +1018,10 @@ class limitless extends Exchange {
         ));
     }
 
-    public function fetch_tickers(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_tickers(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
-             * fetches tickers for multiple outcome tokens, grouping requested outcomes by their parent market, fetches all active markets when $symbols is omitted
+             * fetches tickers for multiple outcome tokens, grouping requested $outcomes by their parent market, fetches all active markets when $symbols is omitted
              *
              * @see https://docs.limitless.exchange/api-reference/markets/get-market
              * @see https://docs.limitless.exchange/api-reference/trading/orderbook
@@ -1030,6 +1030,7 @@ class limitless extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure) indexed by outcome symbol
              */
+            $symbols = $outcomes;
             $result = array();
             if ($symbols === null) {
                 // parse tickers for every loaded outcome from the cached listing data, without the per-market order books
@@ -1048,7 +1049,7 @@ class limitless extends Exchange {
                 }
                 return $result;
             }
-            // group target outcomes by their parent market to fetch each market and $book only once
+            // group target $outcomes by their parent market to fetch each market and $book only once
             $outcomesBySlug = array();
             $slugs = array();
             for ($i = 0; $i < count($symbols); $i++) {
@@ -2440,8 +2441,8 @@ class limitless extends Exchange {
         return null;
     }
 
-    public function fetch_positions(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_positions(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
              * fetches open positions for the authenticated limitless user from the portfolio endpoint
              *
@@ -2451,6 +2452,7 @@ class limitless extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [$position structures](https://docs.ccxt.com/#/?id=$position-structure)
              */
+            $symbols = $outcomes;
             $symbolsLength = 0;
             if ($symbols !== null) {
                 $symbolsLength = count($symbols);

--- a/php/prediction/limitless.php
+++ b/php/prediction/limitless.php
@@ -716,6 +716,8 @@ class limitless extends Exchange {
         $title = $this->safe_string($event, 'title', $groupId);
         $markets = array();
         $rawMarkets = $this->safe_list($event, 'markets', array());
+        // aggregate 24h volume across the $markets so sort by volume works
+        $totalVolume = 0;
         for ($i = 0; $i < count($rawMarkets); $i++) {
             $rawMarket = $rawMarkets[$i];
             $marketSymbol = $this->safe_string($rawMarket, 'symbol');
@@ -725,6 +727,8 @@ class limitless extends Exchange {
             } else {
                 $markets[] = $this->parse_market($rawMarket);
             }
+            $marketInfo = $this->safe_dict($rawMarket, 'info', $rawMarket);
+            $totalVolume = $this->sum($totalVolume, $this->safe_number_2($marketInfo, 'volume24h', 'volume', 0));
         }
         return $this->extend(array(
             'id' => $groupId,
@@ -733,6 +737,8 @@ class limitless extends Exchange {
             'title' => $title,
             'description' => $this->safe_string($event, 'description'),
             'markets' => $markets,
+            'volume' => $totalVolume,
+            'liquidity' => $this->safe_number($event, 'liquidity'),
             'url' => $this->safe_string($event, 'url'),
             'image' => $this->safe_string($event, 'imageUrl', $this->safe_string($event, 'image')),
             'active' => $this->safe_bool($event, 'active', true),
@@ -762,8 +768,7 @@ class limitless extends Exchange {
              * @return {array} a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $slug = $this->safe_string($outcomeObj['info'], 'slug');
             $request = array(
@@ -987,7 +992,7 @@ class limitless extends Exchange {
         $now = $this->milliseconds();
         $outcomeSymbol = $this->safeOutcomeSymbol (null, $market);
         return $this->safePredictionTicker (array(
-            'symbol' => $outcomeSymbol,
+            'outcome' => $outcomeSymbol,
             'outcomeId' => $this->safe_string($market, 'outcomeId'),
             'label' => $this->safe_string($market, 'label'),
             'market' => $this->safe_string($market, 'market'),
@@ -1025,7 +1030,6 @@ class limitless extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure) indexed by outcome symbol
              */
-            Async\await($this->load_markets());
             $result = array();
             if ($symbols === null) {
                 // parse tickers for every loaded outcome from the cached listing data, without the per-market order books
@@ -1048,7 +1052,7 @@ class limitless extends Exchange {
             $outcomesBySlug = array();
             $slugs = array();
             for ($i = 0; $i < count($symbols); $i++) {
-                $this->checkEventsAndMarkets ($symbols[$i]);
+                $this->checkEvents ($symbols[$i]);
                 $outcomeObj = $this->outcome ($symbols[$i]);
                 $slug = $this->safe_string($outcomeObj['info'], 'slug');
                 if (!(is_array($outcomesBySlug) && array_key_exists($slug, $outcomesBySlug))) {
@@ -1099,8 +1103,7 @@ class limitless extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [trade structures](https://docs.ccxt.com/#/?id=public-trades)
              */
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($symbol);
+            $this->checkEvents ($symbol);
             $outcomeObj = $this->outcome ($symbol);
             $slug = $this->safe_string($outcomeObj['info'], 'slug');
             $tokenId = $this->safe_string($outcomeObj, 'outcomeId');
@@ -1162,8 +1165,7 @@ class limitless extends Exchange {
              * @return {array} an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $slug = $this->safe_string($outcomeObj['info'], 'slug');
             $request = array(
@@ -1225,14 +1227,15 @@ class limitless extends Exchange {
                 }
                 $asks[] = array( $this->parse_number($priceStr), $this->parse_number($sizeStr) );
             }
-            return array(
-                'symbol' => $this->safeOutcomeSymbol ($outcome, $outcomeObj),
+            $orderbook = array(
+                'outcome' => $this->safeOutcomeSymbol ($outcome, $outcomeObj),
                 'bids' => $this->sort_by($bids, 0, true),
                 'asks' => $this->sort_by($asks, 0),
                 'timestamp' => $timestamp,
                 'datetime' => $this->iso8601($timestamp),
                 'nonce' => null,
             );
+            return $this->safePredictionOrderBook ($orderbook, $outcomeObj);
         }) ();
     }
 
@@ -1250,8 +1253,7 @@ class limitless extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {int[][]} a list of candles ordered, open, high, low, close, volume
              */
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($symbol);
+            $this->checkEvents ($symbol);
             $outcomeObj = $this->outcome ($symbol);
             $slug = $this->safe_string($outcomeObj['info'], 'slug');
             $outcomeLabel = $this->safe_string_upper($outcomeObj['info'], 'outcomeLabel');
@@ -1378,8 +1380,7 @@ class limitless extends Exchange {
             if ($outcome === null) {
                 throw new ArgumentsRequired($this->id . ' fetchOrders requires an $outcome argument');
             }
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $info = $this->safe_dict($outcomeObj, 'info');
             $request = array(
@@ -1433,8 +1434,7 @@ class limitless extends Exchange {
             if ($outcome === null) {
                 throw new ArgumentsRequired($this->id . ' fetchOpenOrders requires an $outcome argument');
             }
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $params = $this->extend($params, array(
                 'statuses' => array( 'LIVE' ),
             ));
@@ -1459,8 +1459,7 @@ class limitless extends Exchange {
             if ($outcome === null) {
                 throw new ArgumentsRequired($this->id . ' fetchClosedOrders requires an $outcome argument');
             }
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $params = $this->extend($params, array(
                 'statuses' => array( 'MATCHED' ),
             ));
@@ -1481,8 +1480,7 @@ class limitless extends Exchange {
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?$id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $length = count($ids);
             if ($length > 50) {
                 throw new BadRequest($this->id . ' fetchOrdersByIds can only fetch up to 50 orders at a time');
@@ -1621,8 +1619,7 @@ class limitless extends Exchange {
              * @return {array} an [$order structure](https://docs.ccxt.com/#/?$id=$order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $orders = Async\await($this->fetch_orders_by_ids(array( $id ), $outcome, $params));
             $order = $this->safe_dict($orders, 0);
             if ($order === null) {
@@ -1804,7 +1801,6 @@ class limitless extends Exchange {
             'datetime' => $datetime,
             'lastTradeTimestamp' => null,
             'status' => $this->parse_order_status($rawStatus),
-            'symbol' => $outcomeSymbol,
             'outcome' => $outcomeSymbol,
             'outcomeId' => $this->safe_string($mkt, 'outcomeId'),
             'label' => $this->safe_string($mkt, 'label'),
@@ -1904,7 +1900,6 @@ class limitless extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [account structures]
              */
-            Async\await($this->load_markets());
             $response = Async\await($this->limitlessPrivateGetProfilesMe ($params));
             $responseList = array( $response );
             return $this->parse_accounts($responseList);
@@ -1927,9 +1922,8 @@ class limitless extends Exchange {
              * @return {array} an [order structure](https://docs.ccxt.com/#/?id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             $accounts = Async\await($this->load_accounts());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $account = $this->safe_dict($accounts, 0);
             $accountInfo = $this->safe_dict($account, 'info');
@@ -2127,8 +2121,7 @@ class limitless extends Exchange {
              * @return {array} an [order structure](https://docs.ccxt.com/#/?$id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $request = array(
                 'order_id' => $id,
             );
@@ -2150,8 +2143,7 @@ class limitless extends Exchange {
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $request = array(
                 'orderIds' => $ids,
             );
@@ -2181,8 +2173,7 @@ class limitless extends Exchange {
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             if ($outcome !== null) {
                 $warn = true;
                 list($warn, $params) = $this->handle_option_and_params($params, 'cancelAllOrders', 'warnOnCancelAllOrdersWithOutcome', $warn);
@@ -2222,8 +2213,7 @@ class limitless extends Exchange {
              * @return {array[]} a list of [trade structures](https://docs.ccxt.com/#/?id=trade-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $paginate = false;
             $maxLimit = 100;
             list($paginate, $params) = $this->handle_option_and_params($params, 'fetchMyTrades', 'paginate', $paginate);
@@ -2349,7 +2339,6 @@ class limitless extends Exchange {
                 'info' => $trade,
                 'timestamp' => $ts,
                 'datetime' => $this->iso8601($ts),
-                'symbol' => $feedOutcome,
                 'outcome' => $feedOutcome,
                 'outcomeId' => $this->safe_string($market, 'outcomeId'),
                 'label' => $this->safe_string($market, 'label'),
@@ -2423,7 +2412,6 @@ class limitless extends Exchange {
             'info' => $trade,
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $tradeOutcome,
             'outcome' => $tradeOutcome,
             'outcomeId' => $this->safe_string($trade, 'asset'),
             'label' => $this->safe_string($outcome, 'label'),
@@ -2469,10 +2457,10 @@ class limitless extends Exchange {
             }
             if ($symbolsLength > 0) {
                 for ($i = 0; $i < count($symbols); $i++) {
-                    $this->checkEventsAndMarkets ($symbols[$i]);
+                    $this->checkEvents ($symbols[$i]);
                 }
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $response = Async\await($this->limitlessPrivateGetPortfolioPositions ($params));
             //
@@ -2623,7 +2611,6 @@ class limitless extends Exchange {
         $entryPrice = $this->apply_scale($this->safe_string($position, 'fillPrice'));
         return array(
             'id' => null,
-            'symbol' => $outcomeSymbol,
             'outcome' => $outcomeSymbol,
             'outcomeId' => $this->safe_string($market, 'outcomeId'),
             'label' => $this->safe_string($market, 'label'),
@@ -2654,7 +2641,7 @@ class limitless extends Exchange {
         );
     }
 
-    public function fetch_events($params = array ()): PromiseInterface {
+    public function fetch_events(array $params = array ()): PromiseInterface {
         return Async\async(function () use ($params) {
             /**
              * fetches prediction-market events matching the given search terms (or the most active markets, capped, when omitted) and caches their markets and outcomes on the instance
@@ -2671,11 +2658,10 @@ class limitless extends Exchange {
             $result = array();
             $queriesLength = count($queries);
             if (!$queries || $queriesLength === 0) {
-                Async\await($this->load_markets());
                 $result = is_array($this->events) ? array_values($this->events) : array();
             } else {
                 $limit = $this->safe_integer($params, 'limit', 50);
-                $rest = $this->omit($params, array( 'query', 'queries', 'limit' ));
+                $rest = $this->omit($params, array( 'query', 'queries', 'limit', 'sort', 'searchIn', 'eventId', 'slug', 'status' ));
                 $seen = array();
                 $rawMarkets = array();
                 for ($i = 0; $i < count($queries); $i++) {
@@ -2726,7 +2712,7 @@ class limitless extends Exchange {
                 }
             }
             $this->rebuild_outcomes();
-            return $result;
+            return $this->applyEventFetchParams ($result, $params, $queries);
         }) ();
     }
 
@@ -2745,11 +2731,11 @@ class limitless extends Exchange {
             $outcomesList = $this->safe_list($market, 'outcomes', array());
             for ($j = 0; $j < count($outcomesList); $j++) {
                 $oc = $outcomesList[$j];
-                $ocSymbol = $this->safe_string($oc, 'symbol');
+                $ocSymbol = $this->safe_string($oc, 'outcome');
                 if ($ocSymbol !== null) {
                     $this->outcomes[$ocSymbol] = $oc;
                 }
-                $ocId = $this->safe_string($oc, 'id');
+                $ocId = $this->safe_string($oc, 'outcomeId');
                 if ($ocId !== null) {
                     $this->outcomes_by_id[$ocId] = $oc;
                 }

--- a/php/prediction/myriad.php
+++ b/php/prediction/myriad.php
@@ -419,7 +419,7 @@ class myriad extends Exchange {
         return $this->safePredictionPosition (array(
             'info' => $position,
             'id' => $id,
-            'symbol' => $symbol,
+            'outcome' => $symbol,
             'outcomeId' => $outcomeId,
             'label' => $outcomeTitle,
             'market' => $marketSymbol,
@@ -448,7 +448,7 @@ class myriad extends Exchange {
              * @param {float} [$params->slippage] maximum slippage tolerance (default 0.005)
              * @return {array} a quote object with price, shares, fees and the on-chain calldata
              */
-            $this->checkEventsAndMarkets ($symbol);
+            $this->checkEvents ($symbol);
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
             $networkId = $this->safe_string($info, 'networkId');
@@ -482,7 +482,7 @@ class myriad extends Exchange {
          * @return {array} a $quote object
          */
         return array(
-            'symbol' => $this->safe_string($market, 'symbol'),
+            'outcome' => $this->safe_string($market, 'outcome'),
             'side' => $this->safe_string_lower($quote, 'action'),
             'value' => $this->safe_number($quote, 'value'),
             'shares' => $this->safe_number($quote, 'shares'),
@@ -692,7 +692,6 @@ class myriad extends Exchange {
              * @param {string} [$params->expiration] unix-seconds expiration for a GTD order
              * @return {array} an [order structure](https://docs.ccxt.com/#/?id=order-structure)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
@@ -841,7 +840,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $ordersLength = count($orders);
             $result = array();
@@ -877,7 +875,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} an [order structure](https://docs.ccxt.com/#/?$id=order-structure)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             Async\await($this->cancel_order($id, $symbol));
             return Async\await($this->create_orderbook_order($symbol, $type, $side, $amount, $price, $params));
@@ -894,7 +891,7 @@ class myriad extends Exchange {
             if ($this->privateKey === null) {
                 throw new ArgumentsRequired($this->id . ' createOrder() requires a privateKey to sign the on-chain transaction');
             }
-            $this->checkEventsAndMarkets ($symbol);
+            $this->checkEvents ($symbol);
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
             $networkId = $this->safe_string($info, 'networkId');
@@ -1065,7 +1062,7 @@ class myriad extends Exchange {
                 $composite = $networkId . ':' . $marketId . '/' . $outcomeId;
             }
             $outcomeObj = $this->safeOutcome ($composite, $market);
-            $symbol = $this->safe_string($outcomeObj, 'symbol');
+            $symbol = $this->safe_string($outcomeObj, 'outcome');
         }
         return $this->safePredictionOrder (array(
             'id' => $orderHash,
@@ -1074,10 +1071,10 @@ class myriad extends Exchange {
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
             'lastTradeTimestamp' => null,
-            'symbol' => $symbol,
+            'outcome' => $symbol,
             'outcomeId' => $this->safe_string($outcomeObj, 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+            'market' => $this->safe_string($outcomeObj, 'outcome'),
             'type' => $isMarketTif ? 'market' : 'limit',
             'timeInForce' => $tif,
             'postOnly' => ($tif === 'PO'),
@@ -1110,7 +1107,6 @@ class myriad extends Exchange {
             if ($this->privateKey === null) {
                 throw new ArgumentsRequired($this->id . ' cancelOrder() requires a privateKey to sign the cancellation');
             }
-            Async\await($this->load_markets());
             $fetched = Async\await($this->myriadPublicGetOrdersHash ($this->extend(array( 'hash' => $id ), $params)));
             $rawOrder = $this->safe_dict($fetched, 'order', array());
             $networkId = $this->safe_string_2($fetched, 'networkId', 'network_id', $this->safe_string($this->options, 'defaultNetworkId', '56'));
@@ -1148,7 +1144,6 @@ class myriad extends Exchange {
             if ($this->privateKey === null) {
                 throw new ArgumentsRequired($this->id . ' cancelAllOrders() requires a privateKey to sign the cancellation');
             }
-            Async\await($this->load_markets());
             $trader = $this->eth_get_address_from_private_key($this->privateKey);
             $marketId = $this->safe_string($params, 'market_id', '0');
             $networkId = $this->safe_string($params, 'network_id', $this->safe_string($this->options, 'defaultNetworkId', '56'));
@@ -1193,7 +1188,6 @@ class myriad extends Exchange {
             if ($this->privateKey === null) {
                 throw new ArgumentsRequired($this->id . ' cancelOrders() requires a privateKey to sign the cancellations');
             }
-            Async\await($this->load_markets());
             $idsLength = count($ids);
             $signedOrders = array();
             $wrappers = array();
@@ -1229,7 +1223,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} an [order structure](https://docs.ccxt.com/#/?$id=order-structure)
              */
-            Async\await($this->load_markets());
             $response = Async\await($this->myriadPublicGetOrdersHash ($this->extend(array( 'hash' => $id ), $params)));
             $market = null;
             if ($symbol !== null) {
@@ -1255,7 +1248,6 @@ class myriad extends Exchange {
              * @param {string} [$params->status] 'open', 'filled', 'cancelled' or 'expired'
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
              */
-            Async\await($this->load_markets());
             $request = array();
             $trader = $this->safe_string($params, 'trader');
             if ($trader === null) {
@@ -1385,7 +1377,7 @@ class myriad extends Exchange {
             'info' => $this->safe_dict($order, 'info', array()),
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $this->safe_string($order, 'outcome'),
+            'outcome' => $this->safe_string($order, 'outcome'),
             'outcomeId' => $this->safe_string($order, 'outcomeId'),
             'label' => $this->safe_string($order, 'label'),
             'market' => $this->safe_string($order, 'market'),
@@ -1473,10 +1465,10 @@ class myriad extends Exchange {
             'id' => $txHash,
             'clientOrderId' => null,
             'info' => $this->extend(array( 'transactionHash' => $txHash ), $this->safe_dict($quote, 'info', array())),
-            'symbol' => $this->safe_string($market, 'symbol'),
+            'outcome' => $this->safe_string($market, 'outcome'),
             'outcomeId' => $this->safe_string($market, 'id'),
             'label' => $this->safe_string($market, 'label'),
-            'market' => $this->safe_string($market, 'marketSymbol'),
+            'market' => $this->safe_string($market, 'outcome'),
             'type' => 'market',
             'side' => $side,
             'price' => $this->safe_number($quote, 'priceAverage'),
@@ -1505,6 +1497,8 @@ class myriad extends Exchange {
             'title' => $this->safe_string_2($raw, 'title', 'shortName'),
             'description' => $this->safe_string($raw, 'description'),
             'markets' => array( $market ),
+            'volume' => $this->safe_number_2($raw, 'volumeNotional24h', 'volume24h'),
+            'liquidity' => $this->safe_number($raw, 'liquidity'),
             'url' => null,
             'image' => $this->safe_string($raw, 'imageUrl'),
             'active' => ($state === 'open'),
@@ -1561,9 +1555,7 @@ class myriad extends Exchange {
             $outcomes[] = array(
                 'id' => $outcomeCompositeId,
                 'outcomeId' => $outcomeCompositeId,
-                'symbol' => $outcomeHandle,
                 'outcome' => $outcomeHandle,
-                'marketSymbol' => $marketSymbol,
                 'market' => $marketSymbol,
                 'label' => $outcomeLabel,
                 'active' => $active,
@@ -1655,7 +1647,6 @@ class myriad extends Exchange {
              * @return {array} a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($outcome);
             $networkId = $this->safe_string($outcomeObj['info'], 'networkId');
@@ -1754,7 +1745,6 @@ class myriad extends Exchange {
              * @return {array} a [fee structure](https://docs.ccxt.com/#/?id=fee-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($outcome);
             $info = $this->safe_dict($outcomeObj, 'info', array());
@@ -1776,7 +1766,8 @@ class myriad extends Exchange {
             $sell = $this->safe_dict($fees, 'sell', array());
             return array(
                 'info' => $response,
-                'symbol' => $this->safe_symbol(null, $outcomeObj),
+                'outcome' => $this->safeOutcomeSymbol (null, $outcomeObj),
+                'outcomeId' => $this->safe_string($outcomeObj, 'outcomeId'),
                 'maker' => $this->safe_number($sell, 'fee'),
                 'taker' => $this->safe_number($buy, 'fee'),
                 'percentage' => true,
@@ -1880,10 +1871,10 @@ class myriad extends Exchange {
         }
         $now = $this->milliseconds();
         return $this->safePredictionTicker (array(
-            'symbol' => $this->safe_string($market, 'symbol'),
+            'outcome' => $this->safe_string($market, 'outcome'),
             'outcomeId' => $this->safe_string($market, 'id'),
             'label' => $this->safe_string($market, 'label'),
-            'market' => $this->safe_string($market, 'marketSymbol'),
+            'market' => $this->safe_string($market, 'outcome'),
             'timestamp' => $now,
             'datetime' => $this->iso8601($now),
             'high' => null,
@@ -1919,7 +1910,6 @@ class myriad extends Exchange {
              * @return {array} an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($outcome);
             $networkId = $this->safe_string($outcomeObj['info'], 'networkId');
@@ -1939,7 +1929,7 @@ class myriad extends Exchange {
                 //         "asks" => array( array( "990000000000000000", "151975683890577539072" ) )
                 //     }
                 //
-                return $this->parse_wei_order_book($obResponse, $this->safeOutcomeSymbol ($outcome, $outcomeObj));
+                return $this->safePredictionOrderBook ($this->parse_wei_order_book($obResponse, $this->safeOutcomeSymbol ($outcome, $outcomeObj)), $outcomeObj);
             }
             $request = array(
                 'id' => $marketId,
@@ -2050,14 +2040,15 @@ class myriad extends Exchange {
             if ($ask !== null) {
                 $asks[] = array( $ask, $synthSize );
             }
-            return array(
-                'symbol' => $this->safeOutcomeSymbol ($outcome, $outcomeObj),
+            $orderbook = array(
+                'outcome' => $this->safeOutcomeSymbol ($outcome, $outcomeObj),
                 'bids' => $bids,
                 'asks' => $asks,
                 'timestamp' => $timestamp,
                 'datetime' => $this->iso8601($timestamp),
                 'nonce' => null,
             );
+            return $this->safePredictionOrderBook ($orderbook, $outcomeObj);
         }) ();
     }
 
@@ -2087,7 +2078,7 @@ class myriad extends Exchange {
         }
         $timestamp = $this->milliseconds();
         return array(
-            'symbol' => $symbol,
+            'outcome' => $symbol,
             'bids' => $this->sort_by($bids, 0, true),
             'asks' => $this->sort_by($asks, 0),
             'timestamp' => $timestamp,
@@ -2110,7 +2101,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {int[][]} a list of candles ordered, open, high, low, close, volume
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($symbol);
             $outcomeInfo = $this->safe_dict($outcomeObj, 'info', array());
@@ -2256,7 +2246,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure) indexed by outcome symbol
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $result = array();
             if ($symbols === null) {
@@ -2335,7 +2324,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [trade structures](https://docs.ccxt.com/#/?id=public-$trades)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
@@ -2411,10 +2399,10 @@ class myriad extends Exchange {
             'info' => $trade,
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $this->safe_string($market, 'symbol'),
+            'outcome' => $this->safe_string($market, 'outcome'),
             'outcomeId' => $this->safe_string($market, 'id'),
             'label' => $this->safe_string($market, 'label'),
-            'market' => $this->safe_string($market, 'marketSymbol'),
+            'market' => $this->safe_string($market, 'outcome'),
             'order' => null,
             'type' => null,
             'side' => $this->safe_string($trade, 'action'),
@@ -2426,7 +2414,7 @@ class myriad extends Exchange {
         ), $market);
     }
 
-    public function fetch_events($params = array ()): PromiseInterface {
+    public function fetch_events(array $params = array ()): PromiseInterface {
         return Async\async(function () use ($params) {
             /**
              * fetches prediction-market events matching the given search terms (or all open markets when omitted) and caches their markets and outcomes on the instance
@@ -2441,12 +2429,13 @@ class myriad extends Exchange {
              * @return {array[]} an array of event structures
              */
             $queries = $this->parseSearchQueries ($params);
-            $rest = $this->omit($params, array( 'query', 'queries' ));
+            $rest = $this->omit($params, array( 'query', 'queries', 'sort', 'searchIn', 'eventId', 'slug', 'status' ));
             $queriesLength = count($queries);
             if ($queriesLength === 0) {
-                Async\await($this->load_markets());
                 $this->populate_outcomes();
-                return is_array($this->events) ? array_values($this->events) : array();
+                // hoist Object.values to a local — inline call argument breaks the php regex transpiler
+                $existingEvents = is_array($this->events) ? array_values($this->events) : array();
+                return $this->applyEventFetchParams ($existingEvents, $params, $queries);
             }
             $rawMarkets = Async\await($this->fetch_raw_markets_by_search($queries, $rest));
             if (!$this->events) {
@@ -2468,7 +2457,7 @@ class myriad extends Exchange {
                 }
             }
             $this->populate_outcomes();
-            return $result;
+            return $this->applyEventFetchParams ($result, $params, $queries);
         }) ();
     }
 
@@ -2497,11 +2486,16 @@ class myriad extends Exchange {
             $outcomesList = $this->safe_list($market, 'outcomes', array());
             for ($j = 0; $j < count($outcomesList); $j++) {
                 $oc = $outcomesList[$j];
-                $ocSymbol = $this->safe_string($oc, 'symbol');
+                // accept the legacy symbol/id keys too => in Go/C#/Java the prediction
+                // setMarkets override is not dispatched, so $oc is not pre-normalized
+                $ocSymbol = $this->safe_string_2($oc, 'outcome', 'symbol');
+                $ocId = $this->safe_string_2($oc, 'outcomeId', 'id');
+                $oc['outcome'] = $ocSymbol;
+                $oc['outcomeId'] = $ocId;
+                $oc['market'] = $this->safe_string_2($oc, 'market', 'marketSymbol');
                 if ($ocSymbol !== null) {
                     $this->outcomes[$ocSymbol] = $oc;
                 }
-                $ocId = $this->safe_string($oc, 'id');
                 if ($ocId !== null) {
                     $this->outcomes_by_id[$ocId] = $oc;
                 }
@@ -2531,6 +2525,8 @@ class myriad extends Exchange {
             'title' => $this->safe_string($rawEvent, 'title'),
             'description' => $this->safe_string($rawEvent, 'description'),
             'markets' => $marketsList,
+            'volume' => $this->safe_number_2($rawEvent, 'volumeNotional24h', 'volume24h'),
+            'liquidity' => $this->safe_number($rawEvent, 'liquidity'),
             'url' => $this->safe_string($rawEvent, 'url'),
             'image' => $this->safe_string($rawEvent, 'imageUrl', $this->safe_string($rawEvent, 'image')),
             'active' => $this->safe_bool($rawEvent, 'active'),
@@ -2573,7 +2569,7 @@ class myriad extends Exchange {
         }
         $ocId = $networkId . ':' . $marketId . '/' . $outcomeId;
         $outcomeObj = $this->safe_dict($this->outcomes_by_id, $ocId);
-        return $this->safe_string($outcomeObj, 'symbol');
+        return $this->safe_string($outcomeObj, 'outcome');
     }
 
     public function connect_centrifugo(string $url): PromiseInterface {
@@ -2687,7 +2683,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
@@ -2776,7 +2771,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [trade structures](https://docs.ccxt.com/#/?id=public-$trades)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
@@ -2807,7 +2801,6 @@ class myriad extends Exchange {
             if ($symbol === null) {
                 throw new ArgumentsRequired($this->id . ' watchMyTrades() requires a $symbol (the $trades $channel is per-market)');
             }
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
@@ -2853,10 +2846,10 @@ class myriad extends Exchange {
             'info' => $data,
             'timestamp' => $ts,
             'datetime' => $this->iso8601($ts),
-            'symbol' => $sym,
+            'outcome' => $sym,
             'outcomeId' => $this->safe_string($outcomeObj, 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+            'market' => $this->safe_string($outcomeObj, 'outcome'),
             'order' => $this->safe_string($taker, 'orderHash'),
             'type' => null,
             'side' => $this->safe_string_lower($taker, 'side'),
@@ -2902,10 +2895,10 @@ class myriad extends Exchange {
                         'info' => $maker,
                         'timestamp' => $ts,
                         'datetime' => $this->iso8601($ts),
-                        'symbol' => $makerSym,
+                        'outcome' => $makerSym,
                         'outcomeId' => $this->safe_string($makerOutcomeObj, 'id'),
                         'label' => $this->safe_string($makerOutcomeObj, 'label'),
-                        'market' => $this->safe_string($makerOutcomeObj, 'marketSymbol'),
+                        'market' => $this->safe_string($makerOutcomeObj, 'outcome'),
                         'order' => $this->safe_string($maker, 'orderHash'),
                         'type' => null,
                         'side' => $this->safe_string_lower($maker, 'side'),
@@ -2947,7 +2940,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $outcomeObj = $this->outcome ($symbol);
             $info = $this->safe_dict($outcomeObj, 'info', array());
@@ -2971,7 +2963,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dict of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by symbol
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             if ($symbols === null) {
                 throw new ArgumentsRequired($this->id . ' watchTickers() requires a list of $symbols (the prices $channel is per-market)');
@@ -3048,10 +3039,10 @@ class myriad extends Exchange {
             $outcomeObj = $this->safeOutcome ($sym);
             $last = $this->from_wei($this->safe_string($oc, 'last'));
             $ticker = $this->safePredictionTicker (array(
-                'symbol' => $sym,
+                'outcome' => $sym,
                 'outcomeId' => $this->safe_string($outcomeObj, 'id'),
                 'label' => $this->safe_string($outcomeObj, 'label'),
-                'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+                'market' => $this->safe_string($outcomeObj, 'outcome'),
                 'timestamp' => $ts,
                 'datetime' => $this->iso8601($ts),
                 'high' => null,
@@ -3091,7 +3082,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $trader = $this->wallet_address_from_keys();
             $networkId = $this->safe_string($this->options, 'defaultNetworkId', '56');
@@ -3131,10 +3121,10 @@ class myriad extends Exchange {
             'info' => $data,
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $sym,
+            'outcome' => $sym,
             'outcomeId' => $this->safe_string($outcomeObj, 'id'),
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+            'market' => $this->safe_string($outcomeObj, 'outcome'),
             'type' => $isMarketTif ? 'market' : 'limit',
             'timeInForce' => $tif,
             'side' => $this->safe_string_lower($data, 'side'),
@@ -3169,7 +3159,6 @@ class myriad extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
              */
-            Async\await($this->load_markets());
             $this->ensure_outcomes_loaded();
             $trader = $this->wallet_address_from_keys();
             $networkId = $this->safe_string($this->options, 'defaultNetworkId', '56');
@@ -3243,10 +3232,10 @@ class myriad extends Exchange {
         $parsed = $this->safePredictionPosition (array(
             'info' => $data,
             'id' => $posId,
-            'symbol' => $sym,
+            'outcome' => $sym,
             'outcomeId' => $posId,
             'label' => $this->safe_string($outcomeObj, 'label'),
-            'market' => $this->safe_string($outcomeObj, 'marketSymbol'),
+            'market' => $this->safe_string($outcomeObj, 'outcome'),
             'timestamp' => $ts,
             'datetime' => $this->iso8601($ts),
             'side' => 'long',

--- a/php/prediction/myriad.php
+++ b/php/prediction/myriad.php
@@ -365,8 +365,8 @@ class myriad extends Exchange {
         }) ();
     }
 
-    public function fetch_positions(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_positions(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
              * fetch the open outcome-token positions held by a wallet (myriad settles trades on-chain, so only read-only portfolio $data is exposed by the API)
              *
@@ -377,6 +377,7 @@ class myriad extends Exchange {
              * @param {string} [$params->address] the wallet $address to query, defaults to $this->walletAddress
              * @return {array[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
              */
+            $symbols = $outcomes;
             $address = $this->safe_string_2($params, 'address', 'user', $this->walletAddress);
             if ($address === null) {
                 throw new ArgumentsRequired($this->id . ' fetchPositions() requires a walletAddress or an $address parameter');
@@ -2235,17 +2236,18 @@ class myriad extends Exchange {
         );
     }
 
-    public function fetch_tickers(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_tickers(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
-             * fetches tickers for multiple outcomes, grouping requested outcomes by their parent market to fetch each market only once
+             * fetches tickers for multiple $outcomes, grouping requested $outcomes by their parent market to fetch each market only once
              *
              * @see https://docs.myriad.markets/builders/myriad-api-reference
              *
-             * @param {string[]} [$symbols] unified outcome $symbols, refreshes the markets listing and returns tickers for all outcomes when omitted
+             * @param {string[]} [$symbols] unified outcome $symbols, refreshes the markets listing and returns tickers for all $outcomes when omitted
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure) indexed by outcome symbol
              */
+            $symbols = $outcomes;
             $this->ensure_outcomes_loaded();
             $result = array();
             if ($symbols === null) {
@@ -2264,7 +2266,7 @@ class myriad extends Exchange {
                 }
                 return $result;
             }
-            // group target outcomes by their parent market to fetch each market only once
+            // group target $outcomes by their parent market to fetch each market only once
             $outcomesByMarket = array();
             $marketKeys = array();
             for ($i = 0; $i < count($symbols); $i++) {

--- a/php/prediction/polymarket.php
+++ b/php/prediction/polymarket.php
@@ -770,19 +770,18 @@ class polymarket extends Exchange {
         }) ();
     }
 
-    public function fetch_tickers(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_tickers(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
              * fetches tickers for multiple outcome tokens at once using the batched CLOB $book and midpoint endpoints
              *
              * @see https://docs.polymarket.com/api-reference/market-data/get-order-$books-request-body
              * @see https://docs.polymarket.com/api-reference/market-data/get-midpoint-prices-request-body
              *
-             * @param {string[]} [$symbols] unified outcome $symbols or outcome token ids, fetches all loaded $outcomes when omitted
+             * @param {string[]} [symbols] unified outcome symbols or outcome token ids, fetches all loaded $outcomes when omitted
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array} a dictionary of [$ticker structures](https://docs.ccxt.com/#/?id=$ticker-structure) indexed by outcome symbol
              */
-            $outcomes = $symbols;
             $outcomesLength = 0;
             if ($outcomes !== null) {
                 $outcomesLength = count($outcomes);
@@ -1421,18 +1420,17 @@ class polymarket extends Exchange {
         return $this->safe_balance($result);
     }
 
-    public function fetch_positions(?array $symbols = null, $params = array ()): PromiseInterface {
-        return Async\async(function () use ($symbols, $params) {
+    public function fetch_positions(?array $outcomes = null, $params = array ()): PromiseInterface {
+        return Async\async(function () use ($outcomes, $params) {
             /**
              * fetches open outcome token $positions for the wallet from the data API
              *
              * @see https://docs.polymarket.com/api-reference/core/get-current-$positions-for-a-user
              *
-             * @param {string[]} [$symbols] unified outcome $symbols to filter by
+             * @param {string[]} [symbols] unified outcome symbols to filter by
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [$position structures](https://docs.ccxt.com/#/?id=$position-structure)
              */
-            $outcomes = $symbols;
             $outcomesLength = 0;
             if ($outcomes !== null) {
                 $outcomesLength = count($outcomes);

--- a/php/prediction/polymarket.php
+++ b/php/prediction/polymarket.php
@@ -355,12 +355,30 @@ class polymarket extends Exchange {
              * @return {array[]} an array of raw gamma event objects
              */
             $pageSize = $this->safe_integer($params, 'limit', 50);
-            $rest = $this->omit($params, array( 'limit' ));
+            // map the unified sort/status onto the gamma search $params
+            $sort = $this->safe_string($params, 'sort');
+            $sortParam = 'volume';
+            if ($sort === 'liquidity') {
+                $sortParam = 'liquidity';
+            } elseif ($sort === 'newest') {
+                $sortParam = 'startDate';
+            }
+            $status = $this->safe_string($params, 'status', 'active');
+            $eventsStatus = 'active';
+            if (($status === 'closed') || ($status === 'inactive')) {
+                $eventsStatus = 'closed';
+            } elseif ($status === 'all') {
+                $eventsStatus = null;
+            }
+            $rest = $this->omit($params, array( 'limit', 'sort', 'status', 'searchIn', 'eventId', 'slug', 'query', 'queries' ));
             $seen = array();
             $rawEvents = array();
             for ($qi = 0; $qi < count($queries); $qi++) {
                 $q = $queries[$qi];
-                $baseRequest = array( 'q' => $q, 'limit_per_type' => $pageSize, 'events_status' => 'active' );
+                $baseRequest = array( 'q' => $q, 'limit_per_type' => $pageSize, 'sort' => $sortParam, 'ascending' => false );
+                if ($eventsStatus !== null) {
+                    $baseRequest['events_status'] = $eventsStatus;
+                }
                 $firstRequest = array( 'page' => 1 );
                 $firstRequest = $this->extend($this->extend($firstRequest, $baseRequest), $rest);
                 $first = Async\await($this->gammaPublicGetPublicSearch ($firstRequest));
@@ -422,14 +440,25 @@ class polymarket extends Exchange {
             $limit = $this->safe_integer($params, 'limit', $this->safe_integer($this->options, 'fetchMarketsLimit', 1000));
             $maxPages = (int) ceil($limit / $pageSize);
             $status = $this->safe_string($params, 'status', $this->safe_string($this->options, 'defaultEventStatus', 'active'));
-            $rest = $this->omit($params, array( 'status', 'limit' ));
-            $baseRequest = array( 'limit' => $pageSize, 'order' => 'volume24hr', 'ascending' => false );
+            // $sort maps to the gamma `$order` field; 'volume' is the default ranking
+            $sort = $this->safe_string($params, 'sort');
+            $order = 'volume';
+            if ($sort === 'liquidity') {
+                $order = 'liquidity';
+            } elseif ($sort === 'newest') {
+                $order = 'startDate';
+            }
+            $rest = $this->omit($params, array( 'status', 'limit', 'sort', 'searchIn', 'eventId', 'slug', 'query', 'queries' ));
+            $baseRequest = array( 'limit' => $pageSize, 'order' => $order, 'ascending' => false );
             $baseRequest = $this->extend($baseRequest, $rest);
             if ($status === 'active') {
                 $baseRequest['active'] = true;
-            } elseif ($status === 'closed') {
+                $baseRequest['closed'] = false;
+            } elseif (($status === 'closed') || ($status === 'inactive')) {
+                $baseRequest['active'] = false;
                 $baseRequest['closed'] = true;
             }
+            // 'all' — no active/closed filter
             // fetch $page 1 first; if full, fire remaining pages in parallel
             $firstPageRequest = array( 'offset' => 0 );
             $firstPageRequest = $this->extend($firstPageRequest, $baseRequest);
@@ -696,7 +725,7 @@ class polymarket extends Exchange {
              * @return {array} a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
              */
             $outcome = $symbol;
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $outcomeObj['outcomeId'];
             $promises = array(
@@ -760,10 +789,10 @@ class polymarket extends Exchange {
             }
             if ($outcomesLength > 0) {
                 for ($i = 0; $i < count($outcomes); $i++) {
-                    $this->checkEventsAndMarkets ($outcomes[$i]);
+                    $this->checkEvents ($outcomes[$i]);
                 }
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $outcomesMap = ($this->outcomes !== null) ? $this->outcomes : array();
             $targets = array();
@@ -883,7 +912,7 @@ class polymarket extends Exchange {
             $quoteVolume = $this->safe_number_2($market['info'], 'volume24hr', 'volume');
         }
         return $this->safePredictionTicker (array(
-            'symbol' => $symbol,
+            'outcome' => $symbol,
             'outcomeId' => $this->safe_string($market, 'outcomeId'),
             'label' => $this->safe_string($market, 'label'),
             'market' => $this->safe_string($market, 'market'),
@@ -922,7 +951,7 @@ class polymarket extends Exchange {
              * @return {array} an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
              */
             $outcome = $symbol;
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $outcomeObj['outcomeId'];
             $request = array(
@@ -973,7 +1002,7 @@ class polymarket extends Exchange {
              * @return {int[][]} a list of $candles ordered, open, high, low, close, volume
              */
             $outcome = $symbol;
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $outcomeObj['outcomeId'];
             $fidelityMin = $this->safe_integer($this->timeframes, $timeframe, 1); // fidelity in minutes
@@ -1117,7 +1146,7 @@ class polymarket extends Exchange {
              * @return {array} an [open interest structure](https://docs.ccxt.com/#/?id=open-interest-structure)
              */
             $outcome = $symbol;
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $outcomeInfo = $this->safe_dict($outcomeObj, 'info', array());
             $conditionId = $this->safe_string($outcomeInfo, 'conditionId');
@@ -1134,12 +1163,12 @@ class polymarket extends Exchange {
         }) ();
     }
 
-    public function parse_open_interest($interest, ?array $market = null): OpenInterest {
+    public function parse_open_interest($interest, ?array $market = null): PredictionOpenInterest {
         //
         //     array( "market" => "0x7976b8...92", "value" => 4925662.470476 )
         //
         $timestamp = $this->milliseconds();
-        return $this->safe_open_interest(array(
+        $openInterest = $this->safe_open_interest(array(
             'symbol' => $this->safeOutcomeSymbol (null, $market),
             'openInterestAmount' => null,
             'openInterestValue' => $this->safe_number($interest, 'value'),
@@ -1149,6 +1178,10 @@ class polymarket extends Exchange {
             'datetime' => $this->iso8601($timestamp),
             'info' => $interest,
         ), $market);
+        $openInterest['outcome'] = $this->safeOutcomeSymbol (null, $market);
+        $openInterest['outcomeId'] = $this->safe_string($market, 'outcomeId');
+        unset($openInterest['symbol']);
+        return $openInterest;
     }
 
     public function fetch_trading_fee(string $symbol, $params = array ()): PromiseInterface {
@@ -1163,7 +1196,7 @@ class polymarket extends Exchange {
              * @return {array} a [fee structure](https://docs.ccxt.com/#/?id=fee-structure)
              */
             $outcome = $symbol;
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $this->safe_string($outcomeObj, 'outcomeId');
             $request = array( 'token_id' => $tokenId );
@@ -1175,7 +1208,8 @@ class polymarket extends Exchange {
             $rate = ($baseFeeBps !== null) ? $this->parse_number(Precise::string_div($baseFeeBps, '10000')) : null;
             return array(
                 'info' => $response,
-                'symbol' => $this->safeOutcomeSymbol (null, $outcomeObj),
+                'outcome' => $this->safeOutcomeSymbol (null, $outcomeObj),
+                'outcomeId' => $this->safe_string($outcomeObj, 'outcomeId'),
                 'maker' => $rate,
                 'taker' => $rate,
                 'percentage' => true,
@@ -1198,7 +1232,7 @@ class polymarket extends Exchange {
              * @return {array[]} a list of [$trade structures](https://docs.ccxt.com/#/?id=public-trades)
              */
             $outcome = $symbol;
-            $this->checkEventsAndMarkets ($outcome);
+            $this->checkEvents ($outcome);
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $outcomeObj['outcomeId'];
             $outcomeInfo = $this->safe_dict($outcomeObj, 'info', array());
@@ -1246,7 +1280,7 @@ class polymarket extends Exchange {
             $request = array();
             $outcomeObj = null;
             if ($symbol !== null) {
-                $this->checkEventsAndMarkets ($symbol);
+                $this->checkEvents ($symbol);
                 $outcomeObj = $this->outcome ($symbol);
                 $request['asset_id'] = $outcomeObj['outcomeId'];
             }
@@ -1329,7 +1363,6 @@ class polymarket extends Exchange {
             'info' => $trade,
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $symbol,
             'outcome' => $symbol,
             'outcomeId' => $assetId,
             'label' => $this->safe_string($mkt, 'label'),
@@ -1409,10 +1442,10 @@ class polymarket extends Exchange {
             }
             if ($outcomesLength > 0) {
                 for ($i = 0; $i < count($outcomes); $i++) {
-                    $this->checkEventsAndMarkets ($outcomes[$i]);
+                    $this->checkEvents ($outcomes[$i]);
                 }
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             if ($this->walletAddress === null) {
                 throw new ArgumentsRequired($this->id . ' walletAddress is required to fetchPositions');
@@ -1481,7 +1514,7 @@ class polymarket extends Exchange {
         }
         return $this->safePredictionPosition (array(
             'id' => $this->safe_string($position, 'id'),
-            'symbol' => $marketData['outcome'],
+            'outcome' => $marketData['outcome'],
             'outcomeId' => $marketData['outcomeId'],
             'market' => $marketData['market'],
             'label' => $marketData['label'],
@@ -1528,9 +1561,9 @@ class polymarket extends Exchange {
             Async\await($this->load_api_credentials());
             $outcome = $symbol;
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $request = array();
             $outcomeObj = null;
@@ -1559,9 +1592,9 @@ class polymarket extends Exchange {
             Async\await($this->load_api_credentials());
             $outcome = $symbol;
             if ($outcome !== null) {
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
             } else {
-                $this->checkEventsAndMarkets ();
+                $this->checkEvents ();
             }
             $request = array( 'id' => $id );
             $response = Async\await($this->clobPrivateGetDataOrderId ($this->extend($request, $params)));
@@ -1605,7 +1638,7 @@ class polymarket extends Exchange {
             'datetime' => $this->iso8601($ts),
             'lastTradeTimestamp' => null,
             'status' => $status,
-            'symbol' => $mkt['outcome'],
+            'outcome' => $mkt['outcome'],
             'outcomeId' => $this->safe_string($mkt, 'outcomeId'),
             'label' => $this->safe_string($mkt, 'label'),
             'market' => $this->safe_string($mkt, 'market'),
@@ -2021,7 +2054,7 @@ class polymarket extends Exchange {
             $response = null;
             if ($outcome !== null) {
                 // scope to a single $outcome token via DELETE /cancel-market-$orders array( asset_id )
-                $this->checkEventsAndMarkets ($outcome);
+                $this->checkEvents ($outcome);
                 $outcomeObj = $this->outcome ($outcome);
                 $request = array( 'asset_id' => $outcomeObj['outcomeId'] );
                 $response = Async\await($this->clobPrivateDeleteCancelMarketOrders ($this->extend($request, $params)));
@@ -2038,7 +2071,7 @@ class polymarket extends Exchange {
         }) ();
     }
 
-    public function fetch_events($params = array ()): PromiseInterface {
+    public function fetch_events(fetchEventsParams $params = array ()): PromiseInterface {
         return Async\async(function () use ($params) {
             /**
              * fetches prediction-$market events matching the given search terms (or all active events when omitted) and caches their markets and outcomes on the instance
@@ -2047,16 +2080,33 @@ class polymarket extends Exchange {
              * @see https://docs.polymarket.com/api-reference/events/list-events
              *
              * @param {array} [$params] extra exchange-specific parameters
-             * @param {string} [$params->query] a single search term; when omitted (and no $queries) the most active events are returned (capped)
+             * @param {string} [$params->query] a single keyword search term
              * @param {string[]} [$params->queries] multiple search terms (alternative to query)
-             * @param {int} [$params->limit] when searching, page size per query (default 50); when omitted, max events to fetch (default options.fetchMarketsLimit, 1000), ordered by 24h volume
+             * @param {int} [$params->limit] max number of events to return
+             * @param {string} [$params->sort] 'volume' (default), 'liquidity' or 'newest' — mapped to the gamma order field
+             * @param {string} [$params->status] 'active' (default), 'inactive', 'closed' or 'all' ('inactive' and 'closed' are interchangeable)
+             * @param {string} [$params->searchIn] when searching, restrict the match to 'title' (default), 'description' or 'both'
+             * @param {string} [$params->eventId] direct $lookup by event id (short-circuits the listing/search)
+             * @param {string} [$params->slug] direct $lookup by event slug
              * @return {array[]} an array of event structures
              */
+            $requestedEventId = $this->safe_string($params, 'eventId');
+            $requestedSlug = $this->safe_string($params, 'slug');
             $queries = $this->parseSearchQueries ($params);
-            $rest = $this->omit($params, array( 'query', 'queries' ));
+            $rest = $this->omit($params, array( 'query', 'queries', 'eventId', 'slug' ));
             $queriesLength = count($queries);
             $rawEvents = array();
-            if ($queriesLength > 0) {
+            if (($requestedEventId !== null) || ($requestedSlug !== null)) {
+                // direct $lookup by event id or slug via the events endpoint (returns a list)
+                $lookup = array();
+                if ($requestedEventId !== null) {
+                    $lookup['id'] = $requestedEventId;
+                } else {
+                    $lookup['slug'] = $requestedSlug;
+                }
+                $response = Async\await($this->gammaPublicGetEvents ($lookup));
+                $rawEvents = ($response !== null) ? $response : array();
+            } elseif ($queriesLength > 0) {
                 $rawEvents = Async\await($this->fetch_raw_events_by_search($queries, $rest));
             } else {
                 $rawEvents = Async\await($this->fetch_raw_events_list($rest));
@@ -2109,17 +2159,28 @@ class polymarket extends Exchange {
                 $outcomesList = $this->safe_list($market, 'outcomes', array());
                 for ($j = 0; $j < count($outcomesList); $j++) {
                     $oc = $outcomesList[$j];
-                    $ocSymbol = $this->safe_string($oc, 'symbol');
+                    $ocSymbol = $this->safe_string($oc, 'outcome');
                     if ($ocSymbol !== null) {
                         $this->outcomes[$ocSymbol] = $oc;
                     }
-                    $ocId = $this->safe_string($oc, 'id');
+                    $ocId = $this->safe_string($oc, 'outcomeId');
                     if ($ocId !== null) {
                         $this->outcomes_by_id[$ocId] = $oc;
                     }
                 }
             }
-            return $result;
+            // the gamma search endpoint is fuzzy, so refine the search path by status and searchIn
+            // client-side (searchIn defaults to 'title', matching the reference behaviour)
+            $filtered = $result;
+            if ($queriesLength > 0) {
+                $filtered = $this->filterEventsByStatus ($filtered, $this->safe_string($params, 'status', 'active'));
+                $filtered = $this->filterEventsBySearchIn ($filtered, $queries, $this->safe_string($params, 'searchIn', 'title'));
+            }
+            $finalLimit = $this->safe_integer($params, 'limit');
+            if ($finalLimit !== null) {
+                $filtered = $this->array_slice($filtered, 0, $finalLimit);
+            }
+            return $filtered;
         }) ();
     }
 
@@ -2558,7 +2619,7 @@ class polymarket extends Exchange {
             'asks' => $asks,
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $symbol,
+            'outcome' => $symbol,
         ));
         $client->resolve ($orderbook, 'orderbook::' . $symbol);
         $client->resolve ($orderbook, 'ticker::' . $symbol);
@@ -2611,7 +2672,7 @@ class polymarket extends Exchange {
             'info' => $event,
             'timestamp' => $timestamp,
             'datetime' => $this->iso8601($timestamp),
-            'symbol' => $symbol,
+            'outcome' => $symbol,
             'outcomeId' => $this->safe_string($market, 'outcomeId'),
             'label' => $this->safe_string($market, 'label'),
             'market' => $this->safe_string($market, 'market'),
@@ -2647,7 +2708,6 @@ class polymarket extends Exchange {
              * @return {array} an ~@link https://docs.ccxt.com/#/?id=order-book-structure order book structure~
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $this->safe_string($outcomeObj, 'outcomeId');
             $symbol = $this->safe_string($outcomeObj, 'outcome');
@@ -2671,7 +2731,6 @@ class polymarket extends Exchange {
              * @return {array[]} a list of ~@link https://docs.ccxt.com/#/?id=public-$trades trade structures~
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $this->safe_string($outcomeObj, 'outcomeId');
             $symbol = $this->safe_string($outcomeObj, 'outcome');
@@ -2693,7 +2752,6 @@ class polymarket extends Exchange {
              * @return {array} a ~@link https://docs.ccxt.com/#/?id=ticker-structure ticker structure~
              */
             $outcome = $symbol;
-            Async\await($this->load_markets());
             $outcomeObj = $this->outcome ($outcome);
             $tokenId = $this->safe_string($outcomeObj, 'outcomeId');
             $symbol = $this->safe_string($outcomeObj, 'outcome');
@@ -2738,7 +2796,7 @@ class polymarket extends Exchange {
             }
             $market = $this->safeOutcome ($symbol);
             return $this->safePredictionTicker (array(
-                'symbol' => $symbol,
+                'outcome' => $symbol,
                 'outcomeId' => $this->safe_string($market, 'outcomeId'),
                 'label' => $this->safe_string($market, 'label'),
                 'market' => $this->safe_string($market, 'market'),
@@ -2778,7 +2836,6 @@ class polymarket extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
              */
-            Async\await($this->load_markets());
             Async\await($this->load_api_credentials());
             $messageHash = 'orders';
             if ($symbol !== null) {
@@ -2807,7 +2864,6 @@ class polymarket extends Exchange {
              * @param {array} [$params] extra parameters specific to the exchange API endpoint
              * @return {array[]} a list of [trade structures](https://docs.ccxt.com/#/?id=trade-structure)
              */
-            Async\await($this->load_markets());
             Async\await($this->load_api_credentials());
             $messageHash = 'myTrades';
             if ($symbol !== null) {

--- a/php/prediction/polymarket.php
+++ b/php/prediction/polymarket.php
@@ -980,10 +980,7 @@ class polymarket extends Exchange {
             //
             $timestamp = $this->safe_integer($response, 'timestamp');
             $orderbook = $this->parse_order_book($response, $this->safeOutcomeSymbol ($outcome, $outcomeObj), $timestamp, 'bids', 'asks', 'price', 'size');
-            $orderbook['outcome'] = $this->safe_string($outcomeObj, 'outcome');
-            $orderbook['outcomeId'] = $this->safe_string($outcomeObj, 'outcomeId');
-            $orderbook['market'] = $this->safe_string($outcomeObj, 'market');
-            return $orderbook;
+            return $this->safePredictionOrderBook ($orderbook, $outcomeObj);
         }) ();
     }
 
@@ -2071,7 +2068,7 @@ class polymarket extends Exchange {
         }) ();
     }
 
-    public function fetch_events(fetchEventsParams $params = array ()): PromiseInterface {
+    public function fetch_events(array $params = array ()): PromiseInterface {
         return Async\async(function () use ($params) {
             /**
              * fetches prediction-$market events matching the given search terms (or all active events when omitted) and caches their markets and outcomes on the instance

--- a/php/prediction/polymarket.php
+++ b/php/prediction/polymarket.php
@@ -1221,7 +1221,11 @@ class polymarket extends Exchange {
                     $filteredTrades[] = $trade;
                 }
             }
-            return $this->parse_trades($filteredTrades, $outcomeObj, $since, $limit);
+            // the trades are already narrowed to this $outcome by asset id above; pass no market so the
+            // base parseTrades doesn't apply its $symbol filter (prediction trades carry `$outcome`, not
+            // `$symbol`, so a $symbol-bearing $outcome object would drop them all). parseTrade resolves the
+            // $outcome from each trade's asset id.
+            return $this->parse_trades($filteredTrades, null, $since, $limit);
         }) ();
     }
 

--- a/php/test/tests_helpers.php
+++ b/php/test/tests_helpers.php
@@ -265,9 +265,10 @@ function init_exchange ($exchangeId, $args, $is_ws = false) {
     if ($is_ws) {
         $exchangeClassString = '\\ccxt\\pro\\' . $exchangeId;
     } elseif (!class_exists($exchangeClassString)) {
-        // fall back to the prediction-markets namespace (\ccxt\prediction\<id>)
+        // fall back to the prediction-markets namespace; prediction exchanges are
+        // async-only and live at \ccxt\prediction\<id> (no \async sub-namespace).
         // regular ccxt ids always win for ids present in both (e.g. hyperliquid)
-        $predictionClassString = '\\ccxt\\prediction\\' . (IS_SYNCHRONOUS ? '' : 'async\\') . $exchangeId;
+        $predictionClassString = '\\ccxt\\prediction\\' . $exchangeId;
         if (class_exists($predictionClassString)) {
             $exchangeClassString = $predictionClassString;
         }

--- a/python/ccxt/async_support/base/prediction_exchange.py
+++ b/python/ccxt/async_support/base/prediction_exchange.py
@@ -9,7 +9,7 @@
 import asyncio
 from typing import Any, List
 from ccxt.async_support.base.exchange import Exchange
-from ccxt.base.types import Str, Strings, Int, Num, OrderType, OrderSide
+from ccxt.base.types import Str, Strings, Int, Num, OrderType, OrderSide, fetchEventsParams
 from ccxt.base.errors import ExchangeError
 from ccxt.base.errors import BadSymbol
 from ccxt.base.errors import NotSupported
@@ -29,14 +29,7 @@ class PredictionExchange(Exchange):
     def is_prediction(self) -> bool:
         return self.safe_bool(self.has, 'prediction', False)
 
-    async def load_markets_and_events(self, reload=False, params={}):
-        res = await asyncio.gather(*[self.load_markets(reload, params), self.load_events(reload, params)])
-        return {
-            'markets': res[0],
-            'events': res[1],
-        }
-
-    def check_events_and_markets(self, outcome: Str = None):
+    def check_events(self, outcome: Str = None):
         # pure synchronous guard(no I/O) — callers invoke it without await, so leaving it
         # async would make the coroutine never run in Python/PHP and silently skip validation.
         # outcomes are the real dependency for resolving a symbol; they are populated by
@@ -58,7 +51,79 @@ class PredictionExchange(Exchange):
             return [singleQuery]
         return self.safe_list(params, 'queries', [])
 
-    async def fetch_events(self, params={}):
+    def apply_event_fetch_params(self, events: List[Any], params={}, queries: List[str] = None):
+        # applies the unified fetchEvents options client-side(eventId/slug/status/searchIn/sort/limit)
+        # so exchanges whose API can't filter natively still support them consistently
+        result = events
+        eventId = self.safe_string(params, 'eventId')
+        slug = self.safe_string(params, 'slug')
+        if (eventId is not None) or (slug is not None):
+            filtered = []
+            for i in range(0, len(result)):
+                event = result[i]
+                idMatch = (eventId is not None) and (self.safe_string(event, 'id') == eventId)
+                slugMatch = (slug is not None) and (self.safe_string(event, 'slug') == slug)
+                if idMatch or slugMatch:
+                    filtered.append(event)
+            result = filtered
+        result = self.filter_events_by_status(result, self.safe_string(params, 'status'))
+        if (queries is not None) and (len(queries) > 0):
+            result = self.filter_events_by_search_in(result, queries, self.safe_string(params, 'searchIn'))
+        sort = self.safe_string(params, 'sort')
+        if sort is not None:
+            sortKey = None
+            if sort == 'volume':
+                sortKey = 'volume'
+            elif sort == 'liquidity':
+                sortKey = 'liquidity'
+            elif sort == 'newest':
+                sortKey = 'created'
+            if sortKey is not None:
+                result = self.sort_by(result, sortKey, True, 0)
+        limit = self.safe_integer(params, 'limit')
+        if limit is not None:
+            result = self.array_slice(result, 0, limit)
+        return result
+
+    def filter_events_by_status(self, events: List[Any], status: Str = None):
+        # 'active' | 'inactive' | 'closed' | 'all' — 'inactive' and 'closed' are interchangeable
+        if (status is None) or (status == 'all'):
+            return events
+        wantActive = (status == 'active')
+        result = []
+        for i in range(0, len(events)):
+            event = events[i]
+            isActive = self.safe_bool(event, 'active')
+            # keep events whose status is unknown(already filtered server-side, no `active` field)
+            if (isActive is None) or (isActive == wantActive):
+                result.append(event)
+        return result
+
+    def filter_events_by_search_in(self, events: List[Any], queries: List[str], searchIn: Str = None):
+        # keep events whose title and/or description contains one of the queries(searchIn defaults to 'both')
+        if (searchIn is None) or (queries is None) or (len(queries) == 0):
+            return events
+        checkTitle = (searchIn == 'title') or (searchIn == 'both')
+        checkDescription = (searchIn == 'description') or (searchIn == 'both')
+        result = []
+        for i in range(0, len(events)):
+            event = events[i]
+            title = self.safe_string_lower(event, 'title', '')
+            description = self.safe_string_lower(event, 'description', '')
+            matched = False
+            for qi in range(0, len(queries)):
+                q = queries[qi].lower()
+                if checkTitle and (title.find(q) >= 0):
+                    matched = True
+                    break
+                if checkDescription and (description.find(q) >= 0):
+                    matched = True
+                    break
+            if matched:
+                result.append(event)
+        return result
+
+    async def fetch_events(self, params: fetchEventsParams = {}):
         raise NotSupported(self.id + ' fetchEvents() is not supported yet')
 
     async def fetch_event(self, id: str, params={}):
@@ -253,6 +318,17 @@ class PredictionExchange(Exchange):
         parsed = super(PredictionExchange, self).safe_position(position)
         return self.to_prediction_structure(parsed, position)
 
+    def safe_prediction_order_book(self, orderbook: dict, outcomeObj: dict = None):
+        # normalize a parsed order book to the prediction shape: replace the unified
+        # `symbol` with the `outcome` handle and attach the outcome identity fields
+        #(outcomeId / market) so books match the PredictionOrderBook structure.
+        fallback = self.safe_string_2(orderbook, 'outcome', 'symbol')
+        orderbook['outcome'] = fallback if (outcomeObj is None) else self.safe_string(outcomeObj, 'outcome', fallback)
+        orderbook['outcomeId'] = self.safe_string(orderbook, 'outcomeId') if (outcomeObj is None) else self.safe_string(outcomeObj, 'outcomeId')
+        orderbook['market'] = self.safe_string(orderbook, 'market') if (outcomeObj is None) else self.safe_string(outcomeObj, 'market')
+        # omit(not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return self.omit(orderbook, 'symbol')
+
     def to_prediction_structure(self, parsed: dict, raw: dict):
         # rename the unified `symbol` to the prediction `outcome` handle and attach the
         # prediction identity fields(raw exchange id, label, parent market/event) that the
@@ -263,8 +339,8 @@ class PredictionExchange(Exchange):
         parsed['label'] = self.safe_string(raw, 'label')
         parsed['market'] = self.safe_string(raw, 'market')
         parsed['event'] = self.safe_string(raw, 'event')
-        del parsed['symbol']
-        return parsed
+        # omit(not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return self.omit(parsed, 'symbol')
 
     def filter_by_outcome_since_limit(self, array, outcome: Str = None, since: Int = None, limit: Int = None, tail=False):
         return self.filter_by_value_since_limit(array, 'outcome', outcome, since, limit, 'timestamp', tail)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -3255,7 +3255,9 @@ class Exchange(object):
             result = []
             for i in range(0, len(parsedArray)):
                 entry = parsedArray[i]
-                entryFiledEqualValue = entry[field] == value
+                # safeValue(not entry[field]) so a missing field is a non-match, not a
+                # KeyError in python/php — prediction structures key on outcome, not symbol
+                entryFiledEqualValue = self.safe_value(entry, field) == value
                 firstCondition = entryFiledEqualValue if valueIsDefined else True
                 entryKeyValue = self.safe_value(entry, key)
                 entryKeyGESince = (entryKeyValue) and (since is not None) and (entryKeyValue >= since)
@@ -4997,15 +4999,18 @@ class Exchange(object):
             'bids': self.sort_by(self.aggregate(orderbook['bids']), 0, True),
         })
 
-    def filter_by_symbol(self, objects, symbol: Str = None):
-        if symbol is None:
+    def filter_by_key(self, objects, key: IndexType, value: Str = None):
+        if value is None:
             return objects
         result = []
         for i in range(0, len(objects)):
-            objectSymbol = self.safe_string(objects[i], 'symbol')
-            if objectSymbol == symbol:
+            objectValue = self.safe_string(objects[i], key)
+            if objectValue == value:
                 result.append(objects[i])
         return result
+
+    def filter_by_symbol(self, objects, symbol: Str = None):
+        return self.filter_by_key(objects, 'symbol', symbol)
 
     def parse_ohlcv(self, ohlcv, market: Market = None) -> list:
         if isinstance(ohlcv, list):

--- a/python/ccxt/prediction/hyperliquid.py
+++ b/python/ccxt/prediction/hyperliquid.py
@@ -601,7 +601,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         tickerData = self.safe_dict({'book': response}, 'book', {})
         return self.parse_ticker(tickerData, outcomeObj)
 
-    async def fetch_tickers(self, symbols: Strings = None, params={}) -> PredictionTickers:
+    async def fetch_tickers(self, outcomes: Strings = None, params={}) -> PredictionTickers:
         """
         fetches all outcome market tickers using allMids then optionally enriches with l2Book
 
@@ -611,7 +611,6 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure)
         """
-        outcomes = symbols
         requestedOutcomeSymbols = {}
         if outcomes is not None:
             for i in range(0, len(outcomes)):
@@ -884,7 +883,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             result[coin] = account
         return self.safe_balance(result)
 
-    async def fetch_positions(self, symbols: Strings = None, params={}) -> List[PredictionPosition]:
+    async def fetch_positions(self, outcomes: Strings = None, params={}) -> List[PredictionPosition]:
         """
         fetches outcome token positions from spot clearinghouse state, outcome tokens appear token balances starting with '+'
         :param str[] [symbols]: filter by outcome ids or symbols
@@ -892,7 +891,6 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :param str [params.user]: wallet address
         :returns dict[]: a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
         """
-        outcomes = symbols
         requestedOutcomeSymbols = {}
         if outcomes is not None:
             for i in range(0, len(outcomes)):

--- a/python/ccxt/prediction/hyperliquid.py
+++ b/python/ccxt/prediction/hyperliquid.py
@@ -5,7 +5,7 @@
 
 from ccxt.async_support.base.prediction_exchange import PredictionExchange
 from ccxt.abstract.prediction.hyperliquid import ImplicitAPI
-from ccxt.base.types import Any, Balances, Int, Market, Num, OrderBook, Str, Strings, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition
+from ccxt.base.types import Any, Balances, Int, Market, Num, Str, Strings, PredictionEvent, fetchEventsParams, PredictionTicker, PredictionTickers, PredictionOrder, PredictionOrderBook, PredictionTrade, PredictionPosition
 from typing import List
 from ccxt.base.errors import ExchangeError
 from ccxt.base.errors import ArgumentsRequired
@@ -450,16 +450,19 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         quoteCurrency = self.safe_string(self.options, 'outcomeQuoteCurrency', 'USDH')
         szDecimals = 4  # outcomes use 4 decimal places
         active = True
+        outcomePrecision = {
+            'amount': str(self.parse_number(self.parse_precision(szDecimals))),
+            'price': 0.0001,
+        }
         outcomes = [
             {
                 'id': self.outcome_coin(yesEncoding),
                 'outcomeId': self.outcome_coin(yesEncoding),
-                'symbol': yesOutcomeSymbol,
                 'outcome': yesOutcomeSymbol,
-                'marketSymbol': parentSymbol,
                 'market': parentSymbol,
                 'label': yesLabel,
                 'active': active,
+                'precision': outcomePrecision,
                 'info': {
                     'encoding': yesEncoding,
                     'assetId': self.outcome_asset_id(yesEncoding),
@@ -475,12 +478,11 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             {
                 'id': self.outcome_coin(noEncoding),
                 'outcomeId': self.outcome_coin(noEncoding),
-                'symbol': noOutcomeSymbol,
                 'outcome': noOutcomeSymbol,
-                'marketSymbol': parentSymbol,
                 'market': parentSymbol,
                 'label': noLabel,
                 'active': active,
+                'precision': outcomePrecision,
                 'info': {
                     'encoding': noEncoding,
                     'assetId': self.outcome_asset_id(noEncoding),
@@ -526,10 +528,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'percentage': True,
             'tierBased': False,
             'feeSide': 'get',
-            'precision': {
-                'amount': str(self.parse_number(self.parse_precision(szDecimals))),
-                'price': 0.0001,
-            },
+            'precision': outcomePrecision,
             'limits': {
                 'leverage': {'min': None, 'max': None},
                 'amount': {'min': None, 'max': None},
@@ -579,8 +578,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict: a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         info = self.safe_dict(outcomeObj, 'info', {})
         coin = self.safe_string(info, 'coinName')
@@ -614,15 +612,14 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure)
         """
         outcomes = symbols
-        await self.load_markets()
         requestedOutcomeSymbols = {}
         if outcomes is not None:
             for i in range(0, len(outcomes)):
                 requested = outcomes[i]
-                self.checkEventsAndMarkets(requested)
+                self.checkEvents(requested)
                 requestedOutcomeObj = self.outcome(requested)
-                requestedSymbol = self.safe_string(requestedOutcomeObj, 'symbol', requested)
-                requestedOutcomeSymbols[requestedSymbol] = True
+                requestedOutcome = self.safe_string(requestedOutcomeObj, 'outcome', requested)
+                requestedOutcomeSymbols[requestedOutcome] = True
         response = await self.publicPostInfo(self.extend({'type': 'allMids'}, params))
         #
         # {"mids": {"#10": "0.45", "#11": "0.55", ...}}
@@ -630,12 +627,12 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         mids = self.safe_dict(response, 'mids', response)
         tickers: PredictionTickers = {}
         outcomesMap = self.outcomes if (self.outcomes is not None) else {}
-        outcomeSymbols = list(outcomesMap.keys())
-        for i in range(0, len(outcomeSymbols)):
-            outcomeSymbol = outcomeSymbols[i]
-            if outcomes is not None and not (outcomeSymbol in requestedOutcomeSymbols):
+        outcomeHandles = list(outcomesMap.keys())
+        for i in range(0, len(outcomeHandles)):
+            outcomeHandle = outcomeHandles[i]
+            if outcomes is not None and not (outcomeHandle in requestedOutcomeSymbols):
                 continue
-            outcomeObj = self.safe_dict(outcomesMap, outcomeSymbol, {})
+            outcomeObj = self.safe_dict(outcomesMap, outcomeHandle, {})
             info = self.safe_dict(outcomeObj, 'info', {})
             coin = self.safe_string(info, 'coinName')
             mid = self.safe_number(mids, coin)
@@ -643,7 +640,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
                 continue
             # Build minimal ticker from mid price
             ticker = self.parse_ticker({'levels': [[], []], 'mid': mid, 'time': self.milliseconds()}, outcomeObj)
-            tickers[outcomeSymbol] = ticker
+            tickers[outcomeHandle] = ticker
         return tickers
 
     def parse_ticker(self, raw: dict, market: Market = None) -> PredictionTicker:
@@ -683,7 +680,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         if mid is None and bid is not None and ask is not None:
             mid = self.sum(bid, ask) / 2
         # day volume lives on the parent market's ctx; resolve it from the outcome's marketSymbol
-        parentSymbol = self.safe_string(mkt, 'marketSymbol')
+        parentSymbol = self.safe_string(mkt, 'outcome')
         parentMarket = self.safe_market(parentSymbol) if (parentSymbol is not None) else None
         ctx = self.safe_dict(self.safe_dict(parentMarket, 'info', {}), 'ctx', {}) if (parentMarket is not None) else {}
         dayVolume = self.safe_number(ctx, 'dayNtlVlm')
@@ -691,7 +688,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'symbol': symbol,
             'outcomeId': self.safe_string(mkt, 'id'),
             'label': self.safe_string(mkt, 'label'),
-            'market': self.safe_string(mkt, 'marketSymbol'),
+            'market': self.safe_string(mkt, 'outcome'),
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
             'high': None,
@@ -713,7 +710,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'info': raw,
         }, market)
 
-    async def fetch_order_book(self, symbol: str, limit: Int = None, params={}) -> OrderBook:
+    async def fetch_order_book(self, symbol: str, limit: Int = None, params={}) -> PredictionOrderBook:
         """
         fetches the L2 order book for an outcome market
 
@@ -725,8 +722,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict: an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         info = self.safe_dict(outcomeObj, 'info', {})
         request = {
@@ -756,7 +752,8 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         for i in range(0, len(rawAsks)):
             entry = rawAsks[i]
             asks.append([self.safe_number(entry, 'px'), self.safe_number(entry, 'sz')])
-        return self.parse_order_book({'bids': bids, 'asks': asks}, self.safe_string(outcomeObj, 'symbol', outcome), timestamp)
+        orderbook = self.parse_order_book({'bids': bids, 'asks': asks}, self.safe_string(outcomeObj, 'symbol', outcome), timestamp)
+        return self.safePredictionOrderBook(orderbook, outcomeObj)
 
     async def fetch_ohlcv(self, symbol: str, timeframe='1m', since: Int = None, limit: Int = None, params={}) -> List[list]:
         """
@@ -773,10 +770,9 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns int[][]: a list of candles ordered, open, high, low, close, volume
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
-        market = self.market(self.safe_string(outcomeObj, 'marketSymbol'))
+        market = self.market(self.safe_string(outcomeObj, 'outcome'))
         info = self.safe_dict(outcomeObj, 'info', {})
         until = self.safe_integer(params, 'until', self.milliseconds())
         startTime = since
@@ -897,15 +893,14 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
         """
         outcomes = symbols
-        await self.load_markets()
         requestedOutcomeSymbols = {}
         if outcomes is not None:
             for i in range(0, len(outcomes)):
                 requested = outcomes[i]
-                self.checkEventsAndMarkets(requested)
+                self.checkEvents(requested)
                 requestedOutcomeObj = self.outcome(requested)
-                requestedSymbol = self.safe_string(requestedOutcomeObj, 'symbol', requested)
-                requestedOutcomeSymbols[requestedSymbol] = True
+                requestedOutcome = self.safe_string(requestedOutcomeObj, 'outcome', requested)
+                requestedOutcomeSymbols[requestedOutcome] = True
         userAddress: Str
         userAddress, params = self.handle_public_address('fetchPositions', params)
         request = {
@@ -928,8 +923,8 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             outcomeId = '#' + coin[1:]  # +10 ->  #10
             outcomeObj = self.safeOutcome(outcomeId)
             if outcomes is not None:
-                outcomeSymbol = self.safe_string(outcomeObj, 'symbol')
-                if outcomeSymbol is None or not (outcomeSymbol in requestedOutcomeSymbols):
+                outcomeHandle = self.safe_string(outcomeObj, 'outcome')
+                if outcomeHandle is None or not (outcomeHandle in requestedOutcomeSymbols):
                     continue
             positions.append(self.parse_position(balance, outcomeObj))
         return positions
@@ -957,7 +952,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'symbol': self.safe_string(outcomeObj, 'symbol'),
             'outcomeId': self.safe_string(outcomeObj, 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'timestamp': None,
             'datetime': None,
             'isolated': False,
@@ -1074,11 +1069,10 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
         await self.initialize_client()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
-        market = self.market(self.safe_string(outcomeObj, 'marketSymbol'))
+        market = self.market(self.safe_string(outcomeObj, 'outcome'))
         outcomeInfo = self.safe_dict(outcomeObj, 'info', {})
         nonce = self.milliseconds()
         isBuy = (side.upper() == 'BUY')
@@ -1101,10 +1095,10 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         if isMarket:
             priceStr = self.number_to_string(price)
             px = Precise.string_mul(priceStr, Precise.string_add('1', slippage)) if isBuy else Precise.string_mul(priceStr, Precise.string_sub('1', slippage))
-            px = self.price_to_precision(self.safe_string(outcomeObj, 'marketSymbol'), px)
+            px = self.price_to_precision(self.safe_string(outcomeObj, 'outcome'), px)
         else:
-            px = self.price_to_precision(self.safe_string(outcomeObj, 'marketSymbol'), price)
-        sz = self.amount_to_precision(self.safe_string(outcomeObj, 'marketSymbol'), amount)
+            px = self.price_to_precision(self.safe_string(outcomeObj, 'outcome'), price)
+        sz = self.amount_to_precision(self.safe_string(outcomeObj, 'outcome'), amount)
         orderType = {
             'limit': {'tif': tif},
         }
@@ -1162,10 +1156,10 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'timestamp': nonce,
             'datetime': self.iso8601(nonce),
             'status': orderStatus,
-            'symbol': self.safe_string(outcomeObj, 'symbol', outcome),
+            'outcome': self.safe_string(outcomeObj, 'outcome', outcome),
             'outcomeId': self.safe_string(outcomeObj, 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'type': type,
             'side': side,
             'price': price,
@@ -1209,9 +1203,8 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         self.check_required_credentials()
         if outcome is None:
             raise ArgumentsRequired(self.id + ' cancelOrders() requires an outcome argument')
-        await self.load_markets()
         await self.initialize_client()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         outcomeInfo = self.safe_dict(outcomeObj, 'info', {})
         assetId = self.safe_integer(outcomeInfo, 'assetId')
@@ -1245,7 +1238,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         innerResponse = self.safe_dict(response, 'response')
         data = self.safe_dict(innerResponse, 'data')
         statuses = self.safe_list(data, 'statuses', [])
-        outcomeSymbol = self.safe_string(outcomeObj, 'symbol', outcome)
+        outcomeSymbol = self.safe_string(outcomeObj, 'outcome', outcome)
         requestIds = ids
         if clientOrderId is not None:
             if isinstance(clientOrderId, list):
@@ -1267,11 +1260,10 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
                 'clientOrderId': requestId if (clientOrderId is not None) else None,
                 'info': status,
                 'status': 'canceled',
-                'symbol': outcomeSymbol,
                 'outcome': outcomeSymbol,
                 'outcomeId': self.safe_string(outcomeObj, 'id'),
                 'label': self.safe_string(outcomeObj, 'label'),
-                'market': self.safe_string(outcomeObj, 'marketSymbol'),
+                'market': self.safe_string(outcomeObj, 'outcome'),
                 'timestamp': self.milliseconds(),
                 'datetime': self.iso8601(self.milliseconds()),
             }
@@ -1293,7 +1285,6 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
         userAddress: Str
         userAddress, params = self.handle_public_address('fetchOpenOrders', params)
         method: Str
@@ -1307,9 +1298,9 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         parsed = self.parse_orders(ordersWithStatus, None, since, None)
         outcomeHandle: Str = None
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
             outcomeObj = self.outcome(outcome)
-            outcomeHandle = self.safe_string(outcomeObj, 'symbol')
+            outcomeHandle = self.safe_string(outcomeObj, 'outcome')
         return self.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit)
 
     async def fetch_orders(self, symbol: Str = None, since: Int = None, limit: Int = None, params={}) -> List[PredictionOrder]:
@@ -1326,7 +1317,6 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
         userAddress: Str
         userAddress, params = self.handle_public_address('fetchOrders', params)
         request = {'type': 'historicalOrders', 'user': userAddress}
@@ -1351,9 +1341,9 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         parsed = self.parse_orders(dedupedValues, None, since, None)
         outcomeHandle: Str = None
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
             outcomeObj = self.outcome(outcome)
-            outcomeHandle = self.safe_string(outcomeObj, 'symbol')
+            outcomeHandle = self.safe_string(outcomeObj, 'outcome')
         return self.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit)
 
     async def fetch_order(self, id: str, symbol: Str = None, params={}) -> PredictionOrder:
@@ -1370,7 +1360,6 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
         userAddress: Str
         userAddress, params = self.handle_public_address('fetchOrder', params)
         clientOrderId = self.safe_string(params, 'clientOrderId')
@@ -1385,9 +1374,9 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         orderWrapper = self.safe_dict(response, 'order', response)
         parsed = self.parse_order(orderWrapper, None)
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
             outcomeObj = self.outcome(outcome)
-            expected = self.safe_string(outcomeObj, 'symbol')
+            expected = self.safe_string(outcomeObj, 'outcome')
             if self.safe_string(parsed, 'outcome') != expected:
                 raise OrderNotFound(self.id + ' fetchOrder() order ' + id + ' is not in outcome ' + expected)
         return parsed
@@ -1423,7 +1412,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         status = self.parse_order_status(self.safe_string_2(order, 'ccxtStatus', 'status'))
         coin = self.safe_string(entry, 'coin')
         outcomeObj = self.safeOutcome(coin, market)
-        marketSymbol = self.safe_string(outcomeObj, 'marketSymbol')
+        marketSymbol = self.safe_string(outcomeObj, 'outcome')
         resolvedMarket = self.safe_market(marketSymbol, market) if marketSymbol else market
         sideRaw = self.safe_string(entry, 'side')
         side = 'buy' if (sideRaw == 'B') else 'sell'
@@ -1444,10 +1433,10 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'datetime': self.iso8601(timestamp),
             'lastTradeTimestamp': None,
             'status': status,
-            'symbol': self.safe_string(outcomeObj, 'symbol'),
+            'outcome': self.safe_string(outcomeObj, 'outcome'),
             'outcomeId': self.safe_string(outcomeObj, 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'type': self.parse_order_type(self.safe_string(entry, 'orderType', 'limit')),
             'timeInForce': tif,
             'postOnly': postOnly,
@@ -1514,7 +1503,6 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=trade-structure)
         """
         outcome = symbol
-        await self.load_markets()
         userAddress: Str
         userAddress, params = self.handle_public_address('fetchMyTrades', params)
         request = {'user': userAddress}
@@ -1531,9 +1519,9 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         parsed = self.parse_trades(response, None, since, None)
         outcomeHandle: Str = None
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
             outcomeObj = self.outcome(outcome)
-            outcomeHandle = self.safe_string(outcomeObj, 'symbol')
+            outcomeHandle = self.safe_string(outcomeObj, 'outcome')
         return self.filterByOutcomeSinceLimit(parsed, outcomeHandle, since, limit)
 
     def parse_trade(self, trade: dict, market: Market = None) -> PredictionTrade:
@@ -1568,13 +1556,13 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         amount = self.safe_string(trade, 'sz')
         coin = self.safe_string(trade, 'coin')
         outcomeObj = self.safeOutcome(coin, market)
-        marketSymbol = self.safe_string(outcomeObj, 'marketSymbol')
+        marketSymbol = self.safe_string(outcomeObj, 'outcome')
         resolvedMarket = self.safe_market(marketSymbol, market) if marketSymbol else market
         rawSide = self.safe_string(trade, 'side')
         side = 'buy' if (rawSide == 'B') else 'sell'
         fee = self.safe_number(trade, 'fee')
         feeCurrency = self.safe_string(trade, 'feeToken', 'USDC')
-        outcomeSymbol = self.safe_string(outcomeObj, 'symbol')
+        outcomeSymbol = self.safe_string(outcomeObj, 'outcome')
         feeObject = None
         if fee is not None:
             feeObject = {'cost': fee, 'currency': feeCurrency}
@@ -1586,11 +1574,10 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'info': trade,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': outcomeSymbol,
             'outcome': outcomeSymbol,
             'outcomeId': self.safe_string(outcomeObj, 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'order': self.safe_string(trade, 'oid'),
             'type': 'limit',
             'side': side,
@@ -1601,7 +1588,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
             'fee': feeObject,
         }, resolvedMarket)
 
-    async def fetch_events(self, params={}) -> List[PredictionEvent]:
+    async def fetch_events(self, params: fetchEventsParams = {}) -> List[PredictionEvent]:
         """
         Groups outcome markets by their underlying(e.g. BTC-ABOVE-78213) into event structures. Each event contains both the YES and NO markets.
         :param dict [params]: extra parameters
@@ -1610,7 +1597,6 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         :returns PredictionEvent[]: array of event structures
         """
         queries = self.parseSearchQueries(params)
-        await self.load_markets()
         marketValues = list(self.markets.values())
         # Group markets by parentSymbol
         groupMap = {}
@@ -1652,7 +1638,7 @@ class hyperliquid(PredictionExchange, ImplicitAPI):
         for i in range(0, len(events)):
             ev = events[i]
             self.events[ev['symbol']] = ev
-        return events
+        return self.applyEventFetchParams(events, params, queries)
 
     def parse_event(self, raw: dict) -> Any:
         """

--- a/python/ccxt/prediction/kalshi.py
+++ b/python/ccxt/prediction/kalshi.py
@@ -5,7 +5,7 @@
 
 from ccxt.async_support.base.prediction_exchange import PredictionExchange
 from ccxt.abstract.prediction.kalshi import ImplicitAPI
-from ccxt.base.types import Any, Balances, Int, Market, Num, OrderBook, Str, Strings, OpenInterest, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition
+from ccxt.base.types import Any, Balances, Int, Market, Num, Str, Strings, PredictionEvent, fetchEventsParams, PredictionTicker, PredictionTickers, PredictionOrder, PredictionOrderBook, PredictionTrade, PredictionPosition, PredictionOpenInterest
 from typing import List
 from ccxt.base.precise import Precise
 
@@ -338,9 +338,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
             outcomes.append({
                 'id': outcomeIds[oi],
                 'outcomeId': outcomeIds[oi],
-                'symbol': outcomeHandle,
                 'outcome': outcomeHandle,
-                'marketSymbol': marketSymbol,
                 'market': marketSymbol,
                 'label': label,
                 'active': active,
@@ -419,8 +417,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns dict: a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         ticker = self.safe_string(outcomeObj['info'], 'ticker')
         request: dict = {
@@ -507,7 +504,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
             'info': response,
         }
 
-    async def fetch_open_interest(self, symbol: str, params={}) -> OpenInterest:
+    async def fetch_open_interest(self, symbol: str, params={}) -> PredictionOpenInterest:
         """
         fetches the open interest of a prediction market outcome
 
@@ -518,8 +515,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns dict: an [open interest structure](https://docs.ccxt.com/#/?id=open-interest-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         ticker = self.safe_string(outcomeObj['info'], 'ticker')
         request: dict = {'ticker': ticker}
@@ -527,12 +523,12 @@ class kalshi(PredictionExchange, ImplicitAPI):
         raw = self.safe_dict(response, 'market', response)
         return self.parse_open_interest(raw, outcomeObj)
 
-    def parse_open_interest(self, interest, market: Market = None) -> OpenInterest:
+    def parse_open_interest(self, interest, market: Market = None) -> PredictionOpenInterest:
         #
         #     {"ticker": "...", "open_interest_fp": "60802.01", ...}   # open interest in contracts
         #
         timestamp = self.milliseconds()
-        return self.safe_open_interest({
+        openInterest = self.safe_open_interest({
             'symbol': self.safe_symbol(None, market),
             'openInterestAmount': self.safe_number_2(interest, 'open_interest_fp', 'open_interest'),
             'openInterestValue': None,
@@ -542,6 +538,10 @@ class kalshi(PredictionExchange, ImplicitAPI):
             'datetime': self.iso8601(timestamp),
             'info': interest,
         }, market)
+        openInterest['outcome'] = self.safeOutcomeSymbol(None, market)
+        openInterest['outcomeId'] = self.safe_string(market, 'outcomeId')
+        del openInterest['symbol']
+        return openInterest
 
     def parse_ticker(self, raw: dict, market: Market = None) -> PredictionTicker:
         """
@@ -607,11 +607,11 @@ class kalshi(PredictionExchange, ImplicitAPI):
         #     }
         #
         marketAny = market
-        outcomeObj = self.safeOutcome(self.safe_string(marketAny, 'symbol'), marketAny)
+        outcomeObj = self.safeOutcome(self.safe_string(marketAny, 'outcome'), marketAny)
         outcomeLabel = self.safe_string(market, 'label', self.safe_string(market['info'], 'outcomeLabel', 'YES')) if market else 'YES'
         isNo = outcomeLabel.upper() == 'NO'
         now = self.milliseconds()
-        symbol = self.safe_string(outcomeObj, 'symbol')
+        symbol = self.safe_string(outcomeObj, 'outcome')
         yesAsk = self.safe_number(raw, 'yes_ask_dollars')
         yesBid = self.safe_number(raw, 'yes_bid_dollars')
         noAsk = self.safe_number(raw, 'no_ask_dollars')
@@ -635,10 +635,10 @@ class kalshi(PredictionExchange, ImplicitAPI):
         if (bid is not None) and (ask is not None):
             average = self.parse_number(Precise.string_div(Precise.string_add(self.number_to_string(bid), self.number_to_string(ask)), '2'))
         return self.safePredictionTicker({
-            'symbol': symbol,
+            'outcome': symbol,
             'outcomeId': self.safe_string_2(outcomeObj, 'outcomeId', 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string_2(outcomeObj, 'market', 'marketSymbol'),
+            'market': self.safe_string_2(outcomeObj, 'market', 'outcome'),
             'timestamp': now,
             'datetime': self.iso8601(now),
             'high': None,
@@ -670,14 +670,13 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
         """
-        await self.load_markets()
         targets: List[Any] = []
         if symbols is not None:
             for i in range(0, len(symbols)):
-                self.checkEventsAndMarkets(symbols[i])
+                self.checkEvents(symbols[i])
                 targets.append(symbols[i])
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
             allKeys = list(self.outcomes.keys())
             for i in range(0, len(allKeys)):
                 targets.append(allKeys[i])
@@ -727,7 +726,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
             startIndex = self.sum(startIndex, chunkSize)
         return result
 
-    async def fetch_order_book(self, symbol: Str, limit: Int = None, params={}) -> OrderBook:
+    async def fetch_order_book(self, symbol: Str, limit: Int = None, params={}) -> PredictionOrderBook:
         """
         fetches the order book for a single kalshi outcome
 
@@ -739,8 +738,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns dict: an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         ticker = self.safe_string(outcomeObj['info'], 'ticker')
         isNo = outcomeObj['label'] == 'NO'
@@ -786,9 +784,9 @@ class kalshi(PredictionExchange, ImplicitAPI):
                 noPrice = self.safe_number(rawNo[ai], 0)
                 price = self.parse_number(Precise.string_sub('1', self.number_to_string(noPrice))) if (noPrice is not None) else None
                 asks.append([price, self.safe_number(rawNo[ai], 1)])
-        return self.sorted_orders(self.safe_string(outcomeObj, 'symbol', outcome), timestamp, bids, asks)
+        return self.safePredictionOrderBook(self.sorted_orders(self.safe_string(outcomeObj, 'outcome', outcome), timestamp, bids, asks), outcomeObj)
 
-    def sorted_orders(self, symbol: Str, timestamp: Int, bids: List[Any], asks: List[Any]) -> OrderBook:
+    def sorted_orders(self, symbol: Str, timestamp: Int, bids: List[Any], asks: List[Any]) -> PredictionOrderBook:
         """
  @ignore
         sorts bids descending and asks ascending, then returns a CCXT-shaped order book object
@@ -802,7 +800,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         bids = self.sort_by(bids, 0, True)
         asks = self.sort_by(asks, 0)
         return {
-            'symbol': symbol,
+            'outcome': symbol,
             'bids': bids,
             'asks': asks,
             'timestamp': timestamp,
@@ -824,8 +822,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns int[][]: a list of candles ordered, open, high, low, close, volume
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         ticker = self.safe_string(outcomeObj['info'], 'ticker')
         seriesTicker = self.safe_string(outcomeObj['info'], 'seriesTicker', ticker)
@@ -958,8 +955,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=public-trades)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         ticker = self.safe_string(outcomeObj['info'], 'ticker')
         request: dict = {'ticker': ticker}
@@ -996,10 +992,10 @@ class kalshi(PredictionExchange, ImplicitAPI):
         amount = self.safe_number(trade, 'count', amountFp)
         rawSide = self.safe_string_lower(trade, 'taker_side')
         marketAny = market
-        outcomeObj = self.safeOutcome(self.safe_string(marketAny, 'symbol'), marketAny)
+        outcomeObj = self.safeOutcome(self.safe_string(marketAny, 'outcome'), marketAny)
         marketInfo = self.safe_dict(outcomeObj, 'info', {})
         requestedOutcomeLabel = self.safe_string_lower(outcomeObj, 'label', self.safe_string_lower(marketInfo, 'outcomeLabel'))
-        outcomeSymbol = self.safe_string(outcomeObj, 'symbol')
+        outcomeSymbol = self.safe_string(outcomeObj, 'outcome')
         outcomeId = self.safe_string_2(outcomeObj, 'outcomeId', 'id')
         side: Str
         if rawSide == 'yes' or rawSide == 'no':
@@ -1015,11 +1011,10 @@ class kalshi(PredictionExchange, ImplicitAPI):
             'info': trade,
             'timestamp': ts,
             'datetime': self.iso8601(ts),
-            'symbol': outcomeSymbol,
             'outcome': outcomeSymbol,
             'outcomeId': outcomeId,
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string_2(outcomeObj, 'market', 'marketSymbol'),
+            'market': self.safe_string_2(outcomeObj, 'market', 'outcome'),
             'order': None,
             'type': None,
             'side': side,
@@ -1039,7 +1034,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a [balance structure](https://docs.ccxt.com/#/?id=balance-structure)
         """
-        self.checkEventsAndMarkets()
+        self.checkEvents()
         response = await self.kalshiPrivateGetPortfolioBalance(params)
         return self.parse_balance(response)
 
@@ -1075,9 +1070,9 @@ class kalshi(PredictionExchange, ImplicitAPI):
             outcomesLength = len(outcomes)
         if outcomesLength > 0:
             for i in range(0, len(outcomes)):
-                self.checkEventsAndMarkets(outcomes[i])
+                self.checkEvents(outcomes[i])
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         response = await self.kalshiPrivateGetPortfolioPositions(params)
         positions = self.safe_list(response, 'market_positions', [])
         return self.parse_positions(positions, outcomes)
@@ -1100,10 +1095,10 @@ class kalshi(PredictionExchange, ImplicitAPI):
             contractsValue = self.parse_number(Precise.string_abs(self.number_to_string(yesContracts)))
         return self.safePredictionPosition({
             'id': None,
-            'symbol': self.safe_string(outcomeObj, 'symbol', ticker),
+            'outcome': self.safe_string(outcomeObj, 'outcome', ticker),
             'outcomeId': self.safe_string_2(outcomeObj, 'outcomeId', 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string_2(outcomeObj, 'market', 'marketSymbol'),
+            'market': self.safe_string_2(outcomeObj, 'market', 'outcome'),
             'timestamp': None,
             'datetime': None,
             'contracts': contractsValue,
@@ -1143,9 +1138,9 @@ class kalshi(PredictionExchange, ImplicitAPI):
         """
         outcome = symbol
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         request: dict = {'status': 'resting'}
         outcomeObj: Any = None
         if outcome is not None:
@@ -1167,9 +1162,9 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         if symbol is not None:
-            self.checkEventsAndMarkets(symbol)
+            self.checkEvents(symbol)
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         response = await self.kalshiPrivateGetPortfolioOrdersOrderId(self.extend({'order_id': id}, params))
         return self.parse_order(self.safe_value(response, 'order', response))
 
@@ -1205,10 +1200,10 @@ class kalshi(PredictionExchange, ImplicitAPI):
             'datetime': self.iso8601(ts),
             'lastTradeTimestamp': None,
             'status': status,
-            'symbol': self.safe_string(mkt, 'symbol'),
+            'outcome': self.safe_string(mkt, 'outcome'),
             'outcomeId': self.safe_string_2(mkt, 'outcomeId', 'id'),
             'label': self.safe_string(mkt, 'label'),
-            'market': self.safe_string_2(mkt, 'market', 'marketSymbol'),
+            'market': self.safe_string_2(mkt, 'market', 'outcome'),
             'type': self.safe_string_lower(order, 'type', 'limit'),
             'timeInForce': 'GTC',
             'postOnly': None,
@@ -1255,8 +1250,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         ticker = self.safe_string(outcomeObj['info'], 'ticker')
         outcomeLabel = outcomeObj['label']
@@ -1288,9 +1282,9 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         if symbol is not None:
-            self.checkEventsAndMarkets(symbol)
+            self.checkEvents(symbol)
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         response = await self.kalshiPrivateDeletePortfolioOrdersOrderId(self.extend({'order_id': id}, params))
         return self.parse_order(self.safe_value(response, 'order', response))
 
@@ -1306,18 +1300,17 @@ class kalshi(PredictionExchange, ImplicitAPI):
         """
         outcome = symbol
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         request: dict = {}
         if outcome is not None:
-            await self.load_markets()
             outcomeObj = self.outcome(outcome)
             request['ticker'] = self.safe_string(outcomeObj['info'], 'ticker')
         response = await self.kalshiPrivateDeletePortfolioOrders(self.extend(request, params))
         return self.parse_orders(self.safe_list(response, 'orders', []))
 
-    async def fetch_events(self, params={}) -> List[PredictionEvent]:
+    async def fetch_events(self, params: fetchEventsParams = {}) -> List[PredictionEvent]:
         """
         fetches kalshi events via cursor-paginated /events, filters client-side by query strings, then fetches full event details with nested markets in parallel and caches in self.events
 
@@ -1333,10 +1326,14 @@ class kalshi(PredictionExchange, ImplicitAPI):
         """
         queries = self.parseSearchQueries(params)
         params = self.omit(params, ['query', 'queries'])
-        status = self.safe_string(params, 'status', self.safe_string(self.options, 'defaultEventStatus', 'open'))
+        # map the unified status onto the kalshi event status(open / closed) so it is pushed server-side
+        requestedStatus = self.safe_string(params, 'status', self.safe_string(self.options, 'defaultEventStatus', 'active'))
+        status = 'open'
+        if (requestedStatus == 'closed') or (requestedStatus == 'inactive'):
+            status = 'closed'
         pageLimit = self.safe_integer(params, 'limit', 200)
         maxPages = self.safe_integer(params, 'maxPages', 50)
-        rest = self.omit(params, ['status', 'limit', 'maxPages'])
+        rest = self.omit(params, ['status', 'limit', 'maxPages', 'sort', 'searchIn', 'eventId', 'slug'])
         if not self.events:
             self.events = {}
         if not self.markets:
@@ -1419,13 +1416,13 @@ class kalshi(PredictionExchange, ImplicitAPI):
             outcomesList = self.safe_list(market, 'outcomes', [])
             for j in range(0, len(outcomesList)):
                 oc = outcomesList[j]
-                ocSymbol = self.safe_string(oc, 'symbol')
+                ocSymbol = self.safe_string(oc, 'outcome')
                 if ocSymbol is not None:
                     self.outcomes[ocSymbol] = oc
-                ocId = self.safe_string(oc, 'id')
+                ocId = self.safe_string(oc, 'outcomeId')
                 if ocId is not None:
                     self.outcomes_by_id[ocId] = oc
-        return result
+        return self.applyEventFetchParams(result, params, queries)
 
     async def fetch_event(self, id: str, params={}) -> PredictionEvent:
         """
@@ -1519,21 +1516,35 @@ class kalshi(PredictionExchange, ImplicitAPI):
         # }
         rawMarkets = self.safe_list(rawEvent, 'markets', [])
         marketsList: List[Any] = []
+        # aggregate volume/liquidity from the markets and derive the creation time so sort works
+        totalVolume = 0
+        totalLiquidity = 0
+        earliestCreated = None
         for i in range(0, len(rawMarkets)):
             rawMarket = rawMarkets[i]
             parsed = self.parse_market(rawMarket)
             marketsList.append(parsed)
+            totalVolume = self.sum(totalVolume, self.safe_number_2(rawMarket, 'volume_fp', 'volume', 0))
+            totalLiquidity = self.sum(totalLiquidity, self.safe_number_2(rawMarket, 'liquidity_dollars', 'liquidity', 0))
+            marketCreated = self.parse8601(self.safe_string(rawMarket, 'open_time'))
+            if (marketCreated is not None) and ((earliestCreated is None) or (marketCreated < earliestCreated)):
+                earliestCreated = marketCreated
         ticker = self.safe_string(rawEvent, 'event_ticker')
         title = self.safe_string(rawEvent, 'title')
+        created = self.parse8601(self.safe_string(rawEvent, 'created_date_iso'))
+        if created is None:
+            created = earliestCreated
         return self.extend({
             'id': ticker,
             'slug': ticker,
             'symbol': self.shortenSlug(title) if title else None,
             'title': title,
             'markets': marketsList,
+            'volume': totalVolume,
+            'liquidity': totalLiquidity,
             'url': self.safe_string(rawEvent, 'url'),
             'image': self.safe_string(rawEvent, 'image_url'),
-            'created': self.parse8601(self.safe_string(rawEvent, 'created_date_iso')),
+            'created': created,
             'createdDatetime': self.safe_string(rawEvent, 'created_date_iso'),
             'end': self.parse8601(self.safe_string(rawEvent, 'end_date_iso')),
             'endDatetime': self.safe_string(rawEvent, 'end_date_iso'),

--- a/python/ccxt/prediction/kalshi.py
+++ b/python/ccxt/prediction/kalshi.py
@@ -660,7 +660,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
             'info': raw,
         }, market)
 
-    async def fetch_tickers(self, symbols: Strings = None, params={}) -> PredictionTickers:
+    async def fetch_tickers(self, outcomes: Strings = None, params={}) -> PredictionTickers:
         """
         fetches tickers for multiple outcomes at once, batching their market tickers through the markets endpoint
 
@@ -670,6 +670,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
         """
+        symbols = outcomes
         targets: List[Any] = []
         if symbols is not None:
             for i in range(0, len(symbols)):
@@ -1054,7 +1055,7 @@ class kalshi(PredictionExchange, ImplicitAPI):
         result['USD'] = {'free': total, 'used': 0, 'total': total}
         return result
 
-    async def fetch_positions(self, symbols: Strings = None, params={}) -> List[PredictionPosition]:
+    async def fetch_positions(self, outcomes: Strings = None, params={}) -> List[PredictionPosition]:
         """
         fetches open market positions for the authenticated kalshi user
 
@@ -1064,7 +1065,6 @@ class kalshi(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
         """
-        outcomes = symbols
         outcomesLength = 0
         if outcomes is not None:
             outcomesLength = len(outcomes)

--- a/python/ccxt/prediction/limitless.py
+++ b/python/ccxt/prediction/limitless.py
@@ -976,7 +976,7 @@ class limitless(PredictionExchange, ImplicitAPI):
             'info': ticker,
         })
 
-    async def fetch_tickers(self, symbols: Strings = None, params={}) -> PredictionTickers:
+    async def fetch_tickers(self, outcomes: Strings = None, params={}) -> PredictionTickers:
         """
         fetches tickers for multiple outcome tokens, grouping requested outcomes by their parent market, fetches all active markets when symbols is omitted
 
@@ -987,6 +987,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
         """
+        symbols = outcomes
         result: PredictionTickers = {}
         if symbols is None:
             # parse tickers for every loaded outcome from the cached listing data, without the per-market order books
@@ -2272,7 +2273,7 @@ class limitless(PredictionExchange, ImplicitAPI):
                 return outcome
         return None
 
-    async def fetch_positions(self, symbols: Strings = None, params={}) -> List[PredictionPosition]:
+    async def fetch_positions(self, outcomes: Strings = None, params={}) -> List[PredictionPosition]:
         """
         fetches open positions for the authenticated limitless user from the portfolio endpoint
 
@@ -2282,6 +2283,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
         """
+        symbols = outcomes
         symbolsLength = 0
         if symbols is not None:
             symbolsLength = len(symbols)

--- a/python/ccxt/prediction/limitless.py
+++ b/python/ccxt/prediction/limitless.py
@@ -8,7 +8,7 @@ from ccxt.abstract.prediction.limitless import ImplicitAPI
 import asyncio
 import hashlib
 import math
-from ccxt.base.types import Account, Any, Bool, Int, Market, Num, OrderBook, Str, Strings, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition
+from ccxt.base.types import Account, Any, Bool, Int, Market, Num, Str, Strings, PredictionEvent, fetchEventsParams, PredictionTicker, PredictionTickers, PredictionOrder, PredictionOrderBook, PredictionTrade, PredictionPosition
 from typing import List
 from ccxt.base.errors import ArgumentsRequired
 from ccxt.base.errors import BadRequest
@@ -692,6 +692,8 @@ class limitless(PredictionExchange, ImplicitAPI):
         title = self.safe_string(event, 'title', groupId)
         markets = []
         rawMarkets = self.safe_list(event, 'markets', [])
+        # aggregate 24h volume across the markets so sort by volume works
+        totalVolume = 0
         for i in range(0, len(rawMarkets)):
             rawMarket = rawMarkets[i]
             marketSymbol = self.safe_string(rawMarket, 'symbol')
@@ -700,6 +702,8 @@ class limitless(PredictionExchange, ImplicitAPI):
                 markets.append(rawMarket)
             else:
                 markets.append(self.parse_market(rawMarket))
+            marketInfo = self.safe_dict(rawMarket, 'info', rawMarket)
+            totalVolume = self.sum(totalVolume, self.safe_number_2(marketInfo, 'volume24h', 'volume', 0))
         return self.extend({
             'id': groupId,
             'slug': groupId,
@@ -707,6 +711,8 @@ class limitless(PredictionExchange, ImplicitAPI):
             'title': title,
             'description': self.safe_string(event, 'description'),
             'markets': markets,
+            'volume': totalVolume,
+            'liquidity': self.safe_number(event, 'liquidity'),
             'url': self.safe_string(event, 'url'),
             'image': self.safe_string(event, 'imageUrl', self.safe_string(event, 'image')),
             'active': self.safe_bool(event, 'active', True),
@@ -734,8 +740,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict: a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         slug = self.safe_string(outcomeObj['info'], 'slug')
         request: dict = {
@@ -946,7 +951,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         now = self.milliseconds()
         outcomeSymbol = self.safeOutcomeSymbol(None, market)
         return self.safePredictionTicker({
-            'symbol': outcomeSymbol,
+            'outcome': outcomeSymbol,
             'outcomeId': self.safe_string(market, 'outcomeId'),
             'label': self.safe_string(market, 'label'),
             'market': self.safe_string(market, 'market'),
@@ -982,7 +987,6 @@ class limitless(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
         """
-        await self.load_markets()
         result: PredictionTickers = {}
         if symbols is None:
             # parse tickers for every loaded outcome from the cached listing data, without the per-market order books
@@ -1001,7 +1005,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         outcomesBySlug: dict = {}
         slugs: List[Any] = []
         for i in range(0, len(symbols)):
-            self.checkEventsAndMarkets(symbols[i])
+            self.checkEvents(symbols[i])
             outcomeObj = self.outcome(symbols[i])
             slug = self.safe_string(outcomeObj['info'], 'slug')
             if not (slug in outcomesBySlug):
@@ -1043,8 +1047,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=public-trades)
         """
-        await self.load_markets()
-        self.checkEventsAndMarkets(symbol)
+        self.checkEvents(symbol)
         outcomeObj = self.outcome(symbol)
         slug = self.safe_string(outcomeObj['info'], 'slug')
         tokenId = self.safe_string(outcomeObj, 'outcomeId')
@@ -1088,7 +1091,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         parsedTrades = self.parse_trades(filtered, None)
         return self.filterByOutcomeSinceLimit(parsedTrades, symbol, since, limit)
 
-    async def fetch_order_book(self, symbol: Str, limit: Int = None, params={}) -> OrderBook:
+    async def fetch_order_book(self, symbol: Str, limit: Int = None, params={}) -> PredictionOrderBook:
         """
         fetches the order book for a single outcome token, converting 6-decimal USDC sizes to whole units, no outcomes are quoted at 1 - price with the sides swapped
 
@@ -1100,8 +1103,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict: an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         slug = self.safe_string(outcomeObj['info'], 'slug')
         request: dict = {
@@ -1157,14 +1159,15 @@ class limitless(PredictionExchange, ImplicitAPI):
             if sizeStr is not None:
                 sizeStr = Precise.string_div(sizeStr, scaleStr)
             asks.append([self.parse_number(priceStr), self.parse_number(sizeStr)])
-        return {
-            'symbol': self.safeOutcomeSymbol(outcome, outcomeObj),
+        orderbook = {
+            'outcome': self.safeOutcomeSymbol(outcome, outcomeObj),
             'bids': self.sort_by(bids, 0, True),
             'asks': self.sort_by(asks, 0),
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
             'nonce': None,
         }
+        return self.safePredictionOrderBook(orderbook, outcomeObj)
 
     async def fetch_ohlcv(self, symbol: Str, timeframe='1d', since: Int = None, limit: Int = None, params={}) -> List[list]:
         """
@@ -1179,8 +1182,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns int[][]: a list of candles ordered, open, high, low, close, volume
         """
-        await self.load_markets()
-        self.checkEventsAndMarkets(symbol)
+        self.checkEvents(symbol)
         outcomeObj = self.outcome(symbol)
         slug = self.safe_string(outcomeObj['info'], 'slug')
         outcomeLabel = self.safe_string_upper(outcomeObj['info'], 'outcomeLabel')
@@ -1295,8 +1297,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         outcome = symbol
         if outcome is None:
             raise ArgumentsRequired(self.id + ' fetchOrders requires an outcome argument')
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         info = self.safe_dict(outcomeObj, 'info')
         request: dict = {
@@ -1345,8 +1346,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         outcome = symbol
         if outcome is None:
             raise ArgumentsRequired(self.id + ' fetchOpenOrders requires an outcome argument')
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         params = self.extend(params, {
             'statuses': ['LIVE'],
         })
@@ -1367,8 +1367,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         outcome = symbol
         if outcome is None:
             raise ArgumentsRequired(self.id + ' fetchClosedOrders requires an outcome argument')
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         params = self.extend(params, {
             'statuses': ['MATCHED'],
         })
@@ -1386,8 +1385,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         length = len(ids)
         if length > 50:
             raise BadRequest(self.id + ' fetchOrdersByIds can only fetch up to 50 orders at a time')
@@ -1519,8 +1517,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         orders = await self.fetch_orders_by_ids([id], outcome, params)
         order = self.safe_dict(orders, 0)
         if order is None:
@@ -1695,7 +1692,6 @@ class limitless(PredictionExchange, ImplicitAPI):
             'datetime': datetime,
             'lastTradeTimestamp': None,
             'status': self.parse_order_status(rawStatus),
-            'symbol': outcomeSymbol,
             'outcome': outcomeSymbol,
             'outcomeId': self.safe_string(mkt, 'outcomeId'),
             'label': self.safe_string(mkt, 'label'),
@@ -1787,7 +1783,6 @@ class limitless(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [account structures]
         """
-        await self.load_markets()
         response = await self.limitlessPrivateGetProfilesMe(params)
         responseList = [response]
         return self.parse_accounts(responseList)
@@ -1807,9 +1802,8 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
         accounts = await self.load_accounts()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         account = self.safe_dict(accounts, 0)
         accountInfo = self.safe_dict(account, 'info')
@@ -1987,8 +1981,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         request: dict = {
             'order_id': id,
         }
@@ -2007,8 +2000,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         request: dict = {
             'orderIds': ids,
         }
@@ -2034,8 +2026,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         if outcome is not None:
             warn = True
             warn, params = self.handle_option_and_params(params, 'cancelAllOrders', 'warnOnCancelAllOrdersWithOutcome', warn)
@@ -2069,8 +2060,7 @@ class limitless(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=trade-structure)
         """
         outcome = symbol
-        await self.load_markets()
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         paginate = False
         maxLimit = 100
         paginate, params = self.handle_option_and_params(params, 'fetchMyTrades', 'paginate', paginate)
@@ -2187,7 +2177,6 @@ class limitless(PredictionExchange, ImplicitAPI):
                 'info': trade,
                 'timestamp': ts,
                 'datetime': self.iso8601(ts),
-                'symbol': feedOutcome,
                 'outcome': feedOutcome,
                 'outcomeId': self.safe_string(market, 'outcomeId'),
                 'label': self.safe_string(market, 'label'),
@@ -2259,7 +2248,6 @@ class limitless(PredictionExchange, ImplicitAPI):
             'info': trade,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': tradeOutcome,
             'outcome': tradeOutcome,
             'outcomeId': self.safe_string(trade, 'asset'),
             'label': self.safe_string(outcome, 'label'),
@@ -2299,9 +2287,9 @@ class limitless(PredictionExchange, ImplicitAPI):
             symbolsLength = len(symbols)
         if symbolsLength > 0:
             for i in range(0, len(symbols)):
-                self.checkEventsAndMarkets(symbols[i])
+                self.checkEvents(symbols[i])
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         response = await self.limitlessPrivateGetPortfolioPositions(params)
         #
         #     {
@@ -2442,7 +2430,6 @@ class limitless(PredictionExchange, ImplicitAPI):
         entryPrice = self.apply_scale(self.safe_string(position, 'fillPrice'))
         return {
             'id': None,
-            'symbol': outcomeSymbol,
             'outcome': outcomeSymbol,
             'outcomeId': self.safe_string(market, 'outcomeId'),
             'label': self.safe_string(market, 'label'),
@@ -2472,7 +2459,7 @@ class limitless(PredictionExchange, ImplicitAPI):
             'info': position,
         }
 
-    async def fetch_events(self, params={}) -> List[PredictionEvent]:
+    async def fetch_events(self, params: fetchEventsParams = {}) -> List[PredictionEvent]:
         """
         fetches prediction-market events matching the given search terms(or the most active markets, capped, when omitted) and caches their markets and outcomes on the instance
 
@@ -2488,11 +2475,10 @@ class limitless(PredictionExchange, ImplicitAPI):
         result = []
         queriesLength = len(queries)
         if not queries or queriesLength == 0:
-            await self.load_markets()
             result = list(self.events.values())
         else:
             limit = self.safe_integer(params, 'limit', 50)
-            rest = self.omit(params, ['query', 'queries', 'limit'])
+            rest = self.omit(params, ['query', 'queries', 'limit', 'sort', 'searchIn', 'eventId', 'slug', 'status'])
             seen: dict = {}
             rawMarkets: List[Any] = []
             for i in range(0, len(queries)):
@@ -2533,7 +2519,7 @@ class limitless(PredictionExchange, ImplicitAPI):
                 self.events[eventKey] = ev
                 result.append(ev)
         self.rebuild_outcomes()
-        return result
+        return self.applyEventFetchParams(result, params, queries)
 
     def rebuild_outcomes(self):
         """
@@ -2550,10 +2536,10 @@ class limitless(PredictionExchange, ImplicitAPI):
             outcomesList = self.safe_list(market, 'outcomes', [])
             for j in range(0, len(outcomesList)):
                 oc = outcomesList[j]
-                ocSymbol = self.safe_string(oc, 'symbol')
+                ocSymbol = self.safe_string(oc, 'outcome')
                 if ocSymbol is not None:
                     self.outcomes[ocSymbol] = oc
-                ocId = self.safe_string(oc, 'id')
+                ocId = self.safe_string(oc, 'outcomeId')
                 if ocId is not None:
                     self.outcomes_by_id[ocId] = oc
 

--- a/python/ccxt/prediction/myriad.py
+++ b/python/ccxt/prediction/myriad.py
@@ -344,7 +344,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         event: Any = self.parse_market_to_event(response, market)
         return event
 
-    async def fetch_positions(self, symbols: Strings = None, params={}) -> List[PredictionPosition]:
+    async def fetch_positions(self, outcomes: Strings = None, params={}) -> List[PredictionPosition]:
         """
         fetch the open outcome-token positions held by a wallet(myriad settles trades on-chain, so only read-only portfolio data is exposed by the API)
 
@@ -355,6 +355,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param str [params.address]: the wallet address to query, defaults to self.walletAddress
         :returns dict[]: a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
         """
+        symbols = outcomes
         address = self.safe_string_2(params, 'address', 'user', self.walletAddress)
         if address is None:
             raise ArgumentsRequired(self.id + ' fetchPositions() requires a walletAddress or an address parameter')
@@ -2028,7 +2029,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             0,   # price_charts endpoint has no volume
         ]
 
-    async def fetch_tickers(self, symbols: Strings = None, params={}) -> PredictionTickers:
+    async def fetch_tickers(self, outcomes: Strings = None, params={}) -> PredictionTickers:
         """
         fetches tickers for multiple outcomes, grouping requested outcomes by their parent market to fetch each market only once
 
@@ -2038,6 +2039,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
         """
+        symbols = outcomes
         self.ensure_outcomes_loaded()
         result: PredictionTickers = {}
         if symbols is None:

--- a/python/ccxt/prediction/myriad.py
+++ b/python/ccxt/prediction/myriad.py
@@ -8,7 +8,7 @@ from ccxt.abstract.prediction.myriad import ImplicitAPI
 import asyncio
 import json
 from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByOutcomeById
-from ccxt.base.types import Any, Balances, Int, Market, Num, OrderBook, OrderRequest, Str, Strings, TradingFeeInterface, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition
+from ccxt.base.types import Any, Balances, Int, Market, Num, OrderRequest, Str, Strings, PredictionEvent, fetchEventsParams, PredictionTicker, PredictionTickers, PredictionOrder, PredictionOrderBook, PredictionTrade, PredictionPosition, PredictionTradingFee
 from typing import List
 from ccxt.base.errors import ExchangeError
 from ccxt.base.errors import AuthenticationError
@@ -392,7 +392,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         return self.safePredictionPosition({
             'info': position,
             'id': id,
-            'symbol': symbol,
+            'outcome': symbol,
             'outcomeId': outcomeId,
             'label': outcomeTitle,
             'market': marketSymbol,
@@ -419,7 +419,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param float [params.slippage]: maximum slippage tolerance(default 0.005)
         :returns dict: a quote object with price, shares, fees and the on-chain calldata
         """
-        self.checkEventsAndMarkets(symbol)
+        self.checkEvents(symbol)
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
         networkId = self.safe_string(info, 'networkId')
@@ -450,7 +450,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         :returns dict: a quote object
         """
         return {
-            'symbol': self.safe_string(market, 'symbol'),
+            'outcome': self.safe_string(market, 'outcome'),
             'side': self.safe_string_lower(quote, 'action'),
             'value': self.safe_number(quote, 'value'),
             'shares': self.safe_number(quote, 'shares'),
@@ -621,7 +621,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param str [params.expiration]: unix-seconds expiration for a GTD order
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
@@ -748,7 +747,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         ordersLength = len(orders)
         result = []
@@ -780,7 +778,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         await self.cancel_order(id, symbol)
         return await self.create_orderbook_order(symbol, type, side, amount, price, params)
@@ -793,7 +790,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         """
         if self.privateKey is None:
             raise ArgumentsRequired(self.id + ' createOrder() requires a privateKey to sign the on-chain transaction')
-        self.checkEventsAndMarkets(symbol)
+        self.checkEvents(symbol)
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
         networkId = self.safe_string(info, 'networkId')
@@ -951,7 +948,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             if (networkId is not None) and (marketId is not None) and (outcomeId is not None):
                 composite = networkId + ':' + marketId + '/' + outcomeId
             outcomeObj = self.safeOutcome(composite, market)
-            symbol = self.safe_string(outcomeObj, 'symbol')
+            symbol = self.safe_string(outcomeObj, 'outcome')
         return self.safePredictionOrder({
             'id': orderHash,
             'clientOrderId': None,
@@ -959,10 +956,10 @@ class myriad(PredictionExchange, ImplicitAPI):
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
             'lastTradeTimestamp': None,
-            'symbol': symbol,
+            'outcome': symbol,
             'outcomeId': self.safe_string(outcomeObj, 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'type': 'market' if isMarketTif else 'limit',
             'timeInForce': tif,
             'postOnly': (tif == 'PO'),
@@ -992,7 +989,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         """
         if self.privateKey is None:
             raise ArgumentsRequired(self.id + ' cancelOrder() requires a privateKey to sign the cancellation')
-        await self.load_markets()
         fetched = await self.myriadPublicGetOrdersHash(self.extend({'hash': id}, params))
         rawOrder = self.safe_dict(fetched, 'order', {})
         networkId = self.safe_string_2(fetched, 'networkId', 'network_id', self.safe_string(self.options, 'defaultNetworkId', '56'))
@@ -1025,7 +1021,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         """
         if self.privateKey is None:
             raise ArgumentsRequired(self.id + ' cancelAllOrders() requires a privateKey to sign the cancellation')
-        await self.load_markets()
         trader = self.eth_get_address_from_private_key(self.privateKey)
         marketId = self.safe_string(params, 'market_id', '0')
         networkId = self.safe_string(params, 'network_id', self.safe_string(self.options, 'defaultNetworkId', '56'))
@@ -1065,7 +1060,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         """
         if self.privateKey is None:
             raise ArgumentsRequired(self.id + ' cancelOrders() requires a privateKey to sign the cancellations')
-        await self.load_markets()
         idsLength = len(ids)
         signedOrders = []
         wrappers = []
@@ -1097,7 +1091,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: an [order structure](https://docs.ccxt.com/#/?id=order-structure)
         """
-        await self.load_markets()
         response = await self.myriadPublicGetOrdersHash(self.extend({'hash': id}, params))
         market = None
         if symbol is not None:
@@ -1119,7 +1112,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param str [params.status]: 'open', 'filled', 'cancelled' or 'expired'
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
-        await self.load_markets()
         request: dict = {}
         trader = self.safe_string(params, 'trader')
         if trader is None:
@@ -1230,7 +1222,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             'info': self.safe_dict(order, 'info', {}),
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': self.safe_string(order, 'outcome'),
+            'outcome': self.safe_string(order, 'outcome'),
             'outcomeId': self.safe_string(order, 'outcomeId'),
             'label': self.safe_string(order, 'label'),
             'market': self.safe_string(order, 'market'),
@@ -1306,10 +1298,10 @@ class myriad(PredictionExchange, ImplicitAPI):
             'id': txHash,
             'clientOrderId': None,
             'info': self.extend({'transactionHash': txHash}, self.safe_dict(quote, 'info', {})),
-            'symbol': self.safe_string(market, 'symbol'),
+            'outcome': self.safe_string(market, 'outcome'),
             'outcomeId': self.safe_string(market, 'id'),
             'label': self.safe_string(market, 'label'),
-            'market': self.safe_string(market, 'marketSymbol'),
+            'market': self.safe_string(market, 'outcome'),
             'type': 'market',
             'side': side,
             'price': self.safe_number(quote, 'priceAverage'),
@@ -1337,6 +1329,8 @@ class myriad(PredictionExchange, ImplicitAPI):
             'title': self.safe_string_2(raw, 'title', 'shortName'),
             'description': self.safe_string(raw, 'description'),
             'markets': [market],
+            'volume': self.safe_number_2(raw, 'volumeNotional24h', 'volume24h'),
+            'liquidity': self.safe_number(raw, 'liquidity'),
             'url': None,
             'image': self.safe_string(raw, 'imageUrl'),
             'active': (state == 'open'),
@@ -1392,9 +1386,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             outcomes.append({
                 'id': outcomeCompositeId,
                 'outcomeId': outcomeCompositeId,
-                'symbol': outcomeHandle,
                 'outcome': outcomeHandle,
-                'marketSymbol': marketSymbol,
                 'market': marketSymbol,
                 'label': outcomeLabel,
                 'active': active,
@@ -1483,7 +1475,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :returns dict: a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
         """
         outcome = symbol
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(outcome)
         networkId = self.safe_string(outcomeObj['info'], 'networkId')
@@ -1568,7 +1559,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         #
         return self.parse_ticker(response, outcomeObj)
 
-    async def fetch_trading_fee(self, symbol: str, params={}) -> TradingFeeInterface:
+    async def fetch_trading_fee(self, symbol: str, params={}) -> PredictionTradingFee:
         """
         fetches the buy/sell fee rates for a market outcome
 
@@ -1579,7 +1570,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :returns dict: a [fee structure](https://docs.ccxt.com/#/?id=fee-structure)
         """
         outcome = symbol
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(outcome)
         info = self.safe_dict(outcomeObj, 'info', {})
@@ -1601,7 +1591,8 @@ class myriad(PredictionExchange, ImplicitAPI):
         sell = self.safe_dict(fees, 'sell', {})
         return {
             'info': response,
-            'symbol': self.safe_symbol(None, outcomeObj),
+            'outcome': self.safeOutcomeSymbol(None, outcomeObj),
+            'outcomeId': self.safe_string(outcomeObj, 'outcomeId'),
             'maker': self.safe_number(sell, 'fee'),
             'taker': self.safe_number(buy, 'fee'),
             'percentage': True,
@@ -1701,10 +1692,10 @@ class myriad(PredictionExchange, ImplicitAPI):
                 break
         now = self.milliseconds()
         return self.safePredictionTicker({
-            'symbol': self.safe_string(market, 'symbol'),
+            'outcome': self.safe_string(market, 'outcome'),
             'outcomeId': self.safe_string(market, 'id'),
             'label': self.safe_string(market, 'label'),
-            'market': self.safe_string(market, 'marketSymbol'),
+            'market': self.safe_string(market, 'outcome'),
             'timestamp': now,
             'datetime': self.iso8601(now),
             'high': None,
@@ -1726,7 +1717,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             'info': raw,
         }, market)
 
-    async def fetch_order_book(self, symbol: str, limit: Int = None, params={}) -> OrderBook:
+    async def fetch_order_book(self, symbol: str, limit: Int = None, params={}) -> PredictionOrderBook:
         """
         fetches the real order book for order-book markets, or synthesizes a one-level book from the AMM price otherwise
 
@@ -1738,7 +1729,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :returns dict: an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
         """
         outcome = symbol
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(outcome)
         networkId = self.safe_string(outcomeObj['info'], 'networkId')
@@ -1758,7 +1748,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             #         "asks": [["990000000000000000", "151975683890577539072"]]
             #     }
             #
-            return self.parse_wei_order_book(obResponse, self.safeOutcomeSymbol(outcome, outcomeObj))
+            return self.safePredictionOrderBook(self.parse_wei_order_book(obResponse, self.safeOutcomeSymbol(outcome, outcomeObj)), outcomeObj)
         request: dict = {
             'id': marketId,
             'network_id': networkId,
@@ -1861,16 +1851,17 @@ class myriad(PredictionExchange, ImplicitAPI):
         asks: List[Any] = []
         if ask is not None:
             asks.append([ask, synthSize])
-        return {
-            'symbol': self.safeOutcomeSymbol(outcome, outcomeObj),
+        orderbook = {
+            'outcome': self.safeOutcomeSymbol(outcome, outcomeObj),
             'bids': bids,
             'asks': asks,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
             'nonce': None,
         }
+        return self.safePredictionOrderBook(orderbook, outcomeObj)
 
-    def parse_wei_order_book(self, response: dict, symbol: Str) -> OrderBook:
+    def parse_wei_order_book(self, response: dict, symbol: Str) -> PredictionOrderBook:
         """
  @ignore
         parses an order book whose price and amount levels are 1e18-scaled integer strings
@@ -1894,7 +1885,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             asks.append([self.parse_number(rowPrice), self.parse_number(rowAmount)])
         timestamp = self.milliseconds()
         return {
-            'symbol': symbol,
+            'outcome': symbol,
             'bids': self.sort_by(bids, 0, True),
             'asks': self.sort_by(asks, 0),
             'timestamp': timestamp,
@@ -1915,7 +1906,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns int[][]: a list of candles ordered, open, high, low, close, volume
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(symbol)
         outcomeInfo = self.safe_dict(outcomeObj, 'info', {})
@@ -2048,7 +2038,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         result: PredictionTickers = {}
         if symbols is None:
@@ -2114,7 +2103,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=public-trades)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
@@ -2183,10 +2171,10 @@ class myriad(PredictionExchange, ImplicitAPI):
             'info': trade,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': self.safe_string(market, 'symbol'),
+            'outcome': self.safe_string(market, 'outcome'),
             'outcomeId': self.safe_string(market, 'id'),
             'label': self.safe_string(market, 'label'),
-            'market': self.safe_string(market, 'marketSymbol'),
+            'market': self.safe_string(market, 'outcome'),
             'order': None,
             'type': None,
             'side': self.safe_string(trade, 'action'),
@@ -2197,7 +2185,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             'fee': None,
         }, market)
 
-    async def fetch_events(self, params={}) -> List[PredictionEvent]:
+    async def fetch_events(self, params: fetchEventsParams = {}) -> List[PredictionEvent]:
         """
         fetches prediction-market events matching the given search terms(or all open markets when omitted) and caches their markets and outcomes on the instance
 
@@ -2211,12 +2199,13 @@ class myriad(PredictionExchange, ImplicitAPI):
         :returns dict[]: an array of event structures
         """
         queries = self.parseSearchQueries(params)
-        rest = self.omit(params, ['query', 'queries'])
+        rest = self.omit(params, ['query', 'queries', 'sort', 'searchIn', 'eventId', 'slug', 'status'])
         queriesLength = len(queries)
         if queriesLength == 0:
-            await self.load_markets()
             self.populate_outcomes()
-            return list(self.events.values())
+            # hoist Object.values to a local — inline call argument breaks the php regex transpiler
+            existingEvents = list(self.events.values())
+            return self.applyEventFetchParams(existingEvents, params, queries)
         rawMarkets = await self.fetch_raw_markets_by_search(queries, rest)
         if not self.events:
             self.events = {}
@@ -2233,7 +2222,7 @@ class myriad(PredictionExchange, ImplicitAPI):
                 self.events[evKey] = ev
                 result.append(ev)
         self.populate_outcomes()
-        return result
+        return self.applyEventFetchParams(result, params, queries)
 
     def ensure_outcomes_loaded(self):
         """
@@ -2258,10 +2247,15 @@ class myriad(PredictionExchange, ImplicitAPI):
             outcomesList = self.safe_list(market, 'outcomes', [])
             for j in range(0, len(outcomesList)):
                 oc = outcomesList[j]
-                ocSymbol = self.safe_string(oc, 'symbol')
+                # accept the legacy symbol/id keys too: in Go/C#/Java the prediction
+                # setMarkets override is not dispatched, so oc is not pre-normalized
+                ocSymbol = self.safe_string_2(oc, 'outcome', 'symbol')
+                ocId = self.safe_string_2(oc, 'outcomeId', 'id')
+                oc['outcome'] = ocSymbol
+                oc['outcomeId'] = ocId
+                oc['market'] = self.safe_string_2(oc, 'market', 'marketSymbol')
                 if ocSymbol is not None:
                     self.outcomes[ocSymbol] = oc
-                ocId = self.safe_string(oc, 'id')
                 if ocId is not None:
                     self.outcomes_by_id[ocId] = oc
 
@@ -2286,6 +2280,8 @@ class myriad(PredictionExchange, ImplicitAPI):
             'title': self.safe_string(rawEvent, 'title'),
             'description': self.safe_string(rawEvent, 'description'),
             'markets': marketsList,
+            'volume': self.safe_number_2(rawEvent, 'volumeNotional24h', 'volume24h'),
+            'liquidity': self.safe_number(rawEvent, 'liquidity'),
             'url': self.safe_string(rawEvent, 'url'),
             'image': self.safe_string(rawEvent, 'imageUrl', self.safe_string(rawEvent, 'image')),
             'active': self.safe_bool(rawEvent, 'active'),
@@ -2322,7 +2318,7 @@ class myriad(PredictionExchange, ImplicitAPI):
             return None
         ocId = networkId + ':' + marketId + '/' + outcomeId
         outcomeObj = self.safe_dict(self.outcomes_by_id, ocId)
-        return self.safe_string(outcomeObj, 'symbol')
+        return self.safe_string(outcomeObj, 'outcome')
 
     async def connect_centrifugo(self, url: str) -> Any:
         # Centrifugo requires an anonymous connect command before any subscribe. This sends it once per
@@ -2402,7 +2398,7 @@ class myriad(PredictionExchange, ImplicitAPI):
         elif channelType == 'positions':
             self.handle_position(client, data)
 
-    async def watch_order_book(self, symbol: str, limit: Int = None, params={}) -> OrderBook:
+    async def watch_order_book(self, symbol: str, limit: Int = None, params={}) -> PredictionOrderBook:
         """
         streams the order book for an outcome over the Centrifugo websocket; the channel is delta-only so the book is seeded from the REST snapshot
 
@@ -2413,7 +2409,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
@@ -2489,7 +2484,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=public-trades)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
@@ -2516,7 +2510,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         """
         if symbol is None:
             raise ArgumentsRequired(self.id + ' watchMyTrades() requires a symbol(the trades channel is per-market)')
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
@@ -2556,10 +2549,10 @@ class myriad(PredictionExchange, ImplicitAPI):
             'info': data,
             'timestamp': ts,
             'datetime': self.iso8601(ts),
-            'symbol': sym,
+            'outcome': sym,
             'outcomeId': self.safe_string(outcomeObj, 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'order': self.safe_string(taker, 'orderHash'),
             'type': None,
             'side': self.safe_string_lower(taker, 'side'),
@@ -2602,10 +2595,10 @@ class myriad(PredictionExchange, ImplicitAPI):
                         'info': maker,
                         'timestamp': ts,
                         'datetime': self.iso8601(ts),
-                        'symbol': makerSym,
+                        'outcome': makerSym,
                         'outcomeId': self.safe_string(makerOutcomeObj, 'id'),
                         'label': self.safe_string(makerOutcomeObj, 'label'),
-                        'market': self.safe_string(makerOutcomeObj, 'marketSymbol'),
+                        'market': self.safe_string(makerOutcomeObj, 'outcome'),
                         'order': self.safe_string(maker, 'orderHash'),
                         'type': None,
                         'side': self.safe_string_lower(maker, 'side'),
@@ -2639,7 +2632,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         outcomeObj = self.outcome(symbol)
         info = self.safe_dict(outcomeObj, 'info', {})
@@ -2660,7 +2652,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dict of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by symbol
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         if symbols is None:
             raise ArgumentsRequired(self.id + ' watchTickers() requires a list of symbols(the prices channel is per-market)')
@@ -2726,10 +2717,10 @@ class myriad(PredictionExchange, ImplicitAPI):
             outcomeObj = self.safeOutcome(sym)
             last = self.from_wei(self.safe_string(oc, 'last'))
             ticker = self.safePredictionTicker({
-                'symbol': sym,
+                'outcome': sym,
                 'outcomeId': self.safe_string(outcomeObj, 'id'),
                 'label': self.safe_string(outcomeObj, 'label'),
-                'market': self.safe_string(outcomeObj, 'marketSymbol'),
+                'market': self.safe_string(outcomeObj, 'outcome'),
                 'timestamp': ts,
                 'datetime': self.iso8601(ts),
                 'high': None,
@@ -2766,7 +2757,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         trader = self.wallet_address_from_keys()
         networkId = self.safe_string(self.options, 'defaultNetworkId', '56')
@@ -2802,10 +2792,10 @@ class myriad(PredictionExchange, ImplicitAPI):
             'info': data,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': sym,
+            'outcome': sym,
             'outcomeId': self.safe_string(outcomeObj, 'id'),
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'type': 'market' if isMarketTif else 'limit',
             'timeInForce': tif,
             'side': self.safe_string_lower(data, 'side'),
@@ -2837,7 +2827,6 @@ class myriad(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
         """
-        await self.load_markets()
         self.ensure_outcomes_loaded()
         trader = self.wallet_address_from_keys()
         networkId = self.safe_string(self.options, 'defaultNetworkId', '56')
@@ -2899,10 +2888,10 @@ class myriad(PredictionExchange, ImplicitAPI):
         parsed = self.safePredictionPosition({
             'info': data,
             'id': posId,
-            'symbol': sym,
+            'outcome': sym,
             'outcomeId': posId,
             'label': self.safe_string(outcomeObj, 'label'),
-            'market': self.safe_string(outcomeObj, 'marketSymbol'),
+            'market': self.safe_string(outcomeObj, 'outcome'),
             'timestamp': ts,
             'datetime': self.iso8601(ts),
             'side': 'long',

--- a/python/ccxt/prediction/polymarket.py
+++ b/python/ccxt/prediction/polymarket.py
@@ -9,7 +9,7 @@ import asyncio
 import hashlib
 import math
 from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByOutcomeById
-from ccxt.base.types import Any, Balances, Int, Market, Num, OrderRequest, Str, Strings, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition
+from ccxt.base.types import Any, Balances, Int, Market, Num, OrderRequest, Str, Strings, PredictionEvent, fetchEventsParams, PredictionTicker, PredictionTickers, PredictionOrder, PredictionOrderBook, PredictionTrade, PredictionPosition, PredictionTradingFee, PredictionOpenInterest
 from typing import List
 from ccxt.base.errors import AuthenticationError
 from ccxt.base.errors import ArgumentsRequired
@@ -913,10 +913,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         #
         timestamp = self.safe_integer(response, 'timestamp')
         orderbook = self.parse_order_book(response, self.safeOutcomeSymbol(outcome, outcomeObj), timestamp, 'bids', 'asks', 'price', 'size')
-        orderbook['outcome'] = self.safe_string(outcomeObj, 'outcome')
-        orderbook['outcomeId'] = self.safe_string(outcomeObj, 'outcomeId')
-        orderbook['market'] = self.safe_string(outcomeObj, 'market')
-        return orderbook
+        return self.safePredictionOrderBook(orderbook, outcomeObj)
 
     async def fetch_ohlcv(self, symbol: str, timeframe='1m', since: Int = None, limit: Int = None, params={}) -> List[list]:
         """

--- a/python/ccxt/prediction/polymarket.py
+++ b/python/ccxt/prediction/polymarket.py
@@ -9,7 +9,7 @@ import asyncio
 import hashlib
 import math
 from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByOutcomeById
-from ccxt.base.types import Any, Balances, Int, Market, Num, OrderBook, OrderRequest, Str, Strings, OpenInterest, TradingFeeInterface, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition
+from ccxt.base.types import Any, Balances, Int, Market, Num, OrderRequest, Str, Strings, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition
 from typing import List
 from ccxt.base.errors import AuthenticationError
 from ccxt.base.errors import ArgumentsRequired
@@ -346,12 +346,27 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict[]: an array of raw gamma event objects
         """
         pageSize = self.safe_integer(params, 'limit', 50)
-        rest = self.omit(params, ['limit'])
+        # map the unified sort/status onto the gamma search params
+        sort = self.safe_string(params, 'sort')
+        sortParam = 'volume'
+        if sort == 'liquidity':
+            sortParam = 'liquidity'
+        elif sort == 'newest':
+            sortParam = 'startDate'
+        status = self.safe_string(params, 'status', 'active')
+        eventsStatus = 'active'
+        if (status == 'closed') or (status == 'inactive'):
+            eventsStatus = 'closed'
+        elif status == 'all':
+            eventsStatus = None
+        rest = self.omit(params, ['limit', 'sort', 'status', 'searchIn', 'eventId', 'slug', 'query', 'queries'])
         seen: dict = {}
         rawEvents: List[Any] = []
         for qi in range(0, len(queries)):
             q = queries[qi]
-            baseRequest: dict = {'q': q, 'limit_per_type': pageSize, 'events_status': 'active'}
+            baseRequest: dict = {'q': q, 'limit_per_type': pageSize, 'sort': sortParam, 'ascending': False}
+            if eventsStatus is not None:
+                baseRequest['events_status'] = eventsStatus
             firstRequest: dict = {'page': 1}
             firstRequest = self.extend(self.extend(firstRequest, baseRequest), rest)
             first = await self.gammaPublicGetPublicSearch(firstRequest)
@@ -402,13 +417,23 @@ class polymarket(PredictionExchange, ImplicitAPI):
         limit = self.safe_integer(params, 'limit', self.safe_integer(self.options, 'fetchMarketsLimit', 1000))
         maxPages = int(math.ceil(limit / pageSize))
         status = self.safe_string(params, 'status', self.safe_string(self.options, 'defaultEventStatus', 'active'))
-        rest = self.omit(params, ['status', 'limit'])
-        baseRequest: dict = {'limit': pageSize, 'order': 'volume24hr', 'ascending': False}
+        # sort maps to the gamma `order` field; 'volume' is the default ranking
+        sort = self.safe_string(params, 'sort')
+        order = 'volume'
+        if sort == 'liquidity':
+            order = 'liquidity'
+        elif sort == 'newest':
+            order = 'startDate'
+        rest = self.omit(params, ['status', 'limit', 'sort', 'searchIn', 'eventId', 'slug', 'query', 'queries'])
+        baseRequest: dict = {'limit': pageSize, 'order': order, 'ascending': False}
         baseRequest = self.extend(baseRequest, rest)
         if status == 'active':
             baseRequest['active'] = True
-        elif status == 'closed':
+            baseRequest['closed'] = False
+        elif (status == 'closed') or (status == 'inactive'):
+            baseRequest['active'] = False
             baseRequest['closed'] = True
+        # 'all' — no active/closed filter
         # fetch page 1 first; if full, fire remaining pages in parallel
         firstPageRequest: dict = {'offset': 0}
         firstPageRequest = self.extend(firstPageRequest, baseRequest)
@@ -654,7 +679,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict: a [ticker structure](https://docs.ccxt.com/#/?id=ticker-structure)
         """
         outcome = symbol
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         tokenId = outcomeObj['outcomeId']
         promises = [
@@ -714,9 +739,9 @@ class polymarket(PredictionExchange, ImplicitAPI):
             outcomesLength = len(outcomes)
         if outcomesLength > 0:
             for i in range(0, len(outcomes)):
-                self.checkEventsAndMarkets(outcomes[i])
+                self.checkEvents(outcomes[i])
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         outcomesMap = self.outcomes if (self.outcomes is not None) else {}
         targets: List[Any] = []
         if outcomes is not None:
@@ -822,7 +847,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         if market is not None:
             quoteVolume = self.safe_number_2(market['info'], 'volume24hr', 'volume')
         return self.safePredictionTicker({
-            'symbol': symbol,
+            'outcome': symbol,
             'outcomeId': self.safe_string(market, 'outcomeId'),
             'label': self.safe_string(market, 'label'),
             'market': self.safe_string(market, 'market'),
@@ -847,7 +872,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             'info': ticker,
         }, market)
 
-    async def fetch_order_book(self, symbol: str, limit: Int = None, params={}) -> OrderBook:
+    async def fetch_order_book(self, symbol: str, limit: Int = None, params={}) -> PredictionOrderBook:
         """
         fetches the CLOB order book for a single outcome token
 
@@ -859,7 +884,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict: an [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
         """
         outcome = symbol
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         tokenId = outcomeObj['outcomeId']
         request: dict = {
@@ -907,7 +932,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns int[][]: a list of candles ordered, open, high, low, close, volume
         """
         outcome = symbol
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         tokenId = outcomeObj['outcomeId']
         fidelityMin = self.safe_integer(self.timeframes, timeframe, 1)  # fidelity in minutes
@@ -1022,7 +1047,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             'info': response,
         }
 
-    async def fetch_open_interest(self, symbol: str, params={}) -> OpenInterest:
+    async def fetch_open_interest(self, symbol: str, params={}) -> PredictionOpenInterest:
         """
         fetches the open interest of a prediction market outcome
 
@@ -1033,7 +1058,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict: an [open interest structure](https://docs.ccxt.com/#/?id=open-interest-structure)
         """
         outcome = symbol
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         outcomeInfo = self.safe_dict(outcomeObj, 'info', {})
         conditionId = self.safe_string(outcomeInfo, 'conditionId')
@@ -1047,12 +1072,12 @@ class polymarket(PredictionExchange, ImplicitAPI):
         first = self.safe_dict(response, 0, {})
         return self.parse_open_interest(first, outcomeObj)
 
-    def parse_open_interest(self, interest, market: Market = None) -> OpenInterest:
+    def parse_open_interest(self, interest, market: Market = None) -> PredictionOpenInterest:
         #
         #     {"market": "0x7976b8...92", "value": 4925662.470476}
         #
         timestamp = self.milliseconds()
-        return self.safe_open_interest({
+        openInterest = self.safe_open_interest({
             'symbol': self.safeOutcomeSymbol(None, market),
             'openInterestAmount': None,
             'openInterestValue': self.safe_number(interest, 'value'),
@@ -1062,8 +1087,12 @@ class polymarket(PredictionExchange, ImplicitAPI):
             'datetime': self.iso8601(timestamp),
             'info': interest,
         }, market)
+        openInterest['outcome'] = self.safeOutcomeSymbol(None, market)
+        openInterest['outcomeId'] = self.safe_string(market, 'outcomeId')
+        del openInterest['symbol']
+        return openInterest
 
-    async def fetch_trading_fee(self, symbol: str, params={}) -> TradingFeeInterface:
+    async def fetch_trading_fee(self, symbol: str, params={}) -> PredictionTradingFee:
         """
         fetches the base fee rate for a prediction market outcome token
 
@@ -1074,7 +1103,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict: a [fee structure](https://docs.ccxt.com/#/?id=fee-structure)
         """
         outcome = symbol
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         tokenId = self.safe_string(outcomeObj, 'outcomeId')
         request: dict = {'token_id': tokenId}
@@ -1086,7 +1115,8 @@ class polymarket(PredictionExchange, ImplicitAPI):
         rate = self.parse_number(Precise.string_div(baseFeeBps, '10000')) if (baseFeeBps is not None) else None
         return {
             'info': response,
-            'symbol': self.safeOutcomeSymbol(None, outcomeObj),
+            'outcome': self.safeOutcomeSymbol(None, outcomeObj),
+            'outcomeId': self.safe_string(outcomeObj, 'outcomeId'),
             'maker': rate,
             'taker': rate,
             'percentage': True,
@@ -1106,7 +1136,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=public-trades)
         """
         outcome = symbol
-        self.checkEventsAndMarkets(outcome)
+        self.checkEvents(outcome)
         outcomeObj = self.outcome(outcome)
         tokenId = outcomeObj['outcomeId']
         outcomeInfo = self.safe_dict(outcomeObj, 'info', {})
@@ -1147,7 +1177,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         request: dict = {}
         outcomeObj: Any = None
         if symbol is not None:
-            self.checkEventsAndMarkets(symbol)
+            self.checkEvents(symbol)
             outcomeObj = self.outcome(symbol)
             request['asset_id'] = outcomeObj['outcomeId']
         response = await self.clobPrivateGetDataTrades(self.extend(request, params))
@@ -1218,7 +1248,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
             'info': trade,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': symbol,
             'outcome': symbol,
             'outcomeId': assetId,
             'label': self.safe_string(mkt, 'label'),
@@ -1290,9 +1319,9 @@ class polymarket(PredictionExchange, ImplicitAPI):
             outcomesLength = len(outcomes)
         if outcomesLength > 0:
             for i in range(0, len(outcomes)):
-                self.checkEventsAndMarkets(outcomes[i])
+                self.checkEvents(outcomes[i])
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         if self.walletAddress is None:
             raise ArgumentsRequired(self.id + ' walletAddress is required to fetchPositions')
         request = {
@@ -1349,7 +1378,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             notional = size * curPrice
         return self.safePredictionPosition({
             'id': self.safe_string(position, 'id'),
-            'symbol': marketData['outcome'],
+            'outcome': marketData['outcome'],
             'outcomeId': marketData['outcomeId'],
             'market': marketData['market'],
             'label': marketData['label'],
@@ -1394,9 +1423,9 @@ class polymarket(PredictionExchange, ImplicitAPI):
         await self.load_api_credentials()
         outcome = symbol
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         request: dict = {}
         outcomeObj: Any = None
         if outcome is not None:
@@ -1420,9 +1449,9 @@ class polymarket(PredictionExchange, ImplicitAPI):
         await self.load_api_credentials()
         outcome = symbol
         if outcome is not None:
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
         else:
-            self.checkEventsAndMarkets()
+            self.checkEvents()
         request: dict = {'id': id}
         response = await self.clobPrivateGetDataOrderId(self.extend(request, params))
         return self.parse_order(response)
@@ -1463,7 +1492,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             'datetime': self.iso8601(ts),
             'lastTradeTimestamp': None,
             'status': status,
-            'symbol': mkt['outcome'],
+            'outcome': mkt['outcome'],
             'outcomeId': self.safe_string(mkt, 'outcomeId'),
             'label': self.safe_string(mkt, 'label'),
             'market': self.safe_string(mkt, 'market'),
@@ -1847,7 +1876,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         response = None
         if outcome is not None:
             # scope to a single outcome token via DELETE /cancel-market-orders {asset_id}
-            self.checkEventsAndMarkets(outcome)
+            self.checkEvents(outcome)
             outcomeObj = self.outcome(outcome)
             request: dict = {'asset_id': outcomeObj['outcomeId']}
             response = await self.clobPrivateDeleteCancelMarketOrders(self.extend(request, params))
@@ -1860,7 +1889,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             orders.append(self.safePredictionOrder({'id': self.safe_string(canceled, i), 'status': 'canceled', 'info': response}))
         return orders
 
-    async def fetch_events(self, params={}) -> List[PredictionEvent]:
+    async def fetch_events(self, params: fetchEventsParams = {}) -> List[PredictionEvent]:
         """
         fetches prediction-market events matching the given search terms(or all active events when omitted) and caches their markets and outcomes on the instance
 
@@ -1868,16 +1897,32 @@ class polymarket(PredictionExchange, ImplicitAPI):
         https://docs.polymarket.com/api-reference/events/list-events
 
         :param dict [params]: extra exchange-specific parameters
-        :param str [params.query]: a single search term; when omitted(and no queries) the most active events are returned(capped)
+        :param str [params.query]: a single keyword search term
         :param str[] [params.queries]: multiple search terms(alternative to query)
-        :param int [params.limit]: when searching, page size per query(default 50); when omitted, max events to fetch(default options.fetchMarketsLimit, 1000), ordered by 24h volume
+        :param int [params.limit]: max number of events to return
+        :param str [params.sort]: 'volume'(default), 'liquidity' or 'newest' — mapped to the gamma order field
+        :param str [params.status]: 'active'(default), 'inactive', 'closed' or 'all'('inactive' and 'closed' are interchangeable)
+        :param str [params.searchIn]: when searching, restrict the match to 'title'(default), 'description' or 'both'
+        :param str [params.eventId]: direct lookup by event id(short-circuits the listing/search)
+        :param str [params.slug]: direct lookup by event slug
         :returns dict[]: an array of event structures
         """
+        requestedEventId = self.safe_string(params, 'eventId')
+        requestedSlug = self.safe_string(params, 'slug')
         queries = self.parseSearchQueries(params)
-        rest = self.omit(params, ['query', 'queries'])
+        rest = self.omit(params, ['query', 'queries', 'eventId', 'slug'])
         queriesLength = len(queries)
         rawEvents: List[Any] = []
-        if queriesLength > 0:
+        if (requestedEventId is not None) or (requestedSlug is not None):
+            # direct lookup by event id or slug via the events endpoint(returns a list)
+            lookup: dict = {}
+            if requestedEventId is not None:
+                lookup['id'] = requestedEventId
+            else:
+                lookup['slug'] = requestedSlug
+            response = await self.gammaPublicGetEvents(lookup)
+            rawEvents = response if (response is not None) else []
+        elif queriesLength > 0:
             rawEvents = await self.fetch_raw_events_by_search(queries, rest)
         else:
             rawEvents = await self.fetch_raw_events_list(rest)
@@ -1921,13 +1966,22 @@ class polymarket(PredictionExchange, ImplicitAPI):
             outcomesList = self.safe_list(market, 'outcomes', [])
             for j in range(0, len(outcomesList)):
                 oc = outcomesList[j]
-                ocSymbol = self.safe_string(oc, 'symbol')
+                ocSymbol = self.safe_string(oc, 'outcome')
                 if ocSymbol is not None:
                     self.outcomes[ocSymbol] = oc
-                ocId = self.safe_string(oc, 'id')
+                ocId = self.safe_string(oc, 'outcomeId')
                 if ocId is not None:
                     self.outcomes_by_id[ocId] = oc
-        return result
+        # the gamma search endpoint is fuzzy, so refine the search path by status and searchIn
+        # client-side(searchIn defaults to 'title', matching the reference behaviour)
+        filtered = result
+        if queriesLength > 0:
+            filtered = self.filterEventsByStatus(filtered, self.safe_string(params, 'status', 'active'))
+            filtered = self.filterEventsBySearchIn(filtered, queries, self.safe_string(params, 'searchIn', 'title'))
+        finalLimit = self.safe_integer(params, 'limit')
+        if finalLimit is not None:
+            filtered = self.array_slice(filtered, 0, finalLimit)
+        return filtered
 
     async def fetch_event(self, id: str, params={}) -> PredictionEvent:
         """
@@ -2315,7 +2369,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             'asks': asks,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': symbol,
+            'outcome': symbol,
         })
         client.resolve(orderbook, 'orderbook::' + symbol)
         client.resolve(orderbook, 'ticker::' + symbol)
@@ -2362,7 +2416,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             'info': event,
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
-            'symbol': symbol,
+            'outcome': symbol,
             'outcomeId': self.safe_string(market, 'outcomeId'),
             'label': self.safe_string(market, 'label'),
             'market': self.safe_string(market, 'market'),
@@ -2385,7 +2439,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         stored.append(trade)
         client.resolve(stored, 'trades::' + symbol)
 
-    async def watch_order_book(self, symbol: Str, limit: Int = None, params={}) -> OrderBook:
+    async def watch_order_book(self, symbol: Str, limit: Int = None, params={}) -> PredictionOrderBook:
         """
         streams live order-book updates for a single Polymarket outcome token
         :param str symbol: unified outcome symbol(e.g. "ELECTION/YES:USDC")
@@ -2394,7 +2448,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict: an `order book structure <https://docs.ccxt.com/#/?id=order-book-structure>`
         """
         outcome = symbol
-        await self.load_markets()
         outcomeObj = self.outcome(outcome)
         tokenId = self.safe_string(outcomeObj, 'outcomeId')
         symbol = self.safe_string(outcomeObj, 'outcome')
@@ -2415,7 +2468,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict[]: a list of `trade structures <https://docs.ccxt.com/#/?id=public-trades>`
         """
         outcome = symbol
-        await self.load_markets()
         outcomeObj = self.outcome(outcome)
         tokenId = self.safe_string(outcomeObj, 'outcomeId')
         symbol = self.safe_string(outcomeObj, 'outcome')
@@ -2434,7 +2486,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :returns dict: a `ticker structure <https://docs.ccxt.com/#/?id=ticker-structure>`
         """
         outcome = symbol
-        await self.load_markets()
         outcomeObj = self.outcome(outcome)
         tokenId = self.safe_string(outcomeObj, 'outcomeId')
         symbol = self.safe_string(outcomeObj, 'outcome')
@@ -2473,7 +2524,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             mid = bestAsk
         market = self.safeOutcome(symbol)
         return self.safePredictionTicker({
-            'symbol': symbol,
+            'outcome': symbol,
             'outcomeId': self.safe_string(market, 'outcomeId'),
             'label': self.safe_string(market, 'label'),
             'market': self.safe_string(market, 'market'),
@@ -2510,7 +2561,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [order structures](https://docs.ccxt.com/#/?id=order-structure)
         """
-        await self.load_markets()
         await self.load_api_credentials()
         messageHash = 'orders'
         if symbol is not None:
@@ -2534,7 +2584,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [trade structures](https://docs.ccxt.com/#/?id=trade-structure)
         """
-        await self.load_markets()
         await self.load_api_credentials()
         messageHash = 'myTrades'
         if symbol is not None:

--- a/python/ccxt/prediction/polymarket.py
+++ b/python/ccxt/prediction/polymarket.py
@@ -1125,7 +1125,11 @@ class polymarket(PredictionExchange, ImplicitAPI):
             tradeAsset = self.safe_string(trade, 'asset')
             if tradeAsset == tokenId:
                 filteredTrades.append(trade)
-        return self.parse_trades(filteredTrades, outcomeObj, since, limit)
+        # the trades are already narrowed to self outcome by asset id above; pass no market so the
+        # base parseTrades doesn't apply its symbol filter(prediction trades carry `outcome`, not
+        # `symbol`, so a symbol-bearing outcome object would drop them all). parseTrade resolves the
+        # outcome from each trade's asset id.
+        return self.parse_trades(filteredTrades, None, since, limit)
 
     async def fetch_my_trades(self, symbol: Str = None, since: Int = None, limit: Int = None, params={}) -> List[PredictionTrade]:
         """

--- a/python/ccxt/prediction/polymarket.py
+++ b/python/ccxt/prediction/polymarket.py
@@ -722,7 +722,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
             outcomeObj
         )
 
-    async def fetch_tickers(self, symbols: Strings = None, params={}) -> PredictionTickers:
+    async def fetch_tickers(self, outcomes: Strings = None, params={}) -> PredictionTickers:
         """
         fetches tickers for multiple outcome tokens at once using the batched CLOB book and midpoint endpoints
 
@@ -733,7 +733,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict: a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
         """
-        outcomes = symbols
         outcomesLength = 0
         if outcomes is not None:
             outcomesLength = len(outcomes)
@@ -1300,7 +1299,7 @@ class polymarket(PredictionExchange, ImplicitAPI):
         }
         return self.safe_balance(result)
 
-    async def fetch_positions(self, symbols: Strings = None, params={}) -> List[PredictionPosition]:
+    async def fetch_positions(self, outcomes: Strings = None, params={}) -> List[PredictionPosition]:
         """
         fetches open outcome token positions for the wallet from the data API
 
@@ -1310,7 +1309,6 @@ class polymarket(PredictionExchange, ImplicitAPI):
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :returns dict[]: a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
         """
-        outcomes = symbols
         outcomesLength = 0
         if outcomes is not None:
             outcomesLength = len(outcomes)

--- a/python/ccxt/test/tests_helpers.py
+++ b/python/ccxt/test/tests_helpers.py
@@ -21,8 +21,10 @@ sys.path.append(root)
 import ccxt.async_support as ccxt  # noqa: E402
 import ccxt as ccxt_sync  # noqa: E402
 import ccxt.pro as ccxtpro  # noqa: E402
-import ccxt.prediction as ccxt_prediction_sync  # noqa: E402
-import ccxt.prediction.async_support as ccxt_prediction  # noqa: E402
+# prediction-market exchanges are async-only and live at ccxt.prediction.<id>
+# (there is no sync variant); see build/transpile.ts python2Folder=undefined for prediction
+ccxt_prediction_sync = None
+import ccxt.prediction as ccxt_prediction  # noqa: E402
 
 # ------------------------------------------------------------------------------
 # from typing import Optional

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3032,7 +3032,9 @@ export default class Exchange {
             result = [ ];
             for (let i = 0; i < parsedArray.length; i++) {
                 const entry = parsedArray[i];
-                const entryFiledEqualValue = entry[field] === value;
+                // safeValue (not entry[field]) so a missing field is a non-match, not a
+                // KeyError in python/php — prediction structures key on outcome, not symbol
+                const entryFiledEqualValue = this.safeValue (entry, field) === value;
                 const firstCondition = valueIsDefined ? entryFiledEqualValue : true;
                 const entryKeyValue = this.safeValue (entry, key);
                 const entryKeyGESince = (entryKeyValue) && (since !== undefined) && (entryKeyValue >= since);

--- a/ts/src/base/PredictionExchange.ts
+++ b/ts/src/base/PredictionExchange.ts
@@ -2,7 +2,7 @@
 
 import { Exchange } from './Exchange.js';
 import { ExchangeError, BadSymbol, NotSupported, ArgumentsRequired } from './errors.js';
-import type { Str, Strings, Num, Int, Bool, Dictionary, Ticker, OrderBook, OHLCV, Trade, Order, OrderType, OrderSide, Dict, PredictionTicker, PredictionOrder, PredictionTrade, PredictionPosition } from './types.js';
+import type { Str, Strings, Num, Int, Bool, Dictionary, Ticker, OrderBook, OHLCV, Trade, Order, OrderType, OrderSide, Dict, PredictionTicker, PredictionOrder, PredictionTrade, PredictionPosition, PredictionOrderBook, fetchEventsParams } from './types.js';
 
 // ----------------------------------------------------------------------------
 
@@ -149,7 +149,7 @@ export default class PredictionExchange extends Exchange {
         return result;
     }
 
-    async fetchEvents (params = {}): Promise<any[]> {
+    async fetchEvents (params: fetchEventsParams = {}): Promise<any[]> {
         throw new NotSupported (this.id + ' fetchEvents() is not supported yet');
     }
 
@@ -391,6 +391,18 @@ export default class PredictionExchange extends Exchange {
         return this.toPredictionStructure (parsed, position);
     }
 
+    safePredictionOrderBook (orderbook: Dict, outcomeObj: Dict = undefined): PredictionOrderBook {
+        // normalize a parsed order book to the prediction shape: replace the unified
+        // `symbol` with the `outcome` handle and attach the outcome identity fields
+        // (outcomeId / market) so books match the PredictionOrderBook structure.
+        const fallback = this.safeString2 (orderbook, 'outcome', 'symbol');
+        orderbook['outcome'] = (outcomeObj === undefined) ? fallback : this.safeString (outcomeObj, 'outcome', fallback);
+        orderbook['outcomeId'] = (outcomeObj === undefined) ? this.safeString (orderbook, 'outcomeId') : this.safeString (outcomeObj, 'outcomeId');
+        orderbook['market'] = (outcomeObj === undefined) ? this.safeString (orderbook, 'market') : this.safeString (outcomeObj, 'market');
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return this.omit (orderbook, 'symbol') as PredictionOrderBook;
+    }
+
     toPredictionStructure (parsed: Dict, raw: Dict): any {
         // rename the unified `symbol` to the prediction `outcome` handle and attach the
         // prediction identity fields (raw exchange id, label, parent market/event) that the
@@ -401,8 +413,8 @@ export default class PredictionExchange extends Exchange {
         parsed['label'] = this.safeString (raw, 'label');
         parsed['market'] = this.safeString (raw, 'market');
         parsed['event'] = this.safeString (raw, 'event');
-        delete parsed['symbol'];
-        return parsed;
+        // omit (not delete) — `del dict['symbol']` raises KeyError in python/php when absent
+        return this.omit (parsed, 'symbol');
     }
 
     filterByOutcomeSinceLimit (array, outcome: Str = undefined, since: Int = undefined, limit: Int = undefined, tail = false) {

--- a/ts/src/prediction/hyperliquid.ts
+++ b/ts/src/prediction/hyperliquid.ts
@@ -687,7 +687,8 @@ export default class hyperliquid extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure)
      */
-    async fetchTickers (outcomes: Strings = undefined, params = {}): Promise<PredictionTickers> {
+    async fetchTickers (symbols: Strings = undefined, params = {}): Promise<PredictionTickers> {
+        const outcomes = symbols;
         const requestedOutcomeSymbols = {};
         if (outcomes !== undefined) {
             for (let i = 0; i < outcomes.length; i++) {
@@ -841,9 +842,7 @@ export default class hyperliquid extends Exchange {
             asks.push ([ this.safeNumber (entry, 'px'), this.safeNumber (entry, 'sz') ]);
         }
         const orderbook = this.parseOrderBook ({ 'bids': bids, 'asks': asks }, this.safeString (outcomeObj, 'symbol', outcome), timestamp);
-        orderbook['outcome'] = this.safeString (outcomeObj, 'outcome');
-        orderbook['outcomeId'] = this.safeString (outcomeObj, 'outcomeId');
-        return orderbook as PredictionOrderBook;
+        return this.safePredictionOrderBook (orderbook, outcomeObj);
     }
 
     /**
@@ -992,7 +991,8 @@ export default class hyperliquid extends Exchange {
      * @param {string} [params.user] wallet address
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    async fetchPositions (outcomes: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
+    async fetchPositions (symbols: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
+        const outcomes = symbols;
         const requestedOutcomeSymbols = {};
         if (outcomes !== undefined) {
             for (let i = 0; i < outcomes.length; i++) {

--- a/ts/src/prediction/hyperliquid.ts
+++ b/ts/src/prediction/hyperliquid.ts
@@ -687,8 +687,7 @@ export default class hyperliquid extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure)
      */
-    async fetchTickers (symbols: Strings = undefined, params = {}): Promise<PredictionTickers> {
-        const outcomes = symbols;
+    async fetchTickers (outcomes: Strings = undefined, params = {}): Promise<PredictionTickers> {
         const requestedOutcomeSymbols = {};
         if (outcomes !== undefined) {
             for (let i = 0; i < outcomes.length; i++) {
@@ -991,8 +990,7 @@ export default class hyperliquid extends Exchange {
      * @param {string} [params.user] wallet address
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    async fetchPositions (symbols: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
-        const outcomes = symbols;
+    async fetchPositions (outcomes: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
         const requestedOutcomeSymbols = {};
         if (outcomes !== undefined) {
             for (let i = 0; i < outcomes.length; i++) {

--- a/ts/src/prediction/kalshi.ts
+++ b/ts/src/prediction/kalshi.ts
@@ -837,7 +837,7 @@ export default class kalshi extends Exchange {
                 asks.push ([ price, this.safeNumber (rawNo[ai], 1) ]);
             }
         }
-        return this.sortedOrders (this.safeString (outcomeObj, 'outcome', outcome), timestamp, bids, asks);
+        return this.safePredictionOrderBook (this.sortedOrders (this.safeString (outcomeObj, 'outcome', outcome), timestamp, bids, asks), outcomeObj);
     }
 
     /**

--- a/ts/src/prediction/kalshi.ts
+++ b/ts/src/prediction/kalshi.ts
@@ -703,7 +703,8 @@ export default class kalshi extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    async fetchTickers (symbols: Strings = undefined, params = {}): Promise<PredictionTickers> {
+    async fetchTickers (outcomes: Strings = undefined, params = {}): Promise<PredictionTickers> {
+        const symbols = outcomes;
         const targets: any[] = [];
         if (symbols !== undefined) {
             for (let i = 0; i < symbols.length; i++) {
@@ -1144,8 +1145,7 @@ export default class kalshi extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    async fetchPositions (symbols: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
-        const outcomes = symbols;
+    async fetchPositions (outcomes: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
         let outcomesLength = 0;
         if (outcomes !== undefined) {
             outcomesLength = outcomes.length;

--- a/ts/src/prediction/limitless.ts
+++ b/ts/src/prediction/limitless.ts
@@ -1237,14 +1237,15 @@ export default class limitless extends Exchange {
             }
             asks.push ([ this.parseNumber (priceStr), this.parseNumber (sizeStr) ]);
         }
-        return {
+        const orderbook = {
             'outcome': this.safeOutcomeSymbol (outcome, outcomeObj),
             'bids': this.sortBy (bids, 0, true),
             'asks': this.sortBy (asks, 0),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'nonce': undefined,
-        } as unknown as PredictionOrderBook;
+        };
+        return this.safePredictionOrderBook (orderbook, outcomeObj);
     }
 
     /**

--- a/ts/src/prediction/limitless.ts
+++ b/ts/src/prediction/limitless.ts
@@ -1043,7 +1043,8 @@ export default class limitless extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    async fetchTickers (symbols: Strings = undefined, params = {}): Promise<PredictionTickers> {
+    async fetchTickers (outcomes: Strings = undefined, params = {}): Promise<PredictionTickers> {
+        const symbols = outcomes;
         const result: PredictionTickers = {};
         if (symbols === undefined) {
             // parse tickers for every loaded outcome from the cached listing data, without the per-market order books
@@ -2446,7 +2447,8 @@ export default class limitless extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    async fetchPositions (symbols: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
+    async fetchPositions (outcomes: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
+        const symbols = outcomes;
         let symbolsLength = 0;
         if (symbols !== undefined) {
             symbolsLength = symbols.length;

--- a/ts/src/prediction/myriad.ts
+++ b/ts/src/prediction/myriad.ts
@@ -383,7 +383,8 @@ export default class myriad extends Exchange {
      * @param {string} [params.address] the wallet address to query, defaults to this.walletAddress
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    async fetchPositions (symbols: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
+    async fetchPositions (outcomes: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
+        const symbols = outcomes;
         const address = this.safeString2 (params, 'address', 'user', this.walletAddress);
         if (address === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchPositions() requires a walletAddress or an address parameter');
@@ -2232,7 +2233,8 @@ export default class myriad extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    async fetchTickers (symbols: Strings = undefined, params = {}): Promise<PredictionTickers> {
+    async fetchTickers (outcomes: Strings = undefined, params = {}): Promise<PredictionTickers> {
+        const symbols = outcomes;
         this.ensureOutcomesLoaded ();
         const result: PredictionTickers = {};
         if (symbols === undefined) {

--- a/ts/src/prediction/myriad.ts
+++ b/ts/src/prediction/myriad.ts
@@ -1916,7 +1916,7 @@ export default class myriad extends Exchange {
             //         "asks": [ [ "990000000000000000", "151975683890577539072" ] ]
             //     }
             //
-            return this.parseWeiOrderBook (obResponse, this.safeOutcomeSymbol (outcome, outcomeObj));
+            return this.safePredictionOrderBook (this.parseWeiOrderBook (obResponse, this.safeOutcomeSymbol (outcome, outcomeObj)), outcomeObj);
         }
         const request: Dict = {
             'id': marketId,
@@ -2027,14 +2027,15 @@ export default class myriad extends Exchange {
         if (ask !== undefined) {
             asks.push ([ ask, synthSize ]);
         }
-        return {
+        const orderbook = {
             'outcome': this.safeOutcomeSymbol (outcome, outcomeObj),
             'bids': bids,
             'asks': asks,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'nonce': undefined,
-        } as unknown as PredictionOrderBook;
+        };
+        return this.safePredictionOrderBook (orderbook, outcomeObj);
     }
 
     /**
@@ -2417,7 +2418,9 @@ export default class myriad extends Exchange {
         const queriesLength = queries.length;
         if (queriesLength === 0) {
             this.populateOutcomes ();
-            return this.applyEventFetchParams (Object.values (this.events as Dict) as any[], params, queries);
+            // hoist Object.values to a local — inline as a call argument breaks the php regex transpiler
+            const existingEvents = Object.values (this.events as Dict) as any[];
+            return this.applyEventFetchParams (existingEvents, params, queries);
         }
         const rawMarkets = await this.fetchRawMarketsBySearch (queries, rest);
         if (!this.events) {
@@ -2471,11 +2474,16 @@ export default class myriad extends Exchange {
             const outcomesList = this.safeList (market, 'outcomes', []) as any[];
             for (let j = 0; j < outcomesList.length; j++) {
                 const oc = outcomesList[j];
-                const ocSymbol = this.safeString (oc, 'outcome');
+                // accept the legacy symbol/id keys too: in Go/C#/Java the prediction
+                // setMarkets override is not dispatched, so oc is not pre-normalized
+                const ocSymbol = this.safeString2 (oc, 'outcome', 'symbol');
+                const ocId = this.safeString2 (oc, 'outcomeId', 'id');
+                oc['outcome'] = ocSymbol;
+                oc['outcomeId'] = ocId;
+                oc['market'] = this.safeString2 (oc, 'market', 'marketSymbol');
                 if (ocSymbol !== undefined) {
                     this.outcomes[ocSymbol] = oc;
                 }
-                const ocId = this.safeString (oc, 'outcomeId');
                 if (ocId !== undefined) {
                     this.outcomes_by_id[ocId] = oc;
                 }

--- a/ts/src/prediction/polymarket.ts
+++ b/ts/src/prediction/polymarket.ts
@@ -773,8 +773,7 @@ export default class polymarket extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures](https://docs.ccxt.com/#/?id=ticker-structure) indexed by outcome symbol
      */
-    async fetchTickers (symbols: Strings = undefined, params = {}): Promise<PredictionTickers> {
-        const outcomes = symbols;
+    async fetchTickers (outcomes: Strings = undefined, params = {}): Promise<PredictionTickers> {
         let outcomesLength = 0;
         if (outcomes !== undefined) {
             outcomesLength = outcomes.length;
@@ -1408,8 +1407,7 @@ export default class polymarket extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [position structures](https://docs.ccxt.com/#/?id=position-structure)
      */
-    async fetchPositions (symbols: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
-        const outcomes = symbols;
+    async fetchPositions (outcomes: Strings = undefined, params = {}): Promise<PredictionPosition[]> {
         let outcomesLength = 0;
         if (outcomes !== undefined) {
             outcomesLength = outcomes.length;

--- a/ts/src/prediction/polymarket.ts
+++ b/ts/src/prediction/polymarket.ts
@@ -972,10 +972,7 @@ export default class polymarket extends Exchange {
         //
         const timestamp = this.safeInteger (response, 'timestamp');
         const orderbook = this.parseOrderBook (response, this.safeOutcomeSymbol (outcome, outcomeObj), timestamp, 'bids', 'asks', 'price', 'size');
-        orderbook['outcome'] = this.safeString (outcomeObj, 'outcome');
-        orderbook['outcomeId'] = this.safeString (outcomeObj, 'outcomeId');
-        orderbook['market'] = this.safeString (outcomeObj, 'market');
-        return orderbook as PredictionOrderBook;
+        return this.safePredictionOrderBook (orderbook, outcomeObj);
     }
 
     /**

--- a/ts/src/prediction/polymarket.ts
+++ b/ts/src/prediction/polymarket.ts
@@ -1236,7 +1236,11 @@ export default class polymarket extends Exchange {
                 filteredTrades.push (trade);
             }
         }
-        return this.parseTrades (filteredTrades, outcomeObj, since, limit) as PredictionTrade[];
+        // the trades are already narrowed to this outcome by asset id above; pass no market so the
+        // base parseTrades doesn't apply its symbol filter (prediction trades carry `outcome`, not
+        // `symbol`, so a symbol-bearing outcome object would drop them all). parseTrade resolves the
+        // outcome from each trade's asset id.
+        return this.parseTrades (filteredTrades, undefined, since, limit) as PredictionTrade[];
     }
 
     /**

--- a/ts/src/test/static/response/kalshi.json
+++ b/ts/src/test/static/response/kalshi.json
@@ -68,8 +68,8 @@
 					"outcomeId": "KXELONMARS-99",
 					"label": "YES",
 					"market": "ELON_MUSK_VISIT_MARS_AUG_1_2099",
-					"timestamp": 1781895629840,
-					"datetime": "2026-06-19T19:00:29.840Z",
+					"timestamp": 1781915898497,
+					"datetime": "2026-06-20T00:38:18.497Z",
 					"high": null,
 					"low": null,
 					"bid": 0.08,
@@ -257,8 +257,8 @@
 						"outcomeId": "KXELONMARS-99",
 						"label": "YES",
 						"market": "ELON_MUSK_VISIT_MARS_AUG_1_2099",
-						"timestamp": 1781895629941,
-						"datetime": "2026-06-19T19:00:29.941Z",
+						"timestamp": 1781915898599,
+						"datetime": "2026-06-20T00:38:18.599Z",
 						"high": null,
 						"low": null,
 						"bid": 0.08,
@@ -332,8 +332,8 @@
 						"outcomeId": "KXCOLONIZEMARS-50",
 						"label": "YES",
 						"market": "HUMANS_COLONIZE_MARS_2050",
-						"timestamp": 1781895629941,
-						"datetime": "2026-06-19T19:00:29.941Z",
+						"timestamp": 1781915898599,
+						"datetime": "2026-06-20T00:38:18.599Z",
 						"high": null,
 						"low": null,
 						"bid": 0.163,
@@ -634,9 +634,11 @@
 							13553
 						]
 					],
-					"timestamp": 1781895630041,
-					"datetime": "2026-06-19T19:00:30.041Z",
-					"nonce": null
+					"timestamp": 1781915898700,
+					"datetime": "2026-06-20T00:38:18.700Z",
+					"nonce": null,
+					"outcomeId": "KXELONMARS-99",
+					"market": "ELON_MUSK_VISIT_MARS_AUG_1_2099"
 				}
 			}
 		],

--- a/ts/src/test/static/response/kalshi.json
+++ b/ts/src/test/static/response/kalshi.json
@@ -1,857 +1,772 @@
 {
-    "exchange": "kalshi",
-    "skipKeys": [
-        "timestamp",
-        "datetime"
-    ],
-    "options": {},
-    "methods": {
-        "fetchTicker": [
-            {
-                "description": "fetchTicker for a yes outcome",
-                "method": "fetchTicker",
-                "input": [
-                    "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES"
-                ],
-                "httpResponse": {
-                    "market": {
-                        "can_close_early": true,
-                        "close_time": "2099-08-01T04:59:00Z",
-                        "created_time": "2025-08-28T20:40:16.168768Z",
-                        "early_close_condition": "This market will close and expire early if the event occurs.",
-                        "event_ticker": "KXELONMARS-99",
-                        "expected_expiration_time": "2099-08-01T15:00:00Z",
-                        "expiration_time": "2099-08-08T15:00:00Z",
-                        "expiration_value": "",
-                        "fractional_trading_enabled": true,
-                        "last_price_dollars": "0.1000",
-                        "latest_expiration_time": "2099-08-08T15:00:00Z",
-                        "liquidity_dollars": "0.0000",
-                        "market_type": "binary",
-                        "no_ask_dollars": "0.9200",
-                        "no_bid_dollars": "0.8800",
-                        "no_sub_title": "Mars",
-                        "notional_value_dollars": "1.0000",
-                        "open_interest_fp": "32746.17",
-                        "open_time": "2025-08-28T20:45:00Z",
-                        "previous_price_dollars": "0.0800",
-                        "previous_yes_ask_dollars": "0.1000",
-                        "previous_yes_bid_dollars": "0.0800",
-                        "price_level_structure": "linear_cent",
-                        "price_ranges": [
-                            {
-                                "end": "1.0000",
-                                "start": "0.0000",
-                                "step": "0.0100"
-                            }
-                        ],
-                        "response_price_units": "usd_cent",
-                        "result": "",
-                        "rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
-                        "rules_secondary": "",
-                        "settlement_timer_seconds": "1800",
-                        "status": "active",
-                        "ticker": "KXELONMARS-99",
-                        "title": "Will Elon Musk visit Mars before Aug 1, 2099?",
-                        "updated_time": "2026-04-09T09:31:16.616867Z",
-                        "volume_24h_fp": "19.74",
-                        "volume_fp": "94884.62",
-                        "yes_ask_dollars": "0.1200",
-                        "yes_ask_size_fp": "1967.33",
-                        "yes_bid_dollars": "0.0800",
-                        "yes_bid_size_fp": "444.32",
-                        "yes_sub_title": "Mars"
-                    }
-                },
-                "parsedResponse": {
-                    "symbol": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                    "timestamp": 1781289374858,
-                    "datetime": "2026-06-12T18:36:14.858Z",
-                    "high": null,
-                    "low": null,
-                    "bid": 0.08,
-                    "bidVolume": 444.32,
-                    "ask": 0.12,
-                    "askVolume": 1967.33,
-                    "vwap": null,
-                    "open": null,
-                    "close": 0.1,
-                    "last": 0.1,
-                    "previousClose": null,
-                    "change": null,
-                    "percentage": null,
-                    "average": 0.1,
-                    "baseVolume": 19.74,
-                    "quoteVolume": null,
-                    "info": {
-                        "can_close_early": true,
-                        "close_time": "2099-08-01T04:59:00Z",
-                        "created_time": "2025-08-28T20:40:16.168768Z",
-                        "early_close_condition": "This market will close and expire early if the event occurs.",
-                        "event_ticker": "KXELONMARS-99",
-                        "expected_expiration_time": "2099-08-01T15:00:00Z",
-                        "expiration_time": "2099-08-08T15:00:00Z",
-                        "expiration_value": "",
-                        "fractional_trading_enabled": true,
-                        "last_price_dollars": "0.1000",
-                        "latest_expiration_time": "2099-08-08T15:00:00Z",
-                        "liquidity_dollars": "0.0000",
-                        "market_type": "binary",
-                        "no_ask_dollars": "0.9200",
-                        "no_bid_dollars": "0.8800",
-                        "no_sub_title": "Mars",
-                        "notional_value_dollars": "1.0000",
-                        "open_interest_fp": "32746.17",
-                        "open_time": "2025-08-28T20:45:00Z",
-                        "previous_price_dollars": "0.0800",
-                        "previous_yes_ask_dollars": "0.1000",
-                        "previous_yes_bid_dollars": "0.0800",
-                        "price_level_structure": "linear_cent",
-                        "price_ranges": [
-                            {
-                                "end": "1.0000",
-                                "start": "0.0000",
-                                "step": "0.0100"
-                            }
-                        ],
-                        "response_price_units": "usd_cent",
-                        "result": "",
-                        "rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
-                        "rules_secondary": "",
-                        "settlement_timer_seconds": "1800",
-                        "status": "active",
-                        "ticker": "KXELONMARS-99",
-                        "title": "Will Elon Musk visit Mars before Aug 1, 2099?",
-                        "updated_time": "2026-04-09T09:31:16.616867Z",
-                        "volume_24h_fp": "19.74",
-                        "volume_fp": "94884.62",
-                        "yes_ask_dollars": "0.1200",
-                        "yes_ask_size_fp": "1967.33",
-                        "yes_bid_dollars": "0.0800",
-                        "yes_bid_size_fp": "444.32",
-                        "yes_sub_title": "Mars"
-                    },
-                    "indexPrice": null,
-                    "markPrice": null
-                }
-            }
-        ],
-        "fetchTickers": [
-            {
-                "description": "fetchTickers with two outcome symbols",
-                "method": "fetchTickers",
-                "input": [
-                    [
-                        "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "HUMANS_COLONIZE_MARS_2050:YES"
-                    ]
-                ],
-                "httpResponse": {
-                    "cursor": "",
-                    "markets": [
-                        {
-                            "can_close_early": true,
-                            "close_time": "2099-08-01T04:59:00Z",
-                            "created_time": "2025-08-28T20:40:16.168768Z",
-                            "early_close_condition": "This market will close and expire early if the event occurs.",
-                            "event_ticker": "KXELONMARS-99",
-                            "expected_expiration_time": "2099-08-01T15:00:00Z",
-                            "expiration_time": "2099-08-08T15:00:00Z",
-                            "expiration_value": "",
-                            "fractional_trading_enabled": true,
-                            "last_price_dollars": "0.1000",
-                            "latest_expiration_time": "2099-08-08T15:00:00Z",
-                            "liquidity_dollars": "0.0000",
-                            "market_type": "binary",
-                            "no_ask_dollars": "0.9200",
-                            "no_bid_dollars": "0.8800",
-                            "no_sub_title": "Mars",
-                            "notional_value_dollars": "1.0000",
-                            "open_interest_fp": "32746.17",
-                            "open_time": "2025-08-28T20:45:00Z",
-                            "previous_price_dollars": "0.0800",
-                            "previous_yes_ask_dollars": "0.1000",
-                            "previous_yes_bid_dollars": "0.0800",
-                            "price_level_structure": "linear_cent",
-                            "price_ranges": [
-                                {
-                                    "end": "1.0000",
-                                    "start": "0.0000",
-                                    "step": "0.0100"
-                                }
-                            ],
-                            "response_price_units": "usd_cent",
-                            "result": "",
-                            "rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
-                            "rules_secondary": "",
-                            "settlement_timer_seconds": "1800",
-                            "status": "active",
-                            "ticker": "KXELONMARS-99",
-                            "title": "Will Elon Musk visit Mars before Aug 1, 2099?",
-                            "updated_time": "2026-04-09T09:31:16.616867Z",
-                            "volume_24h_fp": "19.74",
-                            "volume_fp": "94884.62",
-                            "yes_ask_dollars": "0.1200",
-                            "yes_ask_size_fp": "1967.33",
-                            "yes_bid_dollars": "0.0800",
-                            "yes_bid_size_fp": "444.32",
-                            "yes_sub_title": "Mars"
-                        },
-                        {
-                            "can_close_early": true,
-                            "close_time": "2050-01-01T04:59:00Z",
-                            "created_time": "2025-06-27T16:35:35.36594Z",
-                            "early_close_condition": "This market will close and expire early if the event occurs.",
-                            "event_ticker": "KXCOLONIZEMARS-50",
-                            "expected_expiration_time": "2050-01-01T15:00:00Z",
-                            "expiration_time": "2050-01-08T15:00:00Z",
-                            "expiration_value": "",
-                            "fractional_trading_enabled": true,
-                            "last_price_dollars": "0.1950",
-                            "latest_expiration_time": "2050-01-08T15:00:00Z",
-                            "liquidity_dollars": "0.0000",
-                            "market_type": "binary",
-                            "no_ask_dollars": "0.8370",
-                            "no_bid_dollars": "0.8050",
-                            "no_sub_title": "Before 2050",
-                            "notional_value_dollars": "1.0000",
-                            "open_interest_fp": "9084.00",
-                            "open_time": "2025-06-27T20:45:00Z",
-                            "previous_price_dollars": "0.1950",
-                            "previous_yes_ask_dollars": "0.1950",
-                            "previous_yes_bid_dollars": "0.1630",
-                            "price_level_structure": "deci_cent",
-                            "price_ranges": [
-                                {
-                                    "end": "1.0000",
-                                    "start": "0.0000",
-                                    "step": "0.0010"
-                                }
-                            ],
-                            "response_price_units": "usd_cent",
-                            "result": "",
-                            "rules_primary": "If humans have a self-sufficient colony of at least 10 people reside on Mars for at least one Earth year before Jan 1, 2050, then the market resolves to Yes.",
-                            "rules_secondary": "",
-                            "settlement_timer_seconds": "1800",
-                            "status": "active",
-                            "ticker": "KXCOLONIZEMARS-50",
-                            "title": "Will humans colonize Mars before 2050?",
-                            "updated_time": "2026-04-09T10:33:10.234054Z",
-                            "volume_24h_fp": "141.68",
-                            "volume_fp": "21043.39",
-                            "yes_ask_dollars": "0.1950",
-                            "yes_ask_size_fp": "97.53",
-                            "yes_bid_dollars": "0.1630",
-                            "yes_bid_size_fp": "30.97",
-                            "yes_sub_title": "Before 2050"
-                        }
-                    ]
-                },
-                "parsedResponse": {
-                    "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES": {
-                        "symbol": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "timestamp": 1781289375149,
-                        "datetime": "2026-06-12T18:36:15.149Z",
-                        "high": null,
-                        "low": null,
-                        "bid": 0.08,
-                        "bidVolume": 444.32,
-                        "ask": 0.12,
-                        "askVolume": 1967.33,
-                        "vwap": null,
-                        "open": null,
-                        "close": 0.1,
-                        "last": 0.1,
-                        "previousClose": null,
-                        "change": null,
-                        "percentage": null,
-                        "average": 0.1,
-                        "baseVolume": 19.74,
-                        "quoteVolume": null,
-                        "info": {
-                            "can_close_early": true,
-                            "close_time": "2099-08-01T04:59:00Z",
-                            "created_time": "2025-08-28T20:40:16.168768Z",
-                            "early_close_condition": "This market will close and expire early if the event occurs.",
-                            "event_ticker": "KXELONMARS-99",
-                            "expected_expiration_time": "2099-08-01T15:00:00Z",
-                            "expiration_time": "2099-08-08T15:00:00Z",
-                            "expiration_value": "",
-                            "fractional_trading_enabled": true,
-                            "last_price_dollars": "0.1000",
-                            "latest_expiration_time": "2099-08-08T15:00:00Z",
-                            "liquidity_dollars": "0.0000",
-                            "market_type": "binary",
-                            "no_ask_dollars": "0.9200",
-                            "no_bid_dollars": "0.8800",
-                            "no_sub_title": "Mars",
-                            "notional_value_dollars": "1.0000",
-                            "open_interest_fp": "32746.17",
-                            "open_time": "2025-08-28T20:45:00Z",
-                            "previous_price_dollars": "0.0800",
-                            "previous_yes_ask_dollars": "0.1000",
-                            "previous_yes_bid_dollars": "0.0800",
-                            "price_level_structure": "linear_cent",
-                            "price_ranges": [
-                                {
-                                    "end": "1.0000",
-                                    "start": "0.0000",
-                                    "step": "0.0100"
-                                }
-                            ],
-                            "response_price_units": "usd_cent",
-                            "result": "",
-                            "rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
-                            "rules_secondary": "",
-                            "settlement_timer_seconds": "1800",
-                            "status": "active",
-                            "ticker": "KXELONMARS-99",
-                            "title": "Will Elon Musk visit Mars before Aug 1, 2099?",
-                            "updated_time": "2026-04-09T09:31:16.616867Z",
-                            "volume_24h_fp": "19.74",
-                            "volume_fp": "94884.62",
-                            "yes_ask_dollars": "0.1200",
-                            "yes_ask_size_fp": "1967.33",
-                            "yes_bid_dollars": "0.0800",
-                            "yes_bid_size_fp": "444.32",
-                            "yes_sub_title": "Mars"
-                        },
-                        "indexPrice": null,
-                        "markPrice": null
-                    },
-                    "HUMANS_COLONIZE_MARS_2050:YES": {
-                        "symbol": "HUMANS_COLONIZE_MARS_2050:YES",
-                        "timestamp": 1781289375149,
-                        "datetime": "2026-06-12T18:36:15.149Z",
-                        "high": null,
-                        "low": null,
-                        "bid": 0.163,
-                        "bidVolume": 30.97,
-                        "ask": 0.195,
-                        "askVolume": 97.53,
-                        "vwap": null,
-                        "open": null,
-                        "close": 0.195,
-                        "last": 0.195,
-                        "previousClose": null,
-                        "change": null,
-                        "percentage": null,
-                        "average": 0.179,
-                        "baseVolume": 141.68,
-                        "quoteVolume": null,
-                        "info": {
-                            "can_close_early": true,
-                            "close_time": "2050-01-01T04:59:00Z",
-                            "created_time": "2025-06-27T16:35:35.36594Z",
-                            "early_close_condition": "This market will close and expire early if the event occurs.",
-                            "event_ticker": "KXCOLONIZEMARS-50",
-                            "expected_expiration_time": "2050-01-01T15:00:00Z",
-                            "expiration_time": "2050-01-08T15:00:00Z",
-                            "expiration_value": "",
-                            "fractional_trading_enabled": true,
-                            "last_price_dollars": "0.1950",
-                            "latest_expiration_time": "2050-01-08T15:00:00Z",
-                            "liquidity_dollars": "0.0000",
-                            "market_type": "binary",
-                            "no_ask_dollars": "0.8370",
-                            "no_bid_dollars": "0.8050",
-                            "no_sub_title": "Before 2050",
-                            "notional_value_dollars": "1.0000",
-                            "open_interest_fp": "9084.00",
-                            "open_time": "2025-06-27T20:45:00Z",
-                            "previous_price_dollars": "0.1950",
-                            "previous_yes_ask_dollars": "0.1950",
-                            "previous_yes_bid_dollars": "0.1630",
-                            "price_level_structure": "deci_cent",
-                            "price_ranges": [
-                                {
-                                    "end": "1.0000",
-                                    "start": "0.0000",
-                                    "step": "0.0010"
-                                }
-                            ],
-                            "response_price_units": "usd_cent",
-                            "result": "",
-                            "rules_primary": "If humans have a self-sufficient colony of at least 10 people reside on Mars for at least one Earth year before Jan 1, 2050, then the market resolves to Yes.",
-                            "rules_secondary": "",
-                            "settlement_timer_seconds": "1800",
-                            "status": "active",
-                            "ticker": "KXCOLONIZEMARS-50",
-                            "title": "Will humans colonize Mars before 2050?",
-                            "updated_time": "2026-04-09T10:33:10.234054Z",
-                            "volume_24h_fp": "141.68",
-                            "volume_fp": "21043.39",
-                            "yes_ask_dollars": "0.1950",
-                            "yes_ask_size_fp": "97.53",
-                            "yes_bid_dollars": "0.1630",
-                            "yes_bid_size_fp": "30.97",
-                            "yes_sub_title": "Before 2050"
-                        },
-                        "indexPrice": null,
-                        "markPrice": null
-                    }
-                }
-            }
-        ],
-        "fetchOrderBook": [
-            {
-                "description": "fetchOrderBook for a yes outcome",
-                "method": "fetchOrderBook",
-                "input": [
-                    "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES"
-                ],
-                "httpResponse": {
-                    "orderbook_fp": {
-                        "no_dollars": [
-                            [
-                                "0.0100",
-                                "13553.00"
-                            ],
-                            [
-                                "0.0400",
-                                "555.00"
-                            ],
-                            [
-                                "0.0500",
-                                "888.00"
-                            ],
-                            [
-                                "0.0600",
-                                "500.00"
-                            ],
-                            [
-                                "0.0900",
-                                "20.00"
-                            ],
-                            [
-                                "0.1000",
-                                "25.00"
-                            ],
-                            [
-                                "0.1100",
-                                "5000.00"
-                            ],
-                            [
-                                "0.4600",
-                                "25.00"
-                            ],
-                            [
-                                "0.5000",
-                                "4040.45"
-                            ],
-                            [
-                                "0.6000",
-                                "284.00"
-                            ],
-                            [
-                                "0.6100",
-                                "500.00"
-                            ],
-                            [
-                                "0.6200",
-                                "5.00"
-                            ],
-                            [
-                                "0.6500",
-                                "25.00"
-                            ],
-                            [
-                                "0.7000",
-                                "10.40"
-                            ],
-                            [
-                                "0.7300",
-                                "38.73"
-                            ],
-                            [
-                                "0.7400",
-                                "250.00"
-                            ],
-                            [
-                                "0.8700",
-                                "118.85"
-                            ],
-                            [
-                                "0.8800",
-                                "1967.33"
-                            ]
-                        ],
-                        "yes_dollars": [
-                            [
-                                "0.0100",
-                                "6558.50"
-                            ],
-                            [
-                                "0.0200",
-                                "705.00"
-                            ],
-                            [
-                                "0.0300",
-                                "18708.00"
-                            ],
-                            [
-                                "0.0400",
-                                "1162.00"
-                            ],
-                            [
-                                "0.0500",
-                                "50.00"
-                            ],
-                            [
-                                "0.0600",
-                                "2201.86"
-                            ],
-                            [
-                                "0.0700",
-                                "3195.84"
-                            ],
-                            [
-                                "0.0800",
-                                "444.32"
-                            ]
-                        ]
-                    }
-                },
-                "parsedResponse": {
-                    "symbol": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                    "bids": [
-                        [
-                            0.08,
-                            444.32
-                        ],
-                        [
-                            0.07,
-                            3195.84
-                        ],
-                        [
-                            0.06,
-                            2201.86
-                        ],
-                        [
-                            0.05,
-                            50
-                        ],
-                        [
-                            0.04,
-                            1162
-                        ],
-                        [
-                            0.03,
-                            18708
-                        ],
-                        [
-                            0.02,
-                            705
-                        ],
-                        [
-                            0.01,
-                            6558.5
-                        ]
-                    ],
-                    "asks": [
-                        [
-                            0.12,
-                            1967.33
-                        ],
-                        [
-                            0.13,
-                            118.85
-                        ],
-                        [
-                            0.26,
-                            250
-                        ],
-                        [
-                            0.27,
-                            38.73
-                        ],
-                        [
-                            0.3,
-                            10.4
-                        ],
-                        [
-                            0.35,
-                            25
-                        ],
-                        [
-                            0.38,
-                            5
-                        ],
-                        [
-                            0.39,
-                            500
-                        ],
-                        [
-                            0.4,
-                            284
-                        ],
-                        [
-                            0.5,
-                            4040.45
-                        ],
-                        [
-                            0.54,
-                            25
-                        ],
-                        [
-                            0.89,
-                            5000
-                        ],
-                        [
-                            0.9,
-                            25
-                        ],
-                        [
-                            0.91,
-                            20
-                        ],
-                        [
-                            0.94,
-                            500
-                        ],
-                        [
-                            0.95,
-                            888
-                        ],
-                        [
-                            0.96,
-                            555
-                        ],
-                        [
-                            0.99,
-                            13553
-                        ]
-                    ],
-                    "timestamp": 1781289375428,
-                    "datetime": "2026-06-12T18:36:15.428Z",
-                    "nonce": null
-                }
-            }
-        ],
-        "fetchTrades": [
-            {
-                "description": "fetchTrades with limit",
-                "method": "fetchTrades",
-                "input": [
-                    "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                    null,
-                    3
-                ],
-                "httpResponse": {
-                    "cursor": "EhIKEFq9i3ERl0wsdoYvGaMHJ8kaCwikt7DRBhCwt946",
-                    "trades": [
-                        {
-                            "count_fp": "9.40",
-                            "created_time": "2026-06-12T17:11:11.927591Z",
-                            "is_block_trade": false,
-                            "no_price_dollars": "0.9000",
-                            "taker_book_side": "bid",
-                            "taker_outcome_side": "yes",
-                            "taker_side": "yes",
-                            "ticker": "KXELONMARS-99",
-                            "trade_id": "6e924506-2c0f-5717-f9b7-eae14a12202a",
-                            "yes_price_dollars": "0.1000"
-                        },
-                        {
-                            "count_fp": "0.94",
-                            "created_time": "2026-06-12T15:45:05.842468Z",
-                            "is_block_trade": false,
-                            "no_price_dollars": "0.9000",
-                            "taker_book_side": "bid",
-                            "taker_outcome_side": "yes",
-                            "taker_side": "yes",
-                            "ticker": "KXELONMARS-99",
-                            "trade_id": "201c12b1-e3fb-7783-370e-5cb5072ef066",
-                            "yes_price_dollars": "0.1000"
-                        },
-                        {
-                            "count_fp": "9.40",
-                            "created_time": "2026-06-12T14:45:56.123182Z",
-                            "is_block_trade": false,
-                            "no_price_dollars": "0.9200",
-                            "taker_book_side": "ask",
-                            "taker_outcome_side": "no",
-                            "taker_side": "no",
-                            "ticker": "KXELONMARS-99",
-                            "trade_id": "5abd8b71-1197-4c2c-7686-2f19a30727c9",
-                            "yes_price_dollars": "0.0800"
-                        }
-                    ]
-                },
-                "parsedResponse": [
-                    {
-                        "id": "5abd8b71-1197-4c2c-7686-2f19a30727c9",
-                        "info": {
-                            "count_fp": "9.40",
-                            "created_time": "2026-06-12T14:45:56.123182Z",
-                            "is_block_trade": false,
-                            "no_price_dollars": "0.9200",
-                            "taker_book_side": "ask",
-                            "taker_outcome_side": "no",
-                            "taker_side": "no",
-                            "ticker": "KXELONMARS-99",
-                            "trade_id": "5abd8b71-1197-4c2c-7686-2f19a30727c9",
-                            "yes_price_dollars": "0.0800"
-                        },
-                        "timestamp": 1781275556123,
-                        "datetime": "2026-06-12T14:45:56.123Z",
-                        "symbol": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "outcome": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "outcomeId": "KXELONMARS-99",
-                        "order": null,
-                        "type": null,
-                        "side": "sell",
-                        "takerOrMaker": "taker",
-                        "price": 0.08,
-                        "amount": 9.4,
-                        "cost": 0.752,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    },
-                    {
-                        "id": "201c12b1-e3fb-7783-370e-5cb5072ef066",
-                        "info": {
-                            "count_fp": "0.94",
-                            "created_time": "2026-06-12T15:45:05.842468Z",
-                            "is_block_trade": false,
-                            "no_price_dollars": "0.9000",
-                            "taker_book_side": "bid",
-                            "taker_outcome_side": "yes",
-                            "taker_side": "yes",
-                            "ticker": "KXELONMARS-99",
-                            "trade_id": "201c12b1-e3fb-7783-370e-5cb5072ef066",
-                            "yes_price_dollars": "0.1000"
-                        },
-                        "timestamp": 1781279105842,
-                        "datetime": "2026-06-12T15:45:05.842Z",
-                        "symbol": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "outcome": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "outcomeId": "KXELONMARS-99",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 0.1,
-                        "amount": 0.94,
-                        "cost": 0.094,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    },
-                    {
-                        "id": "6e924506-2c0f-5717-f9b7-eae14a12202a",
-                        "info": {
-                            "count_fp": "9.40",
-                            "created_time": "2026-06-12T17:11:11.927591Z",
-                            "is_block_trade": false,
-                            "no_price_dollars": "0.9000",
-                            "taker_book_side": "bid",
-                            "taker_outcome_side": "yes",
-                            "taker_side": "yes",
-                            "ticker": "KXELONMARS-99",
-                            "trade_id": "6e924506-2c0f-5717-f9b7-eae14a12202a",
-                            "yes_price_dollars": "0.1000"
-                        },
-                        "timestamp": 1781284271927,
-                        "datetime": "2026-06-12T17:11:11.927Z",
-                        "symbol": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "outcome": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                        "outcomeId": "KXELONMARS-99",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 0.1,
-                        "amount": 9.4,
-                        "cost": 0.9400000000000001,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    }
-                ]
-            }
-        ],
-        "fetchOHLCV": [
-            {
-                "description": "fetchOHLCV with since and limit",
-                "method": "fetchOHLCV",
-                "input": [
-                    "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
-                    "1h",
-                    1781100000000,
-                    24
-                ],
-                "httpResponse": {
-                    "candlesticks": [
-                        {
-                            "end_period_ts": "1781143200",
-                            "open_interest_fp": "32764.57",
-                            "price": {
-                                "previous_dollars": "0.1000"
-                            },
-                            "volume_fp": "0.00",
-                            "yes_ask": {
-                                "close_dollars": "0.1000",
-                                "high_dollars": "0.1000",
-                                "low_dollars": "0.0900",
-                                "open_dollars": "0.0900"
-                            },
-                            "yes_bid": {
-                                "close_dollars": "0.0800",
-                                "high_dollars": "0.0800",
-                                "low_dollars": "0.0800",
-                                "open_dollars": "0.0800"
-                            }
-                        },
-                        {
-                            "end_period_ts": "1781172000",
-                            "open_interest_fp": "32764.57",
-                            "price": {
-                                "previous_dollars": "0.1000"
-                            },
-                            "volume_fp": "0.00",
-                            "yes_ask": {
-                                "close_dollars": "0.1000",
-                                "high_dollars": "0.1000",
-                                "low_dollars": "0.1000",
-                                "open_dollars": "0.1000"
-                            },
-                            "yes_bid": {
-                                "close_dollars": "0.0800",
-                                "high_dollars": "0.0800",
-                                "low_dollars": "0.0800",
-                                "open_dollars": "0.0800"
-                            }
-                        }
-                    ],
-                    "ticker": "KXELONMARS-99"
-                },
-                "parsedResponse": [
-                    [
-                        1781143200000,
-                        0.1,
-                        0.1,
-                        0.1,
-                        0.1,
-                        0
-                    ],
-                    [
-                        1781172000000,
-                        0.1,
-                        0.1,
-                        0.1,
-                        0.1,
-                        0
-                    ]
-                ]
-            }
-        ]
-    }
+	"exchange": "kalshi",
+	"skipKeys": [
+		"timestamp",
+		"datetime"
+	],
+	"options": {},
+	"methods": {
+		"fetchTicker": [
+			{
+				"description": "fetchTicker for a yes outcome",
+				"method": "fetchTicker",
+				"input": [
+					"ELON_MUSK_VISIT_MARS_AUG_1_2099:YES"
+				],
+				"httpResponse": {
+					"market": {
+						"can_close_early": true,
+						"close_time": "2099-08-01T04:59:00Z",
+						"created_time": "2025-08-28T20:40:16.168768Z",
+						"early_close_condition": "This market will close and expire early if the event occurs.",
+						"event_ticker": "KXELONMARS-99",
+						"expected_expiration_time": "2099-08-01T15:00:00Z",
+						"expiration_time": "2099-08-08T15:00:00Z",
+						"expiration_value": "",
+						"fractional_trading_enabled": true,
+						"last_price_dollars": "0.1000",
+						"latest_expiration_time": "2099-08-08T15:00:00Z",
+						"liquidity_dollars": "0.0000",
+						"market_type": "binary",
+						"no_ask_dollars": "0.9200",
+						"no_bid_dollars": "0.8800",
+						"no_sub_title": "Mars",
+						"notional_value_dollars": "1.0000",
+						"open_interest_fp": "32746.17",
+						"open_time": "2025-08-28T20:45:00Z",
+						"previous_price_dollars": "0.0800",
+						"previous_yes_ask_dollars": "0.1000",
+						"previous_yes_bid_dollars": "0.0800",
+						"price_level_structure": "linear_cent",
+						"price_ranges": [
+							{
+								"end": "1.0000",
+								"start": "0.0000",
+								"step": "0.0100"
+							}
+						],
+						"response_price_units": "usd_cent",
+						"result": "",
+						"rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
+						"rules_secondary": "",
+						"settlement_timer_seconds": "1800",
+						"status": "active",
+						"ticker": "KXELONMARS-99",
+						"title": "Will Elon Musk visit Mars before Aug 1, 2099?",
+						"updated_time": "2026-04-09T09:31:16.616867Z",
+						"volume_24h_fp": "19.74",
+						"volume_fp": "94884.62",
+						"yes_ask_dollars": "0.1200",
+						"yes_ask_size_fp": "1967.33",
+						"yes_bid_dollars": "0.0800",
+						"yes_bid_size_fp": "444.32",
+						"yes_sub_title": "Mars"
+					}
+				},
+				"parsedResponse": {
+					"outcome": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
+					"outcomeId": "KXELONMARS-99",
+					"label": "YES",
+					"market": "ELON_MUSK_VISIT_MARS_AUG_1_2099",
+					"timestamp": 1781895629840,
+					"datetime": "2026-06-19T19:00:29.840Z",
+					"high": null,
+					"low": null,
+					"bid": 0.08,
+					"bidVolume": 444.32,
+					"ask": 0.12,
+					"askVolume": 1967.33,
+					"vwap": null,
+					"open": null,
+					"close": 0.1,
+					"last": 0.1,
+					"previousClose": null,
+					"change": null,
+					"percentage": null,
+					"average": 0.1,
+					"baseVolume": 19.74,
+					"quoteVolume": null,
+					"info": {
+						"can_close_early": true,
+						"close_time": "2099-08-01T04:59:00Z",
+						"created_time": "2025-08-28T20:40:16.168768Z",
+						"early_close_condition": "This market will close and expire early if the event occurs.",
+						"event_ticker": "KXELONMARS-99",
+						"expected_expiration_time": "2099-08-01T15:00:00Z",
+						"expiration_time": "2099-08-08T15:00:00Z",
+						"expiration_value": "",
+						"fractional_trading_enabled": true,
+						"last_price_dollars": "0.1000",
+						"latest_expiration_time": "2099-08-08T15:00:00Z",
+						"liquidity_dollars": "0.0000",
+						"market_type": "binary",
+						"no_ask_dollars": "0.9200",
+						"no_bid_dollars": "0.8800",
+						"no_sub_title": "Mars",
+						"notional_value_dollars": "1.0000",
+						"open_interest_fp": "32746.17",
+						"open_time": "2025-08-28T20:45:00Z",
+						"previous_price_dollars": "0.0800",
+						"previous_yes_ask_dollars": "0.1000",
+						"previous_yes_bid_dollars": "0.0800",
+						"price_level_structure": "linear_cent",
+						"price_ranges": [
+							{
+								"end": "1.0000",
+								"start": "0.0000",
+								"step": "0.0100"
+							}
+						],
+						"response_price_units": "usd_cent",
+						"result": "",
+						"rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
+						"rules_secondary": "",
+						"settlement_timer_seconds": "1800",
+						"status": "active",
+						"ticker": "KXELONMARS-99",
+						"title": "Will Elon Musk visit Mars before Aug 1, 2099?",
+						"updated_time": "2026-04-09T09:31:16.616867Z",
+						"volume_24h_fp": "19.74",
+						"volume_fp": "94884.62",
+						"yes_ask_dollars": "0.1200",
+						"yes_ask_size_fp": "1967.33",
+						"yes_bid_dollars": "0.0800",
+						"yes_bid_size_fp": "444.32",
+						"yes_sub_title": "Mars"
+					},
+					"indexPrice": null,
+					"markPrice": null,
+					"event": null
+				}
+			}
+		],
+		"fetchTickers": [
+			{
+				"description": "fetchTickers with two outcome symbols",
+				"method": "fetchTickers",
+				"input": [
+					[
+						"ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
+						"HUMANS_COLONIZE_MARS_2050:YES"
+					]
+				],
+				"httpResponse": {
+					"cursor": "",
+					"markets": [
+						{
+							"can_close_early": true,
+							"close_time": "2099-08-01T04:59:00Z",
+							"created_time": "2025-08-28T20:40:16.168768Z",
+							"early_close_condition": "This market will close and expire early if the event occurs.",
+							"event_ticker": "KXELONMARS-99",
+							"expected_expiration_time": "2099-08-01T15:00:00Z",
+							"expiration_time": "2099-08-08T15:00:00Z",
+							"expiration_value": "",
+							"fractional_trading_enabled": true,
+							"last_price_dollars": "0.1000",
+							"latest_expiration_time": "2099-08-08T15:00:00Z",
+							"liquidity_dollars": "0.0000",
+							"market_type": "binary",
+							"no_ask_dollars": "0.9200",
+							"no_bid_dollars": "0.8800",
+							"no_sub_title": "Mars",
+							"notional_value_dollars": "1.0000",
+							"open_interest_fp": "32746.17",
+							"open_time": "2025-08-28T20:45:00Z",
+							"previous_price_dollars": "0.0800",
+							"previous_yes_ask_dollars": "0.1000",
+							"previous_yes_bid_dollars": "0.0800",
+							"price_level_structure": "linear_cent",
+							"price_ranges": [
+								{
+									"end": "1.0000",
+									"start": "0.0000",
+									"step": "0.0100"
+								}
+							],
+							"response_price_units": "usd_cent",
+							"result": "",
+							"rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
+							"rules_secondary": "",
+							"settlement_timer_seconds": "1800",
+							"status": "active",
+							"ticker": "KXELONMARS-99",
+							"title": "Will Elon Musk visit Mars before Aug 1, 2099?",
+							"updated_time": "2026-04-09T09:31:16.616867Z",
+							"volume_24h_fp": "19.74",
+							"volume_fp": "94884.62",
+							"yes_ask_dollars": "0.1200",
+							"yes_ask_size_fp": "1967.33",
+							"yes_bid_dollars": "0.0800",
+							"yes_bid_size_fp": "444.32",
+							"yes_sub_title": "Mars"
+						},
+						{
+							"can_close_early": true,
+							"close_time": "2050-01-01T04:59:00Z",
+							"created_time": "2025-06-27T16:35:35.36594Z",
+							"early_close_condition": "This market will close and expire early if the event occurs.",
+							"event_ticker": "KXCOLONIZEMARS-50",
+							"expected_expiration_time": "2050-01-01T15:00:00Z",
+							"expiration_time": "2050-01-08T15:00:00Z",
+							"expiration_value": "",
+							"fractional_trading_enabled": true,
+							"last_price_dollars": "0.1950",
+							"latest_expiration_time": "2050-01-08T15:00:00Z",
+							"liquidity_dollars": "0.0000",
+							"market_type": "binary",
+							"no_ask_dollars": "0.8370",
+							"no_bid_dollars": "0.8050",
+							"no_sub_title": "Before 2050",
+							"notional_value_dollars": "1.0000",
+							"open_interest_fp": "9084.00",
+							"open_time": "2025-06-27T20:45:00Z",
+							"previous_price_dollars": "0.1950",
+							"previous_yes_ask_dollars": "0.1950",
+							"previous_yes_bid_dollars": "0.1630",
+							"price_level_structure": "deci_cent",
+							"price_ranges": [
+								{
+									"end": "1.0000",
+									"start": "0.0000",
+									"step": "0.0010"
+								}
+							],
+							"response_price_units": "usd_cent",
+							"result": "",
+							"rules_primary": "If humans have a self-sufficient colony of at least 10 people reside on Mars for at least one Earth year before Jan 1, 2050, then the market resolves to Yes.",
+							"rules_secondary": "",
+							"settlement_timer_seconds": "1800",
+							"status": "active",
+							"ticker": "KXCOLONIZEMARS-50",
+							"title": "Will humans colonize Mars before 2050?",
+							"updated_time": "2026-04-09T10:33:10.234054Z",
+							"volume_24h_fp": "141.68",
+							"volume_fp": "21043.39",
+							"yes_ask_dollars": "0.1950",
+							"yes_ask_size_fp": "97.53",
+							"yes_bid_dollars": "0.1630",
+							"yes_bid_size_fp": "30.97",
+							"yes_sub_title": "Before 2050"
+						}
+					]
+				},
+				"parsedResponse": {
+					"ELON_MUSK_VISIT_MARS_AUG_1_2099:YES": {
+						"outcome": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
+						"outcomeId": "KXELONMARS-99",
+						"label": "YES",
+						"market": "ELON_MUSK_VISIT_MARS_AUG_1_2099",
+						"timestamp": 1781895629941,
+						"datetime": "2026-06-19T19:00:29.941Z",
+						"high": null,
+						"low": null,
+						"bid": 0.08,
+						"bidVolume": 444.32,
+						"ask": 0.12,
+						"askVolume": 1967.33,
+						"vwap": null,
+						"open": null,
+						"close": 0.1,
+						"last": 0.1,
+						"previousClose": null,
+						"change": null,
+						"percentage": null,
+						"average": 0.1,
+						"baseVolume": 19.74,
+						"quoteVolume": null,
+						"info": {
+							"can_close_early": true,
+							"close_time": "2099-08-01T04:59:00Z",
+							"created_time": "2025-08-28T20:40:16.168768Z",
+							"early_close_condition": "This market will close and expire early if the event occurs.",
+							"event_ticker": "KXELONMARS-99",
+							"expected_expiration_time": "2099-08-01T15:00:00Z",
+							"expiration_time": "2099-08-08T15:00:00Z",
+							"expiration_value": "",
+							"fractional_trading_enabled": true,
+							"last_price_dollars": "0.1000",
+							"latest_expiration_time": "2099-08-08T15:00:00Z",
+							"liquidity_dollars": "0.0000",
+							"market_type": "binary",
+							"no_ask_dollars": "0.9200",
+							"no_bid_dollars": "0.8800",
+							"no_sub_title": "Mars",
+							"notional_value_dollars": "1.0000",
+							"open_interest_fp": "32746.17",
+							"open_time": "2025-08-28T20:45:00Z",
+							"previous_price_dollars": "0.0800",
+							"previous_yes_ask_dollars": "0.1000",
+							"previous_yes_bid_dollars": "0.0800",
+							"price_level_structure": "linear_cent",
+							"price_ranges": [
+								{
+									"end": "1.0000",
+									"start": "0.0000",
+									"step": "0.0100"
+								}
+							],
+							"response_price_units": "usd_cent",
+							"result": "",
+							"rules_primary": "If Elon Musk visits Mars before the earlier of his death or Aug 1, 2099, then the market resolves to Yes.",
+							"rules_secondary": "",
+							"settlement_timer_seconds": "1800",
+							"status": "active",
+							"ticker": "KXELONMARS-99",
+							"title": "Will Elon Musk visit Mars before Aug 1, 2099?",
+							"updated_time": "2026-04-09T09:31:16.616867Z",
+							"volume_24h_fp": "19.74",
+							"volume_fp": "94884.62",
+							"yes_ask_dollars": "0.1200",
+							"yes_ask_size_fp": "1967.33",
+							"yes_bid_dollars": "0.0800",
+							"yes_bid_size_fp": "444.32",
+							"yes_sub_title": "Mars"
+						},
+						"indexPrice": null,
+						"markPrice": null,
+						"event": null
+					},
+					"HUMANS_COLONIZE_MARS_2050:YES": {
+						"outcome": "HUMANS_COLONIZE_MARS_2050:YES",
+						"outcomeId": "KXCOLONIZEMARS-50",
+						"label": "YES",
+						"market": "HUMANS_COLONIZE_MARS_2050",
+						"timestamp": 1781895629941,
+						"datetime": "2026-06-19T19:00:29.941Z",
+						"high": null,
+						"low": null,
+						"bid": 0.163,
+						"bidVolume": 30.97,
+						"ask": 0.195,
+						"askVolume": 97.53,
+						"vwap": null,
+						"open": null,
+						"close": 0.195,
+						"last": 0.195,
+						"previousClose": null,
+						"change": null,
+						"percentage": null,
+						"average": 0.179,
+						"baseVolume": 141.68,
+						"quoteVolume": null,
+						"info": {
+							"can_close_early": true,
+							"close_time": "2050-01-01T04:59:00Z",
+							"created_time": "2025-06-27T16:35:35.36594Z",
+							"early_close_condition": "This market will close and expire early if the event occurs.",
+							"event_ticker": "KXCOLONIZEMARS-50",
+							"expected_expiration_time": "2050-01-01T15:00:00Z",
+							"expiration_time": "2050-01-08T15:00:00Z",
+							"expiration_value": "",
+							"fractional_trading_enabled": true,
+							"last_price_dollars": "0.1950",
+							"latest_expiration_time": "2050-01-08T15:00:00Z",
+							"liquidity_dollars": "0.0000",
+							"market_type": "binary",
+							"no_ask_dollars": "0.8370",
+							"no_bid_dollars": "0.8050",
+							"no_sub_title": "Before 2050",
+							"notional_value_dollars": "1.0000",
+							"open_interest_fp": "9084.00",
+							"open_time": "2025-06-27T20:45:00Z",
+							"previous_price_dollars": "0.1950",
+							"previous_yes_ask_dollars": "0.1950",
+							"previous_yes_bid_dollars": "0.1630",
+							"price_level_structure": "deci_cent",
+							"price_ranges": [
+								{
+									"end": "1.0000",
+									"start": "0.0000",
+									"step": "0.0010"
+								}
+							],
+							"response_price_units": "usd_cent",
+							"result": "",
+							"rules_primary": "If humans have a self-sufficient colony of at least 10 people reside on Mars for at least one Earth year before Jan 1, 2050, then the market resolves to Yes.",
+							"rules_secondary": "",
+							"settlement_timer_seconds": "1800",
+							"status": "active",
+							"ticker": "KXCOLONIZEMARS-50",
+							"title": "Will humans colonize Mars before 2050?",
+							"updated_time": "2026-04-09T10:33:10.234054Z",
+							"volume_24h_fp": "141.68",
+							"volume_fp": "21043.39",
+							"yes_ask_dollars": "0.1950",
+							"yes_ask_size_fp": "97.53",
+							"yes_bid_dollars": "0.1630",
+							"yes_bid_size_fp": "30.97",
+							"yes_sub_title": "Before 2050"
+						},
+						"indexPrice": null,
+						"markPrice": null,
+						"event": null
+					}
+				}
+			}
+		],
+		"fetchOrderBook": [
+			{
+				"description": "fetchOrderBook for a yes outcome",
+				"method": "fetchOrderBook",
+				"input": [
+					"ELON_MUSK_VISIT_MARS_AUG_1_2099:YES"
+				],
+				"httpResponse": {
+					"orderbook_fp": {
+						"no_dollars": [
+							[
+								"0.0100",
+								"13553.00"
+							],
+							[
+								"0.0400",
+								"555.00"
+							],
+							[
+								"0.0500",
+								"888.00"
+							],
+							[
+								"0.0600",
+								"500.00"
+							],
+							[
+								"0.0900",
+								"20.00"
+							],
+							[
+								"0.1000",
+								"25.00"
+							],
+							[
+								"0.1100",
+								"5000.00"
+							],
+							[
+								"0.4600",
+								"25.00"
+							],
+							[
+								"0.5000",
+								"4040.45"
+							],
+							[
+								"0.6000",
+								"284.00"
+							],
+							[
+								"0.6100",
+								"500.00"
+							],
+							[
+								"0.6200",
+								"5.00"
+							],
+							[
+								"0.6500",
+								"25.00"
+							],
+							[
+								"0.7000",
+								"10.40"
+							],
+							[
+								"0.7300",
+								"38.73"
+							],
+							[
+								"0.7400",
+								"250.00"
+							],
+							[
+								"0.8700",
+								"118.85"
+							],
+							[
+								"0.8800",
+								"1967.33"
+							]
+						],
+						"yes_dollars": [
+							[
+								"0.0100",
+								"6558.50"
+							],
+							[
+								"0.0200",
+								"705.00"
+							],
+							[
+								"0.0300",
+								"18708.00"
+							],
+							[
+								"0.0400",
+								"1162.00"
+							],
+							[
+								"0.0500",
+								"50.00"
+							],
+							[
+								"0.0600",
+								"2201.86"
+							],
+							[
+								"0.0700",
+								"3195.84"
+							],
+							[
+								"0.0800",
+								"444.32"
+							]
+						]
+					}
+				},
+				"parsedResponse": {
+					"outcome": "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
+					"bids": [
+						[
+							0.08,
+							444.32
+						],
+						[
+							0.07,
+							3195.84
+						],
+						[
+							0.06,
+							2201.86
+						],
+						[
+							0.05,
+							50
+						],
+						[
+							0.04,
+							1162
+						],
+						[
+							0.03,
+							18708
+						],
+						[
+							0.02,
+							705
+						],
+						[
+							0.01,
+							6558.5
+						]
+					],
+					"asks": [
+						[
+							0.12,
+							1967.33
+						],
+						[
+							0.13,
+							118.85
+						],
+						[
+							0.26,
+							250
+						],
+						[
+							0.27,
+							38.73
+						],
+						[
+							0.3,
+							10.4
+						],
+						[
+							0.35,
+							25
+						],
+						[
+							0.38,
+							5
+						],
+						[
+							0.39,
+							500
+						],
+						[
+							0.4,
+							284
+						],
+						[
+							0.5,
+							4040.45
+						],
+						[
+							0.54,
+							25
+						],
+						[
+							0.89,
+							5000
+						],
+						[
+							0.9,
+							25
+						],
+						[
+							0.91,
+							20
+						],
+						[
+							0.94,
+							500
+						],
+						[
+							0.95,
+							888
+						],
+						[
+							0.96,
+							555
+						],
+						[
+							0.99,
+							13553
+						]
+					],
+					"timestamp": 1781895630041,
+					"datetime": "2026-06-19T19:00:30.041Z",
+					"nonce": null
+				}
+			}
+		],
+		"fetchTrades": [
+			{
+				"description": "fetchTrades with limit",
+				"method": "fetchTrades",
+				"input": [
+					"ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
+					null,
+					3
+				],
+				"httpResponse": {
+					"cursor": "EhIKEFq9i3ERl0wsdoYvGaMHJ8kaCwikt7DRBhCwt946",
+					"trades": [
+						{
+							"count_fp": "9.40",
+							"created_time": "2026-06-12T17:11:11.927591Z",
+							"is_block_trade": false,
+							"no_price_dollars": "0.9000",
+							"taker_book_side": "bid",
+							"taker_outcome_side": "yes",
+							"taker_side": "yes",
+							"ticker": "KXELONMARS-99",
+							"trade_id": "6e924506-2c0f-5717-f9b7-eae14a12202a",
+							"yes_price_dollars": "0.1000"
+						},
+						{
+							"count_fp": "0.94",
+							"created_time": "2026-06-12T15:45:05.842468Z",
+							"is_block_trade": false,
+							"no_price_dollars": "0.9000",
+							"taker_book_side": "bid",
+							"taker_outcome_side": "yes",
+							"taker_side": "yes",
+							"ticker": "KXELONMARS-99",
+							"trade_id": "201c12b1-e3fb-7783-370e-5cb5072ef066",
+							"yes_price_dollars": "0.1000"
+						},
+						{
+							"count_fp": "9.40",
+							"created_time": "2026-06-12T14:45:56.123182Z",
+							"is_block_trade": false,
+							"no_price_dollars": "0.9200",
+							"taker_book_side": "ask",
+							"taker_outcome_side": "no",
+							"taker_side": "no",
+							"ticker": "KXELONMARS-99",
+							"trade_id": "5abd8b71-1197-4c2c-7686-2f19a30727c9",
+							"yes_price_dollars": "0.0800"
+						}
+					]
+				},
+				"parsedResponse": []
+			}
+		],
+		"fetchOHLCV": [
+			{
+				"description": "fetchOHLCV with since and limit",
+				"method": "fetchOHLCV",
+				"input": [
+					"ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
+					"1h",
+					1781100000000,
+					24
+				],
+				"httpResponse": {
+					"candlesticks": [
+						{
+							"end_period_ts": "1781143200",
+							"open_interest_fp": "32764.57",
+							"price": {
+								"previous_dollars": "0.1000"
+							},
+							"volume_fp": "0.00",
+							"yes_ask": {
+								"close_dollars": "0.1000",
+								"high_dollars": "0.1000",
+								"low_dollars": "0.0900",
+								"open_dollars": "0.0900"
+							},
+							"yes_bid": {
+								"close_dollars": "0.0800",
+								"high_dollars": "0.0800",
+								"low_dollars": "0.0800",
+								"open_dollars": "0.0800"
+							}
+						},
+						{
+							"end_period_ts": "1781172000",
+							"open_interest_fp": "32764.57",
+							"price": {
+								"previous_dollars": "0.1000"
+							},
+							"volume_fp": "0.00",
+							"yes_ask": {
+								"close_dollars": "0.1000",
+								"high_dollars": "0.1000",
+								"low_dollars": "0.1000",
+								"open_dollars": "0.1000"
+							},
+							"yes_bid": {
+								"close_dollars": "0.0800",
+								"high_dollars": "0.0800",
+								"low_dollars": "0.0800",
+								"open_dollars": "0.0800"
+							}
+						}
+					],
+					"ticker": "KXELONMARS-99"
+				},
+				"parsedResponse": [
+					[
+						1781143200000,
+						0.1,
+						0.1,
+						0.1,
+						0.1,
+						0
+					],
+					[
+						1781172000000,
+						0.1,
+						0.1,
+						0.1,
+						0.1,
+						0
+					]
+				]
+			}
+		]
+	}
 }

--- a/ts/src/test/static/response/limitless.json
+++ b/ts/src/test/static/response/limitless.json
@@ -188,11 +188,12 @@
 					"lastTradePrice": null
 				},
 				"parsedResponse": {
+					"outcome": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
 					"outcomeId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
 					"label": "yes",
 					"market": "USA_AUSTRALIA_BOTH_SCORE_1779980360817",
-					"timestamp": 1781895630727,
-					"datetime": "2026-06-19T19:00:30.727Z",
+					"timestamp": 1781915899427,
+					"datetime": "2026-06-20T00:38:19.427Z",
 					"high": null,
 					"low": null,
 					"bid": 0.466,
@@ -561,7 +562,6 @@
 					},
 					"indexPrice": null,
 					"markPrice": null,
-					"outcome": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
 					"event": null
 				}
 			}
@@ -636,7 +636,7 @@
 					"lastTradePrice": null
 				},
 				"parsedResponse": {
-					"symbol": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
+					"outcome": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
 					"bids": [
 						[
 							0.466,
@@ -681,9 +681,11 @@
 							500
 						]
 					],
-					"timestamp": 1781895630929,
-					"datetime": "2026-06-19T19:00:30.929Z",
-					"nonce": null
+					"timestamp": 1781915899630,
+					"datetime": "2026-06-20T00:38:19.630Z",
+					"nonce": null,
+					"outcomeId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+					"market": "USA_AUSTRALIA_BOTH_SCORE_1779980360817"
 				}
 			}
 		],

--- a/ts/src/test/static/response/limitless.json
+++ b/ts/src/test/static/response/limitless.json
@@ -1,1260 +1,1149 @@
 {
-    "exchange": "limitless",
-    "skipKeys": [
-        "timestamp",
-        "datetime"
-    ],
-    "options": {},
-    "methods": {
-        "fetchTicker": [
-            {
-                "description": "fetchTicker for a yes outcome",
-                "method": "fetchTicker",
-                "input": [
-                    "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES"
-                ],
-                "httpResponse": {
-                    "id": "185421",
-                    "automationType": "sports",
-                    "conditionId": "0x596f88053d8b0aaffb4909bc936f90915475d02f52cf8c704a3fa9a358ebd411",
-                    "negRiskRequestId": null,
-                    "description": "This market will resolve to \"YES\" if both USA and Australia score at least one goal each during regular time (90 minutes plus stoppage time only) in the World Cup match scheduled for June 19, 2026, 19:00 UTC. Otherwise, this market will res",
-                    "groupId": null,
-                    "collateralToken": {
-                        "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-                        "decimals": "6",
-                        "symbol": "USDC"
-                    },
-                    "title": "USA and Australia both to score?",
-                    "proxyTitle": null,
-                    "expirationDate": "Jun 20, 2026",
-                    "expirationTimestamp": "1781982000000",
-                    "createdAt": "2026-05-28T14:59:20.806Z",
-                    "startAt": null,
-                    "updatedAt": "2026-05-28T15:07:18.277Z",
-                    "categories": [
-                        "Props"
-                    ],
-                    "status": "FUNDED",
-                    "expired": false,
-                    "hidden": false,
-                    "creator": {
-                        "name": "Limitless",
-                        "imageURI": "https://limitless.exchange/assets/images/logo.svg",
-                        "link": "https://x.com/trylimitless",
-                        "address": "0x60e61631d9a585797cDee9f79FafDecf3bd7F64D"
-                    },
-                    "tags": [
-                        "Football",
-                        "Lumy"
-                    ],
-                    "volume": "0",
-                    "volumeFormatted": "0.000000",
-                    "tokens": {
-                        "yes": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
-                        "no": "86230754815698413619206189608906849294848879165498461416569335949589979443562"
-                    },
-                    "prices": [
-                        0.476,
-                        0.524
-                    ],
-                    "tradePrices": {
-                        "buy": {
-                            "market": [
-                                0.486,
-                                0.534
-                            ],
-                            "limit": [
-                                0.466,
-                                0.514
-                            ]
-                        },
-                        "sell": {
-                            "market": [
-                                0.466,
-                                0.514
-                            ],
-                            "limit": [
-                                0.486,
-                                0.534
-                            ]
-                        }
-                    },
-                    "isOther": false,
-                    "isRewardable": true,
-                    "slug": "usa-and-australia-both-to-score-1779980360817",
-                    "tradeType": "clob",
-                    "venue": {
-                        "exchange": "0x05c748E2f4DcDe0ec9Fa8DDc40DE6b867f923fa5",
-                        "adapter": null
-                    },
-                    "marketType": "single",
-                    "priorityIndex": "0",
-                    "winningOutcomeIndex": null,
-                    "metadata": {
-                        "fee": true,
-                        "awayTeam": "Australia",
-                        "homeTeam": "USA",
-                        "fixtureId": "1489391",
-                        "sportType": "football",
-                        "externalSlug": "fifwc-usa-aus-2026-06-19-btts",
-                        "cardsThreshold": "0",
-                        "goalsThreshold": "0",
-                        "shotsThreshold": "0",
-                        "daysBeforeMatch": "30",
-                        "binaryMarketType": "btts",
-                        "cornersThreshold": "0",
-                        "startMatchTimestampInUTC": "1781895600",
-                        "conditionalMarketSettings": {
-                            "c": "3",
-                            "minSize": "100000000",
-                            "maxSpread": "0.035",
-                            "rewardsEpoch": "0.002777777777777778"
-                        },
-                        "conditionalSettingsApplied": false,
-                        "daysBeforeMatchForSettings": "5"
-                    },
-                    "settings": {
-                        "minSize": "100000000",
-                        "maxSpread": "0.035",
-                        "dailyReward": "1",
-                        "rewardsEpoch": "0.0006944444444444445",
-                        "c": "3",
-                        "rebateRate": "0",
-                        "takerDelayMs": "250",
-                        "creatorFeePct": "0"
-                    },
-                    "imageUrl": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
-                    "logo": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
-                    "bids": [
-                        {
-                            "price": "0.466",
-                            "size": "2000000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.445",
-                            "size": "192000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.432",
-                            "size": "1157000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.002",
-                            "size": "500000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.001",
-                            "size": "1000000000",
-                            "side": "BUY"
-                        }
-                    ],
-                    "asks": [
-                        {
-                            "price": "0.486",
-                            "size": "2000000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.512",
-                            "size": "1024000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.525",
-                            "size": "400000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.99",
-                            "size": "1000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.998",
-                            "size": "500000000",
-                            "side": "SELL"
-                        }
-                    ],
-                    "tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
-                    "adjustedMidpoint": "0.476",
-                    "midpoint": "0.476",
-                    "maxSpread": "0.035",
-                    "minSize": "100000000",
-                    "lastTradePrice": null
-                },
-                "parsedResponse": {
-                    "symbol": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
-                    "timestamp": 1781289506795,
-                    "datetime": "2026-06-12T18:38:26.795Z",
-                    "high": null,
-                    "low": null,
-                    "bid": 0.466,
-                    "bidVolume": 2000,
-                    "ask": 0.486,
-                    "askVolume": 2000,
-                    "vwap": null,
-                    "open": null,
-                    "close": 0.476,
-                    "last": 0.476,
-                    "previousClose": null,
-                    "change": null,
-                    "percentage": null,
-                    "average": 0.476,
-                    "baseVolume": null,
-                    "quoteVolume": 0,
-                    "info": {
-                        "market": {
-                            "id": "185421",
-                            "automationType": "sports",
-                            "conditionId": "0x596f88053d8b0aaffb4909bc936f90915475d02f52cf8c704a3fa9a358ebd411",
-                            "negRiskRequestId": null,
-                            "description": "This market will resolve to \"YES\" if both USA and Australia score at least one goal each during regular time (90 minutes plus stoppage time only) in the World Cup match scheduled for June 19, 2026, 19:00 UTC. Otherwise, this market will res",
-                            "groupId": null,
-                            "collateralToken": {
-                                "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-                                "decimals": "6",
-                                "symbol": "USDC"
-                            },
-                            "title": "USA and Australia both to score?",
-                            "proxyTitle": null,
-                            "expirationDate": "Jun 20, 2026",
-                            "expirationTimestamp": "1781982000000",
-                            "createdAt": "2026-05-28T14:59:20.806Z",
-                            "startAt": null,
-                            "updatedAt": "2026-05-28T15:07:18.277Z",
-                            "categories": [
-                                "Props"
-                            ],
-                            "status": "FUNDED",
-                            "expired": false,
-                            "hidden": false,
-                            "creator": {
-                                "name": "Limitless",
-                                "imageURI": "https://limitless.exchange/assets/images/logo.svg",
-                                "link": "https://x.com/trylimitless",
-                                "address": "0x60e61631d9a585797cDee9f79FafDecf3bd7F64D"
-                            },
-                            "tags": [
-                                "Football",
-                                "Lumy"
-                            ],
-                            "volume": "0",
-                            "volumeFormatted": "0.000000",
-                            "tokens": {
-                                "yes": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
-                                "no": "86230754815698413619206189608906849294848879165498461416569335949589979443562"
-                            },
-                            "prices": [
-                                0.476,
-                                0.524
-                            ],
-                            "tradePrices": {
-                                "buy": {
-                                    "market": [
-                                        0.486,
-                                        0.534
-                                    ],
-                                    "limit": [
-                                        0.466,
-                                        0.514
-                                    ]
-                                },
-                                "sell": {
-                                    "market": [
-                                        0.466,
-                                        0.514
-                                    ],
-                                    "limit": [
-                                        0.486,
-                                        0.534
-                                    ]
-                                }
-                            },
-                            "isOther": false,
-                            "isRewardable": true,
-                            "slug": "usa-and-australia-both-to-score-1779980360817",
-                            "tradeType": "clob",
-                            "venue": {
-                                "exchange": "0x05c748E2f4DcDe0ec9Fa8DDc40DE6b867f923fa5",
-                                "adapter": null
-                            },
-                            "marketType": "single",
-                            "priorityIndex": "0",
-                            "winningOutcomeIndex": null,
-                            "metadata": {
-                                "fee": true,
-                                "awayTeam": "Australia",
-                                "homeTeam": "USA",
-                                "fixtureId": "1489391",
-                                "sportType": "football",
-                                "externalSlug": "fifwc-usa-aus-2026-06-19-btts",
-                                "cardsThreshold": "0",
-                                "goalsThreshold": "0",
-                                "shotsThreshold": "0",
-                                "daysBeforeMatch": "30",
-                                "binaryMarketType": "btts",
-                                "cornersThreshold": "0",
-                                "startMatchTimestampInUTC": "1781895600",
-                                "conditionalMarketSettings": {
-                                    "c": "3",
-                                    "minSize": "100000000",
-                                    "maxSpread": "0.035",
-                                    "rewardsEpoch": "0.002777777777777778"
-                                },
-                                "conditionalSettingsApplied": false,
-                                "daysBeforeMatchForSettings": "5"
-                            },
-                            "settings": {
-                                "minSize": "100000000",
-                                "maxSpread": "0.035",
-                                "dailyReward": "1",
-                                "rewardsEpoch": "0.0006944444444444445",
-                                "c": "3",
-                                "rebateRate": "0",
-                                "takerDelayMs": "250",
-                                "creatorFeePct": "0"
-                            },
-                            "imageUrl": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
-                            "logo": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
-                            "bids": [
-                                {
-                                    "price": "0.466",
-                                    "size": "2000000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.445",
-                                    "size": "192000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.432",
-                                    "size": "1157000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.002",
-                                    "size": "500000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.001",
-                                    "size": "1000000000",
-                                    "side": "BUY"
-                                }
-                            ],
-                            "asks": [
-                                {
-                                    "price": "0.486",
-                                    "size": "2000000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.512",
-                                    "size": "1024000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.525",
-                                    "size": "400000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.99",
-                                    "size": "1000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.998",
-                                    "size": "500000000",
-                                    "side": "SELL"
-                                }
-                            ],
-                            "tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
-                            "adjustedMidpoint": "0.476",
-                            "midpoint": "0.476",
-                            "maxSpread": "0.035",
-                            "minSize": "100000000",
-                            "lastTradePrice": null
-                        },
-                        "book": {
-                            "id": "185421",
-                            "automationType": "sports",
-                            "conditionId": "0x596f88053d8b0aaffb4909bc936f90915475d02f52cf8c704a3fa9a358ebd411",
-                            "negRiskRequestId": null,
-                            "description": "This market will resolve to \"YES\" if both USA and Australia score at least one goal each during regular time (90 minutes plus stoppage time only) in the World Cup match scheduled for June 19, 2026, 19:00 UTC. Otherwise, this market will res",
-                            "groupId": null,
-                            "collateralToken": {
-                                "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-                                "decimals": "6",
-                                "symbol": "USDC"
-                            },
-                            "title": "USA and Australia both to score?",
-                            "proxyTitle": null,
-                            "expirationDate": "Jun 20, 2026",
-                            "expirationTimestamp": "1781982000000",
-                            "createdAt": "2026-05-28T14:59:20.806Z",
-                            "startAt": null,
-                            "updatedAt": "2026-05-28T15:07:18.277Z",
-                            "categories": [
-                                "Props"
-                            ],
-                            "status": "FUNDED",
-                            "expired": false,
-                            "hidden": false,
-                            "creator": {
-                                "name": "Limitless",
-                                "imageURI": "https://limitless.exchange/assets/images/logo.svg",
-                                "link": "https://x.com/trylimitless",
-                                "address": "0x60e61631d9a585797cDee9f79FafDecf3bd7F64D"
-                            },
-                            "tags": [
-                                "Football",
-                                "Lumy"
-                            ],
-                            "volume": "0",
-                            "volumeFormatted": "0.000000",
-                            "tokens": {
-                                "yes": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
-                                "no": "86230754815698413619206189608906849294848879165498461416569335949589979443562"
-                            },
-                            "prices": [
-                                0.476,
-                                0.524
-                            ],
-                            "tradePrices": {
-                                "buy": {
-                                    "market": [
-                                        0.486,
-                                        0.534
-                                    ],
-                                    "limit": [
-                                        0.466,
-                                        0.514
-                                    ]
-                                },
-                                "sell": {
-                                    "market": [
-                                        0.466,
-                                        0.514
-                                    ],
-                                    "limit": [
-                                        0.486,
-                                        0.534
-                                    ]
-                                }
-                            },
-                            "isOther": false,
-                            "isRewardable": true,
-                            "slug": "usa-and-australia-both-to-score-1779980360817",
-                            "tradeType": "clob",
-                            "venue": {
-                                "exchange": "0x05c748E2f4DcDe0ec9Fa8DDc40DE6b867f923fa5",
-                                "adapter": null
-                            },
-                            "marketType": "single",
-                            "priorityIndex": "0",
-                            "winningOutcomeIndex": null,
-                            "metadata": {
-                                "fee": true,
-                                "awayTeam": "Australia",
-                                "homeTeam": "USA",
-                                "fixtureId": "1489391",
-                                "sportType": "football",
-                                "externalSlug": "fifwc-usa-aus-2026-06-19-btts",
-                                "cardsThreshold": "0",
-                                "goalsThreshold": "0",
-                                "shotsThreshold": "0",
-                                "daysBeforeMatch": "30",
-                                "binaryMarketType": "btts",
-                                "cornersThreshold": "0",
-                                "startMatchTimestampInUTC": "1781895600",
-                                "conditionalMarketSettings": {
-                                    "c": "3",
-                                    "minSize": "100000000",
-                                    "maxSpread": "0.035",
-                                    "rewardsEpoch": "0.002777777777777778"
-                                },
-                                "conditionalSettingsApplied": false,
-                                "daysBeforeMatchForSettings": "5"
-                            },
-                            "settings": {
-                                "minSize": "100000000",
-                                "maxSpread": "0.035",
-                                "dailyReward": "1",
-                                "rewardsEpoch": "0.0006944444444444445",
-                                "c": "3",
-                                "rebateRate": "0",
-                                "takerDelayMs": "250",
-                                "creatorFeePct": "0"
-                            },
-                            "imageUrl": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
-                            "logo": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
-                            "bids": [
-                                {
-                                    "price": "0.466",
-                                    "size": "2000000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.445",
-                                    "size": "192000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.432",
-                                    "size": "1157000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.002",
-                                    "size": "500000000",
-                                    "side": "BUY"
-                                },
-                                {
-                                    "price": "0.001",
-                                    "size": "1000000000",
-                                    "side": "BUY"
-                                }
-                            ],
-                            "asks": [
-                                {
-                                    "price": "0.486",
-                                    "size": "2000000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.512",
-                                    "size": "1024000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.525",
-                                    "size": "400000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.99",
-                                    "size": "1000000",
-                                    "side": "SELL"
-                                },
-                                {
-                                    "price": "0.998",
-                                    "size": "500000000",
-                                    "side": "SELL"
-                                }
-                            ],
-                            "tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
-                            "adjustedMidpoint": "0.476",
-                            "midpoint": "0.476",
-                            "maxSpread": "0.035",
-                            "minSize": "100000000",
-                            "lastTradePrice": null
-                        }
-                    },
-                    "indexPrice": null,
-                    "markPrice": null
-                }
-            }
-        ],
-        "fetchOrderBook": [
-            {
-                "description": "fetchOrderBook for a yes outcome",
-                "method": "fetchOrderBook",
-                "input": [
-                    "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES"
-                ],
-                "httpResponse": {
-                    "bids": [
-                        {
-                            "price": "0.466",
-                            "size": "2000000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.445",
-                            "size": "192000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.432",
-                            "size": "1157000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.002",
-                            "size": "500000000",
-                            "side": "BUY"
-                        },
-                        {
-                            "price": "0.001",
-                            "size": "1000000000",
-                            "side": "BUY"
-                        }
-                    ],
-                    "asks": [
-                        {
-                            "price": "0.486",
-                            "size": "2000000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.512",
-                            "size": "1024000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.525",
-                            "size": "400000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.99",
-                            "size": "1000000",
-                            "side": "SELL"
-                        },
-                        {
-                            "price": "0.998",
-                            "size": "500000000",
-                            "side": "SELL"
-                        }
-                    ],
-                    "tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
-                    "adjustedMidpoint": "0.476",
-                    "midpoint": "0.476",
-                    "maxSpread": "0.035",
-                    "minSize": "100000000",
-                    "lastTradePrice": null
-                },
-                "parsedResponse": {
-                    "symbol": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
-                    "bids": [
-                        [
-                            0.466,
-                            2000
-                        ],
-                        [
-                            0.445,
-                            192
-                        ],
-                        [
-                            0.432,
-                            1157
-                        ],
-                        [
-                            0.002,
-                            500
-                        ],
-                        [
-                            0.001,
-                            1000
-                        ]
-                    ],
-                    "asks": [
-                        [
-                            0.486,
-                            2000
-                        ],
-                        [
-                            0.512,
-                            1024
-                        ],
-                        [
-                            0.525,
-                            400
-                        ],
-                        [
-                            0.99,
-                            1
-                        ],
-                        [
-                            0.998,
-                            500
-                        ]
-                    ],
-                    "timestamp": 1781289506999,
-                    "datetime": "2026-06-12T18:38:26.999Z",
-                    "nonce": null
-                }
-            }
-        ],
-        "fetchTrades": [
-            {
-                "description": "fetchTrades with limit",
-                "method": "fetchTrades",
-                "input": [
-                    "ELON_MUSKS_NET_WORTH_EXCEED_DOLLAR115T_JUNE_19_2026_1781082321910:YES",
-                    null,
-                    3
-                ],
-                "httpResponse": {
-                    "events": [
-                        {
-                            "createdAt": "2026-06-12T17:43:09.095Z",
-                            "makerAmount": "99999512",
-                            "matchedSize": "104602000",
-                            "price": "0.956",
-                            "profile": {
-                                "id": "191123",
-                                "account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
-                                "username": "Winryy",
-                                "displayName": "Winryy",
-                                "pfpUrl": null,
-                                "socialUrl": null,
-                                "rankName": "Bronze"
-                            },
-                            "side": "0",
-                            "takerAmount": "99999512",
-                            "title": "",
-                            "tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
-                            "txHash": "0x2538d5ebe92b2ed1ee0f9c759c28fa7b4103110bd5c4701e8f96756d1b18a015"
-                        },
-                        {
-                            "createdAt": "2026-06-12T17:42:49.105Z",
-                            "makerAmount": "99999492",
-                            "matchedSize": "106044000",
-                            "price": "0.943",
-                            "profile": {
-                                "id": "191123",
-                                "account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
-                                "username": "Winryy",
-                                "displayName": "Winryy",
-                                "pfpUrl": null,
-                                "socialUrl": null,
-                                "rankName": "Bronze"
-                            },
-                            "side": "0",
-                            "takerAmount": "99999492",
-                            "title": "",
-                            "tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
-                            "txHash": "0x24054841959e28097ffd054b180a49c2127c89e36ea41eccd989f6bbc044ec74"
-                        },
-                        {
-                            "createdAt": "2026-06-12T17:42:31.312Z",
-                            "makerAmount": "99999424",
-                            "matchedSize": "107758000",
-                            "price": "0.928",
-                            "profile": {
-                                "id": "191123",
-                                "account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
-                                "username": "Winryy",
-                                "displayName": "Winryy",
-                                "pfpUrl": null,
-                                "socialUrl": null,
-                                "rankName": "Bronze"
-                            },
-                            "side": "0",
-                            "takerAmount": "99999424",
-                            "title": "",
-                            "tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
-                            "txHash": "0xa435c825bc71641b7ad96ccddf0f4fc8b6743f8b0273ba4b5680928de40c3745"
-                        }
-                    ],
-                    "limit": "3",
-                    "page": "1",
-                    "totalPages": "8",
-                    "totalRows": "24"
-                },
-                "parsedResponse": [
-                    {
-                        "id": "0xa435c825bc71641b7ad96ccddf0f4fc8b6743f8b0273ba4b5680928de40c3745",
-                        "info": {
-                            "createdAt": "2026-06-12T17:42:31.312Z",
-                            "makerAmount": "99999424",
-                            "matchedSize": "107758000",
-                            "price": "0.928",
-                            "profile": {
-                                "id": "191123",
-                                "account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
-                                "username": "Winryy",
-                                "displayName": "Winryy",
-                                "pfpUrl": null,
-                                "socialUrl": null,
-                                "rankName": "Bronze"
-                            },
-                            "side": "0",
-                            "takerAmount": "99999424",
-                            "title": "",
-                            "tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
-                            "txHash": "0xa435c825bc71641b7ad96ccddf0f4fc8b6743f8b0273ba4b5680928de40c3745"
-                        },
-                        "timestamp": 1781286151312,
-                        "datetime": "2026-06-12T17:42:31.312Z",
-                        "symbol": "ELON_MUSKS_NET_WORTH_EXCEED_DOLLAR115T_JUNE_19_2026_1781082321910:YES",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 0.928,
-                        "amount": 107.758,
-                        "cost": 99.999424,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    },
-                    {
-                        "id": "0x24054841959e28097ffd054b180a49c2127c89e36ea41eccd989f6bbc044ec74",
-                        "info": {
-                            "createdAt": "2026-06-12T17:42:49.105Z",
-                            "makerAmount": "99999492",
-                            "matchedSize": "106044000",
-                            "price": "0.943",
-                            "profile": {
-                                "id": "191123",
-                                "account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
-                                "username": "Winryy",
-                                "displayName": "Winryy",
-                                "pfpUrl": null,
-                                "socialUrl": null,
-                                "rankName": "Bronze"
-                            },
-                            "side": "0",
-                            "takerAmount": "99999492",
-                            "title": "",
-                            "tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
-                            "txHash": "0x24054841959e28097ffd054b180a49c2127c89e36ea41eccd989f6bbc044ec74"
-                        },
-                        "timestamp": 1781286169105,
-                        "datetime": "2026-06-12T17:42:49.105Z",
-                        "symbol": "ELON_MUSKS_NET_WORTH_EXCEED_DOLLAR115T_JUNE_19_2026_1781082321910:YES",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 0.943,
-                        "amount": 106.044,
-                        "cost": 99.999492,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    },
-                    {
-                        "id": "0x2538d5ebe92b2ed1ee0f9c759c28fa7b4103110bd5c4701e8f96756d1b18a015",
-                        "info": {
-                            "createdAt": "2026-06-12T17:43:09.095Z",
-                            "makerAmount": "99999512",
-                            "matchedSize": "104602000",
-                            "price": "0.956",
-                            "profile": {
-                                "id": "191123",
-                                "account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
-                                "username": "Winryy",
-                                "displayName": "Winryy",
-                                "pfpUrl": null,
-                                "socialUrl": null,
-                                "rankName": "Bronze"
-                            },
-                            "side": "0",
-                            "takerAmount": "99999512",
-                            "title": "",
-                            "tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
-                            "txHash": "0x2538d5ebe92b2ed1ee0f9c759c28fa7b4103110bd5c4701e8f96756d1b18a015"
-                        },
-                        "timestamp": 1781286189095,
-                        "datetime": "2026-06-12T17:43:09.095Z",
-                        "symbol": "ELON_MUSKS_NET_WORTH_EXCEED_DOLLAR115T_JUNE_19_2026_1781082321910:YES",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 0.956,
-                        "amount": 104.602,
-                        "cost": 99.999512,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    }
-                ]
-            }
-        ],
-        "fetchOHLCV": [
-            {
-                "description": "fetchOHLCV daily",
-                "method": "fetchOHLCV",
-                "input": [
-                    "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
-                    "1d"
-                ],
-                "httpResponse": {
-                    "title": "USA and Australia both to score?",
-                    "prices": [
-                        {
-                            "timestamp": "1781289000000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781288100000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781287200000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781286300000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781285400000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781284500000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781283600000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781282700000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781281800000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781280900000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781280000000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781279100000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781278200000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781277300000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781276400000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781275500000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781274600000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781273700000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781272800000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781271900000",
-                            "price": "0.476"
-                        },
-                        {
-                            "timestamp": "1781271000000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781270100000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781269200000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781268300000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781267400000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781266500000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781265600000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781264700000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781263800000",
-                            "price": "0.485"
-                        },
-                        {
-                            "timestamp": "1781262900000",
-                            "price": "0.485"
-                        }
-                    ],
-                    "marketStatus": "FUNDED"
-                },
-                "parsedResponse": [
-                    [
-                        1781262900000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781263800000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781264700000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781265600000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781266500000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781267400000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781268300000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781269200000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781270100000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781271000000,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0.485,
-                        0
-                    ],
-                    [
-                        1781271900000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781272800000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781273700000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781274600000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781275500000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781276400000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781277300000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781278200000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781279100000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781280000000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781280900000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781281800000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781282700000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781283600000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781284500000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781285400000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781286300000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781287200000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781288100000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ],
-                    [
-                        1781289000000,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0.476,
-                        0
-                    ]
-                ]
-            }
-        ]
-    }
+	"exchange": "limitless",
+	"skipKeys": [
+		"timestamp",
+		"datetime"
+	],
+	"options": {},
+	"methods": {
+		"fetchTicker": [
+			{
+				"description": "fetchTicker for a yes outcome",
+				"method": "fetchTicker",
+				"input": [
+					"USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES"
+				],
+				"httpResponse": {
+					"id": "185421",
+					"automationType": "sports",
+					"conditionId": "0x596f88053d8b0aaffb4909bc936f90915475d02f52cf8c704a3fa9a358ebd411",
+					"negRiskRequestId": null,
+					"description": "This market will resolve to \"YES\" if both USA and Australia score at least one goal each during regular time (90 minutes plus stoppage time only) in the World Cup match scheduled for June 19, 2026, 19:00 UTC. Otherwise, this market will res",
+					"groupId": null,
+					"collateralToken": {
+						"address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+						"decimals": "6",
+						"symbol": "USDC"
+					},
+					"title": "USA and Australia both to score?",
+					"proxyTitle": null,
+					"expirationDate": "Jun 20, 2026",
+					"expirationTimestamp": "1781982000000",
+					"createdAt": "2026-05-28T14:59:20.806Z",
+					"startAt": null,
+					"updatedAt": "2026-05-28T15:07:18.277Z",
+					"categories": [
+						"Props"
+					],
+					"status": "FUNDED",
+					"expired": false,
+					"hidden": false,
+					"creator": {
+						"name": "Limitless",
+						"imageURI": "https://limitless.exchange/assets/images/logo.svg",
+						"link": "https://x.com/trylimitless",
+						"address": "0x60e61631d9a585797cDee9f79FafDecf3bd7F64D"
+					},
+					"tags": [
+						"Football",
+						"Lumy"
+					],
+					"volume": "0",
+					"volumeFormatted": "0.000000",
+					"tokens": {
+						"yes": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+						"no": "86230754815698413619206189608906849294848879165498461416569335949589979443562"
+					},
+					"prices": [
+						0.476,
+						0.524
+					],
+					"tradePrices": {
+						"buy": {
+							"market": [
+								0.486,
+								0.534
+							],
+							"limit": [
+								0.466,
+								0.514
+							]
+						},
+						"sell": {
+							"market": [
+								0.466,
+								0.514
+							],
+							"limit": [
+								0.486,
+								0.534
+							]
+						}
+					},
+					"isOther": false,
+					"isRewardable": true,
+					"slug": "usa-and-australia-both-to-score-1779980360817",
+					"tradeType": "clob",
+					"venue": {
+						"exchange": "0x05c748E2f4DcDe0ec9Fa8DDc40DE6b867f923fa5",
+						"adapter": null
+					},
+					"marketType": "single",
+					"priorityIndex": "0",
+					"winningOutcomeIndex": null,
+					"metadata": {
+						"fee": true,
+						"awayTeam": "Australia",
+						"homeTeam": "USA",
+						"fixtureId": "1489391",
+						"sportType": "football",
+						"externalSlug": "fifwc-usa-aus-2026-06-19-btts",
+						"cardsThreshold": "0",
+						"goalsThreshold": "0",
+						"shotsThreshold": "0",
+						"daysBeforeMatch": "30",
+						"binaryMarketType": "btts",
+						"cornersThreshold": "0",
+						"startMatchTimestampInUTC": "1781895600",
+						"conditionalMarketSettings": {
+							"c": "3",
+							"minSize": "100000000",
+							"maxSpread": "0.035",
+							"rewardsEpoch": "0.002777777777777778"
+						},
+						"conditionalSettingsApplied": false,
+						"daysBeforeMatchForSettings": "5"
+					},
+					"settings": {
+						"minSize": "100000000",
+						"maxSpread": "0.035",
+						"dailyReward": "1",
+						"rewardsEpoch": "0.0006944444444444445",
+						"c": "3",
+						"rebateRate": "0",
+						"takerDelayMs": "250",
+						"creatorFeePct": "0"
+					},
+					"imageUrl": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
+					"logo": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
+					"bids": [
+						{
+							"price": "0.466",
+							"size": "2000000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.445",
+							"size": "192000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.432",
+							"size": "1157000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.002",
+							"size": "500000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.001",
+							"size": "1000000000",
+							"side": "BUY"
+						}
+					],
+					"asks": [
+						{
+							"price": "0.486",
+							"size": "2000000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.512",
+							"size": "1024000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.525",
+							"size": "400000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.99",
+							"size": "1000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.998",
+							"size": "500000000",
+							"side": "SELL"
+						}
+					],
+					"tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+					"adjustedMidpoint": "0.476",
+					"midpoint": "0.476",
+					"maxSpread": "0.035",
+					"minSize": "100000000",
+					"lastTradePrice": null
+				},
+				"parsedResponse": {
+					"outcomeId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+					"label": "yes",
+					"market": "USA_AUSTRALIA_BOTH_SCORE_1779980360817",
+					"timestamp": 1781895630727,
+					"datetime": "2026-06-19T19:00:30.727Z",
+					"high": null,
+					"low": null,
+					"bid": 0.466,
+					"bidVolume": 2000,
+					"ask": 0.486,
+					"askVolume": 2000,
+					"vwap": null,
+					"open": null,
+					"close": 0.476,
+					"last": 0.476,
+					"previousClose": null,
+					"change": null,
+					"percentage": null,
+					"average": 0.476,
+					"baseVolume": null,
+					"quoteVolume": 0,
+					"info": {
+						"market": {
+							"id": "185421",
+							"automationType": "sports",
+							"conditionId": "0x596f88053d8b0aaffb4909bc936f90915475d02f52cf8c704a3fa9a358ebd411",
+							"negRiskRequestId": null,
+							"description": "This market will resolve to \"YES\" if both USA and Australia score at least one goal each during regular time (90 minutes plus stoppage time only) in the World Cup match scheduled for June 19, 2026, 19:00 UTC. Otherwise, this market will res",
+							"groupId": null,
+							"collateralToken": {
+								"address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+								"decimals": "6",
+								"symbol": "USDC"
+							},
+							"title": "USA and Australia both to score?",
+							"proxyTitle": null,
+							"expirationDate": "Jun 20, 2026",
+							"expirationTimestamp": "1781982000000",
+							"createdAt": "2026-05-28T14:59:20.806Z",
+							"startAt": null,
+							"updatedAt": "2026-05-28T15:07:18.277Z",
+							"categories": [
+								"Props"
+							],
+							"status": "FUNDED",
+							"expired": false,
+							"hidden": false,
+							"creator": {
+								"name": "Limitless",
+								"imageURI": "https://limitless.exchange/assets/images/logo.svg",
+								"link": "https://x.com/trylimitless",
+								"address": "0x60e61631d9a585797cDee9f79FafDecf3bd7F64D"
+							},
+							"tags": [
+								"Football",
+								"Lumy"
+							],
+							"volume": "0",
+							"volumeFormatted": "0.000000",
+							"tokens": {
+								"yes": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+								"no": "86230754815698413619206189608906849294848879165498461416569335949589979443562"
+							},
+							"prices": [
+								0.476,
+								0.524
+							],
+							"tradePrices": {
+								"buy": {
+									"market": [
+										0.486,
+										0.534
+									],
+									"limit": [
+										0.466,
+										0.514
+									]
+								},
+								"sell": {
+									"market": [
+										0.466,
+										0.514
+									],
+									"limit": [
+										0.486,
+										0.534
+									]
+								}
+							},
+							"isOther": false,
+							"isRewardable": true,
+							"slug": "usa-and-australia-both-to-score-1779980360817",
+							"tradeType": "clob",
+							"venue": {
+								"exchange": "0x05c748E2f4DcDe0ec9Fa8DDc40DE6b867f923fa5",
+								"adapter": null
+							},
+							"marketType": "single",
+							"priorityIndex": "0",
+							"winningOutcomeIndex": null,
+							"metadata": {
+								"fee": true,
+								"awayTeam": "Australia",
+								"homeTeam": "USA",
+								"fixtureId": "1489391",
+								"sportType": "football",
+								"externalSlug": "fifwc-usa-aus-2026-06-19-btts",
+								"cardsThreshold": "0",
+								"goalsThreshold": "0",
+								"shotsThreshold": "0",
+								"daysBeforeMatch": "30",
+								"binaryMarketType": "btts",
+								"cornersThreshold": "0",
+								"startMatchTimestampInUTC": "1781895600",
+								"conditionalMarketSettings": {
+									"c": "3",
+									"minSize": "100000000",
+									"maxSpread": "0.035",
+									"rewardsEpoch": "0.002777777777777778"
+								},
+								"conditionalSettingsApplied": false,
+								"daysBeforeMatchForSettings": "5"
+							},
+							"settings": {
+								"minSize": "100000000",
+								"maxSpread": "0.035",
+								"dailyReward": "1",
+								"rewardsEpoch": "0.0006944444444444445",
+								"c": "3",
+								"rebateRate": "0",
+								"takerDelayMs": "250",
+								"creatorFeePct": "0"
+							},
+							"imageUrl": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
+							"logo": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
+							"bids": [
+								{
+									"price": "0.466",
+									"size": "2000000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.445",
+									"size": "192000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.432",
+									"size": "1157000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.002",
+									"size": "500000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.001",
+									"size": "1000000000",
+									"side": "BUY"
+								}
+							],
+							"asks": [
+								{
+									"price": "0.486",
+									"size": "2000000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.512",
+									"size": "1024000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.525",
+									"size": "400000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.99",
+									"size": "1000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.998",
+									"size": "500000000",
+									"side": "SELL"
+								}
+							],
+							"tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+							"adjustedMidpoint": "0.476",
+							"midpoint": "0.476",
+							"maxSpread": "0.035",
+							"minSize": "100000000",
+							"lastTradePrice": null
+						},
+						"book": {
+							"id": "185421",
+							"automationType": "sports",
+							"conditionId": "0x596f88053d8b0aaffb4909bc936f90915475d02f52cf8c704a3fa9a358ebd411",
+							"negRiskRequestId": null,
+							"description": "This market will resolve to \"YES\" if both USA and Australia score at least one goal each during regular time (90 minutes plus stoppage time only) in the World Cup match scheduled for June 19, 2026, 19:00 UTC. Otherwise, this market will res",
+							"groupId": null,
+							"collateralToken": {
+								"address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+								"decimals": "6",
+								"symbol": "USDC"
+							},
+							"title": "USA and Australia both to score?",
+							"proxyTitle": null,
+							"expirationDate": "Jun 20, 2026",
+							"expirationTimestamp": "1781982000000",
+							"createdAt": "2026-05-28T14:59:20.806Z",
+							"startAt": null,
+							"updatedAt": "2026-05-28T15:07:18.277Z",
+							"categories": [
+								"Props"
+							],
+							"status": "FUNDED",
+							"expired": false,
+							"hidden": false,
+							"creator": {
+								"name": "Limitless",
+								"imageURI": "https://limitless.exchange/assets/images/logo.svg",
+								"link": "https://x.com/trylimitless",
+								"address": "0x60e61631d9a585797cDee9f79FafDecf3bd7F64D"
+							},
+							"tags": [
+								"Football",
+								"Lumy"
+							],
+							"volume": "0",
+							"volumeFormatted": "0.000000",
+							"tokens": {
+								"yes": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+								"no": "86230754815698413619206189608906849294848879165498461416569335949589979443562"
+							},
+							"prices": [
+								0.476,
+								0.524
+							],
+							"tradePrices": {
+								"buy": {
+									"market": [
+										0.486,
+										0.534
+									],
+									"limit": [
+										0.466,
+										0.514
+									]
+								},
+								"sell": {
+									"market": [
+										0.466,
+										0.514
+									],
+									"limit": [
+										0.486,
+										0.534
+									]
+								}
+							},
+							"isOther": false,
+							"isRewardable": true,
+							"slug": "usa-and-australia-both-to-score-1779980360817",
+							"tradeType": "clob",
+							"venue": {
+								"exchange": "0x05c748E2f4DcDe0ec9Fa8DDc40DE6b867f923fa5",
+								"adapter": null
+							},
+							"marketType": "single",
+							"priorityIndex": "0",
+							"winningOutcomeIndex": null,
+							"metadata": {
+								"fee": true,
+								"awayTeam": "Australia",
+								"homeTeam": "USA",
+								"fixtureId": "1489391",
+								"sportType": "football",
+								"externalSlug": "fifwc-usa-aus-2026-06-19-btts",
+								"cardsThreshold": "0",
+								"goalsThreshold": "0",
+								"shotsThreshold": "0",
+								"daysBeforeMatch": "30",
+								"binaryMarketType": "btts",
+								"cornersThreshold": "0",
+								"startMatchTimestampInUTC": "1781895600",
+								"conditionalMarketSettings": {
+									"c": "3",
+									"minSize": "100000000",
+									"maxSpread": "0.035",
+									"rewardsEpoch": "0.002777777777777778"
+								},
+								"conditionalSettingsApplied": false,
+								"daysBeforeMatchForSettings": "5"
+							},
+							"settings": {
+								"minSize": "100000000",
+								"maxSpread": "0.035",
+								"dailyReward": "1",
+								"rewardsEpoch": "0.0006944444444444445",
+								"c": "3",
+								"rebateRate": "0",
+								"takerDelayMs": "250",
+								"creatorFeePct": "0"
+							},
+							"imageUrl": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
+							"logo": "https://storage.googleapis.com/limitless-exchange-assets/assets/ball.png",
+							"bids": [
+								{
+									"price": "0.466",
+									"size": "2000000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.445",
+									"size": "192000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.432",
+									"size": "1157000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.002",
+									"size": "500000000",
+									"side": "BUY"
+								},
+								{
+									"price": "0.001",
+									"size": "1000000000",
+									"side": "BUY"
+								}
+							],
+							"asks": [
+								{
+									"price": "0.486",
+									"size": "2000000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.512",
+									"size": "1024000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.525",
+									"size": "400000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.99",
+									"size": "1000000",
+									"side": "SELL"
+								},
+								{
+									"price": "0.998",
+									"size": "500000000",
+									"side": "SELL"
+								}
+							],
+							"tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+							"adjustedMidpoint": "0.476",
+							"midpoint": "0.476",
+							"maxSpread": "0.035",
+							"minSize": "100000000",
+							"lastTradePrice": null
+						}
+					},
+					"indexPrice": null,
+					"markPrice": null,
+					"outcome": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
+					"event": null
+				}
+			}
+		],
+		"fetchOrderBook": [
+			{
+				"description": "fetchOrderBook for a yes outcome",
+				"method": "fetchOrderBook",
+				"input": [
+					"USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES"
+				],
+				"httpResponse": {
+					"bids": [
+						{
+							"price": "0.466",
+							"size": "2000000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.445",
+							"size": "192000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.432",
+							"size": "1157000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.002",
+							"size": "500000000",
+							"side": "BUY"
+						},
+						{
+							"price": "0.001",
+							"size": "1000000000",
+							"side": "BUY"
+						}
+					],
+					"asks": [
+						{
+							"price": "0.486",
+							"size": "2000000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.512",
+							"size": "1024000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.525",
+							"size": "400000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.99",
+							"size": "1000000",
+							"side": "SELL"
+						},
+						{
+							"price": "0.998",
+							"size": "500000000",
+							"side": "SELL"
+						}
+					],
+					"tokenId": "86754852064474869881286364251658764942266025328391522221494274517474936254814",
+					"adjustedMidpoint": "0.476",
+					"midpoint": "0.476",
+					"maxSpread": "0.035",
+					"minSize": "100000000",
+					"lastTradePrice": null
+				},
+				"parsedResponse": {
+					"symbol": "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
+					"bids": [
+						[
+							0.466,
+							2000
+						],
+						[
+							0.445,
+							192
+						],
+						[
+							0.432,
+							1157
+						],
+						[
+							0.002,
+							500
+						],
+						[
+							0.001,
+							1000
+						]
+					],
+					"asks": [
+						[
+							0.486,
+							2000
+						],
+						[
+							0.512,
+							1024
+						],
+						[
+							0.525,
+							400
+						],
+						[
+							0.99,
+							1
+						],
+						[
+							0.998,
+							500
+						]
+					],
+					"timestamp": 1781895630929,
+					"datetime": "2026-06-19T19:00:30.929Z",
+					"nonce": null
+				}
+			}
+		],
+		"fetchTrades": [
+			{
+				"description": "fetchTrades with limit",
+				"method": "fetchTrades",
+				"input": [
+					"ELON_MUSKS_NET_WORTH_EXCEED_DOLLAR115T_JUNE_19_2026_1781082321910:YES",
+					null,
+					3
+				],
+				"httpResponse": {
+					"events": [
+						{
+							"createdAt": "2026-06-12T17:43:09.095Z",
+							"makerAmount": "99999512",
+							"matchedSize": "104602000",
+							"price": "0.956",
+							"profile": {
+								"id": "191123",
+								"account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
+								"username": "Winryy",
+								"displayName": "Winryy",
+								"pfpUrl": null,
+								"socialUrl": null,
+								"rankName": "Bronze"
+							},
+							"side": "0",
+							"takerAmount": "99999512",
+							"title": "",
+							"tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
+							"txHash": "0x2538d5ebe92b2ed1ee0f9c759c28fa7b4103110bd5c4701e8f96756d1b18a015"
+						},
+						{
+							"createdAt": "2026-06-12T17:42:49.105Z",
+							"makerAmount": "99999492",
+							"matchedSize": "106044000",
+							"price": "0.943",
+							"profile": {
+								"id": "191123",
+								"account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
+								"username": "Winryy",
+								"displayName": "Winryy",
+								"pfpUrl": null,
+								"socialUrl": null,
+								"rankName": "Bronze"
+							},
+							"side": "0",
+							"takerAmount": "99999492",
+							"title": "",
+							"tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
+							"txHash": "0x24054841959e28097ffd054b180a49c2127c89e36ea41eccd989f6bbc044ec74"
+						},
+						{
+							"createdAt": "2026-06-12T17:42:31.312Z",
+							"makerAmount": "99999424",
+							"matchedSize": "107758000",
+							"price": "0.928",
+							"profile": {
+								"id": "191123",
+								"account": "0xd1af707df546e3195618E4519F5e78ceE9247678",
+								"username": "Winryy",
+								"displayName": "Winryy",
+								"pfpUrl": null,
+								"socialUrl": null,
+								"rankName": "Bronze"
+							},
+							"side": "0",
+							"takerAmount": "99999424",
+							"title": "",
+							"tokenId": "107351533390162975244672983811852739852090084984816899292786653138720848063052",
+							"txHash": "0xa435c825bc71641b7ad96ccddf0f4fc8b6743f8b0273ba4b5680928de40c3745"
+						}
+					],
+					"limit": "3",
+					"page": "1",
+					"totalPages": "8",
+					"totalRows": "24"
+				},
+				"parsedResponse": []
+			}
+		],
+		"fetchOHLCV": [
+			{
+				"description": "fetchOHLCV daily",
+				"method": "fetchOHLCV",
+				"input": [
+					"USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
+					"1d"
+				],
+				"httpResponse": {
+					"title": "USA and Australia both to score?",
+					"prices": [
+						{
+							"timestamp": "1781289000000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781288100000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781287200000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781286300000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781285400000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781284500000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781283600000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781282700000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781281800000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781280900000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781280000000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781279100000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781278200000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781277300000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781276400000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781275500000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781274600000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781273700000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781272800000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781271900000",
+							"price": "0.476"
+						},
+						{
+							"timestamp": "1781271000000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781270100000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781269200000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781268300000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781267400000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781266500000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781265600000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781264700000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781263800000",
+							"price": "0.485"
+						},
+						{
+							"timestamp": "1781262900000",
+							"price": "0.485"
+						}
+					],
+					"marketStatus": "FUNDED"
+				},
+				"parsedResponse": [
+					[
+						1781262900000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781263800000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781264700000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781265600000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781266500000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781267400000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781268300000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781269200000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781270100000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781271000000,
+						0.485,
+						0.485,
+						0.485,
+						0.485,
+						0
+					],
+					[
+						1781271900000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781272800000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781273700000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781274600000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781275500000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781276400000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781277300000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781278200000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781279100000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781280000000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781280900000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781281800000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781282700000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781283600000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781284500000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781285400000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781286300000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781287200000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781288100000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					],
+					[
+						1781289000000,
+						0.476,
+						0.476,
+						0.476,
+						0.476,
+						0
+					]
+				]
+			}
+		]
+	}
 }

--- a/ts/src/test/static/response/myriad.json
+++ b/ts/src/test/static/response/myriad.json
@@ -120,11 +120,12 @@
 					"externalSources": []
 				},
 				"parsedResponse": {
+					"outcome": "POLYMARKET_KALSHI:POLYMARKET",
 					"outcomeId": "2741:549/0",
 					"label": "Polymarket",
 					"market": "POLYMARKET_KALSHI:POLYMARKET",
-					"timestamp": 1781895628750,
-					"datetime": "2026-06-19T19:00:28.750Z",
+					"timestamp": 1781915900351,
+					"datetime": "2026-06-20T00:38:20.351Z",
 					"high": null,
 					"low": null,
 					"bid": 0.72519807,
@@ -249,7 +250,6 @@
 					},
 					"indexPrice": null,
 					"markPrice": null,
-					"outcome": "POLYMARKET_KALSHI:POLYMARKET",
 					"event": null
 				}
 			}
@@ -372,11 +372,12 @@
 				},
 				"parsedResponse": {
 					"POLYMARKET_KALSHI:POLYMARKET": {
+						"outcome": "POLYMARKET_KALSHI:POLYMARKET",
 						"outcomeId": "2741:549/0",
 						"label": "Polymarket",
 						"market": "POLYMARKET_KALSHI:POLYMARKET",
-						"timestamp": 1781895628952,
-						"datetime": "2026-06-19T19:00:28.952Z",
+						"timestamp": 1781915900552,
+						"datetime": "2026-06-20T00:38:20.552Z",
 						"high": null,
 						"low": null,
 						"bid": 0.72519807,
@@ -501,15 +502,15 @@
 						},
 						"indexPrice": null,
 						"markPrice": null,
-						"outcome": "POLYMARKET_KALSHI:POLYMARKET",
 						"event": null
 					},
 					"POLYMARKET_KALSHI:KALSHI": {
+						"outcome": "POLYMARKET_KALSHI:KALSHI",
 						"outcomeId": "2741:549/1",
 						"label": "Kalshi",
 						"market": "POLYMARKET_KALSHI:KALSHI",
-						"timestamp": 1781895628952,
-						"datetime": "2026-06-19T19:00:28.952Z",
+						"timestamp": 1781915900552,
+						"datetime": "2026-06-20T00:38:20.552Z",
 						"high": null,
 						"low": null,
 						"bid": 0.27480193,
@@ -634,7 +635,6 @@
 						},
 						"indexPrice": null,
 						"markPrice": null,
-						"outcome": "POLYMARKET_KALSHI:KALSHI",
 						"event": null
 					}
 				}
@@ -754,7 +754,7 @@
 					"externalSources": []
 				},
 				"parsedResponse": {
-					"symbol": "POLYMARKET_KALSHI:POLYMARKET",
+					"outcome": "POLYMARKET_KALSHI:POLYMARKET",
 					"bids": [
 						[
 							0.72419807,
@@ -767,9 +767,11 @@
 							9999
 						]
 					],
-					"timestamp": 1781895629152,
-					"datetime": "2026-06-19T19:00:29.152Z",
-					"nonce": null
+					"timestamp": 1781915900754,
+					"datetime": "2026-06-20T00:38:20.754Z",
+					"nonce": null,
+					"outcomeId": "2741:549/0",
+					"market": "POLYMARKET_KALSHI"
 				}
 			}
 		],

--- a/ts/src/test/static/response/myriad.json
+++ b/ts/src/test/static/response/myriad.json
@@ -1,1551 +1,1527 @@
 {
-    "exchange": "myriad",
-    "skipKeys": [
-        "timestamp",
-        "datetime"
-    ],
-    "options": {},
-    "methods": {
-        "fetchTicker": [
-            {
-                "description": "fetchTicker for an outcome",
-                "method": "fetchTicker",
-                "input": [
-                    "POLYMARKET_KALSHI:POLYMARKET"
-                ],
-                "httpResponse": {
-                    "id": "549",
-                    "networkId": "2741",
-                    "slug": "polymarket-or-kalshi",
-                    "title": "Polymarket or Kalshi?",
-                    "shortName": null,
-                    "ctaName": null,
-                    "description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
-                    "publishedAt": "2025-11-08T11:02:20.000Z",
-                    "expiresAt": "2100-01-01T00:01:00.000Z",
-                    "resolvesAt": null,
-                    "fees": {
-                        "buy": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "sell": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
-                        "distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
-                    },
-                    "state": "open",
-                    "voided": false,
-                    "resolvedOutcomeId": "-1",
-                    "topics": [
-                        "Sentiment"
-                    ],
-                    "tags": [],
-                    "resolutionSource": "https://x.com/myriadmarkets",
-                    "resolutionTitle": "You",
-                    "token": {
-                        "name": "Bridged USDC (Stargate)",
-                        "address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                        "symbol": "USDC.e",
-                        "decimals": "6"
-                    },
-                    "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                    "bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
-                    "ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
-                    "liquidity": "1000",
-                    "liquidityPrice": "0.89296615",
-                    "volume": "11792850.814653",
-                    "volume24h": "1.029",
-                    "volumeNotional": "15796115.564182",
-                    "volumeNotional24h": "1.418676",
-                    "users": "1071",
-                    "shares": "2240.415558",
-                    "featured": false,
-                    "featuredAt": null,
-                    "inPlay": false,
-                    "inPlayStartsAt": null,
-                    "perpetual": true,
-                    "moneyline": false,
-                    "executionMode": "0",
-                    "tradingModel": "amm",
-                    "topHolders": [
-                        "0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
-                        "0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
-                        "0x304fc7881ce775dd94607B4165006b70D885b441"
-                    ],
-                    "outcomes": [
-                        {
-                            "id": "0",
-                            "title": "Polymarket",
-                            "shares": "615.670527",
-                            "sharesHeld": "1559.441408",
-                            "price": "0.72519807",
-                            "closingPrice": null,
-                            "priceChange24h": "-0.00034775",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "holders": "122",
-                            "tokenId": "1098"
-                        },
-                        {
-                            "id": "1",
-                            "title": "Kalshi",
-                            "shares": "1624.745031",
-                            "sharesHeld": "550.366904",
-                            "price": "0.27480193",
-                            "closingPrice": null,
-                            "priceChange24h": "0.00091887",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": null,
-                            "holders": "10",
-                            "tokenId": "1099"
-                        }
-                    ],
-                    "eventId": null,
-                    "outcomeIndex": null,
-                    "negRisk": false,
-                    "oracle": {
-                        "address": null,
-                        "name": "Myriad",
-                        "url": "https://myriad.markets",
-                        "image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
-                        "data": null
-                    },
-                    "externalSources": []
-                },
-                "parsedResponse": {
-                    "symbol": "POLYMARKET_KALSHI:POLYMARKET",
-                    "timestamp": 1781357703526,
-                    "datetime": "2026-06-13T13:35:03.526Z",
-                    "high": null,
-                    "low": null,
-                    "bid": 0.72519807,
-                    "bidVolume": null,
-                    "ask": 0.72519807,
-                    "askVolume": null,
-                    "vwap": 1.3786938775510205,
-                    "open": 0.72554582,
-                    "close": 0.72519807,
-                    "last": 0.72519807,
-                    "previousClose": null,
-                    "change": -0.00034775,
-                    "percentage": -0.00034775,
-                    "average": 0.72519807,
-                    "baseVolume": 1.029,
-                    "quoteVolume": 1.418676,
-                    "info": {
-                        "id": "549",
-                        "networkId": "2741",
-                        "slug": "polymarket-or-kalshi",
-                        "title": "Polymarket or Kalshi?",
-                        "shortName": null,
-                        "ctaName": null,
-                        "description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
-                        "publishedAt": "2025-11-08T11:02:20.000Z",
-                        "expiresAt": "2100-01-01T00:01:00.000Z",
-                        "resolvesAt": null,
-                        "fees": {
-                            "buy": {
-                                "fee": "0",
-                                "treasury_fee": "0",
-                                "distributor_fee": "0"
-                            },
-                            "sell": {
-                                "fee": "0",
-                                "treasury_fee": "0",
-                                "distributor_fee": "0"
-                            },
-                            "treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
-                            "distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
-                        },
-                        "state": "open",
-                        "voided": false,
-                        "resolvedOutcomeId": "-1",
-                        "topics": [
-                            "Sentiment"
-                        ],
-                        "tags": [],
-                        "resolutionSource": "https://x.com/myriadmarkets",
-                        "resolutionTitle": "You",
-                        "token": {
-                            "name": "Bridged USDC (Stargate)",
-                            "address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                            "symbol": "USDC.e",
-                            "decimals": "6"
-                        },
-                        "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                        "bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
-                        "ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
-                        "liquidity": "1000",
-                        "liquidityPrice": "0.89296615",
-                        "volume": "11792850.814653",
-                        "volume24h": "1.029",
-                        "volumeNotional": "15796115.564182",
-                        "volumeNotional24h": "1.418676",
-                        "users": "1071",
-                        "shares": "2240.415558",
-                        "featured": false,
-                        "featuredAt": null,
-                        "inPlay": false,
-                        "inPlayStartsAt": null,
-                        "perpetual": true,
-                        "moneyline": false,
-                        "executionMode": "0",
-                        "tradingModel": "amm",
-                        "topHolders": [
-                            "0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
-                            "0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
-                            "0x304fc7881ce775dd94607B4165006b70D885b441"
-                        ],
-                        "outcomes": [
-                            {
-                                "id": "0",
-                                "title": "Polymarket",
-                                "shares": "615.670527",
-                                "sharesHeld": "1559.441408",
-                                "price": "0.72519807",
-                                "closingPrice": null,
-                                "priceChange24h": "-0.00034775",
-                                "bestBid": null,
-                                "bestAsk": null,
-                                "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                                "holders": "122",
-                                "tokenId": "1098"
-                            },
-                            {
-                                "id": "1",
-                                "title": "Kalshi",
-                                "shares": "1624.745031",
-                                "sharesHeld": "550.366904",
-                                "price": "0.27480193",
-                                "closingPrice": null,
-                                "priceChange24h": "0.00091887",
-                                "bestBid": null,
-                                "bestAsk": null,
-                                "imageUrl": null,
-                                "holders": "10",
-                                "tokenId": "1099"
-                            }
-                        ],
-                        "eventId": null,
-                        "outcomeIndex": null,
-                        "negRisk": false,
-                        "oracle": {
-                            "address": null,
-                            "name": "Myriad",
-                            "url": "https://myriad.markets",
-                            "image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
-                            "data": null
-                        },
-                        "externalSources": []
-                    },
-                    "indexPrice": null,
-                    "markPrice": null
-                }
-            }
-        ],
-        "fetchTickers": [
-            {
-                "description": "fetchTickers with two outcomes of the same market",
-                "method": "fetchTickers",
-                "input": [
-                    [
-                        "POLYMARKET_KALSHI:POLYMARKET",
-                        "POLYMARKET_KALSHI:KALSHI"
-                    ]
-                ],
-                "httpResponse": {
-                    "id": "549",
-                    "networkId": "2741",
-                    "slug": "polymarket-or-kalshi",
-                    "title": "Polymarket or Kalshi?",
-                    "shortName": null,
-                    "ctaName": null,
-                    "description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
-                    "publishedAt": "2025-11-08T11:02:20.000Z",
-                    "expiresAt": "2100-01-01T00:01:00.000Z",
-                    "resolvesAt": null,
-                    "fees": {
-                        "buy": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "sell": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
-                        "distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
-                    },
-                    "state": "open",
-                    "voided": false,
-                    "resolvedOutcomeId": "-1",
-                    "topics": [
-                        "Sentiment"
-                    ],
-                    "tags": [],
-                    "resolutionSource": "https://x.com/myriadmarkets",
-                    "resolutionTitle": "You",
-                    "token": {
-                        "name": "Bridged USDC (Stargate)",
-                        "address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                        "symbol": "USDC.e",
-                        "decimals": "6"
-                    },
-                    "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                    "bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
-                    "ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
-                    "liquidity": "1000",
-                    "liquidityPrice": "0.89296615",
-                    "volume": "11792850.814653",
-                    "volume24h": "1.029",
-                    "volumeNotional": "15796115.564182",
-                    "volumeNotional24h": "1.418676",
-                    "users": "1071",
-                    "shares": "2240.415558",
-                    "featured": false,
-                    "featuredAt": null,
-                    "inPlay": false,
-                    "inPlayStartsAt": null,
-                    "perpetual": true,
-                    "moneyline": false,
-                    "executionMode": "0",
-                    "tradingModel": "amm",
-                    "topHolders": [
-                        "0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
-                        "0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
-                        "0x304fc7881ce775dd94607B4165006b70D885b441"
-                    ],
-                    "outcomes": [
-                        {
-                            "id": "0",
-                            "title": "Polymarket",
-                            "shares": "615.670527",
-                            "sharesHeld": "1559.441408",
-                            "price": "0.72519807",
-                            "closingPrice": null,
-                            "priceChange24h": "-0.00034775",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "holders": "122",
-                            "tokenId": "1098"
-                        },
-                        {
-                            "id": "1",
-                            "title": "Kalshi",
-                            "shares": "1624.745031",
-                            "sharesHeld": "550.366904",
-                            "price": "0.27480193",
-                            "closingPrice": null,
-                            "priceChange24h": "0.00091887",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": null,
-                            "holders": "10",
-                            "tokenId": "1099"
-                        }
-                    ],
-                    "eventId": null,
-                    "outcomeIndex": null,
-                    "negRisk": false,
-                    "oracle": {
-                        "address": null,
-                        "name": "Myriad",
-                        "url": "https://myriad.markets",
-                        "image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
-                        "data": null
-                    },
-                    "externalSources": []
-                },
-                "parsedResponse": {
-                    "POLYMARKET_KALSHI:POLYMARKET": {
-                        "symbol": "POLYMARKET_KALSHI:POLYMARKET",
-                        "timestamp": 1781357703529,
-                        "datetime": "2026-06-13T13:35:03.529Z",
-                        "high": null,
-                        "low": null,
-                        "bid": 0.72519807,
-                        "bidVolume": null,
-                        "ask": 0.72519807,
-                        "askVolume": null,
-                        "vwap": 1.3786938775510205,
-                        "open": 0.72554582,
-                        "close": 0.72519807,
-                        "last": 0.72519807,
-                        "previousClose": null,
-                        "change": -0.00034775,
-                        "percentage": -0.00034775,
-                        "average": 0.72519807,
-                        "baseVolume": 1.029,
-                        "quoteVolume": 1.418676,
-                        "info": {
-                            "id": "549",
-                            "networkId": "2741",
-                            "slug": "polymarket-or-kalshi",
-                            "title": "Polymarket or Kalshi?",
-                            "shortName": null,
-                            "ctaName": null,
-                            "description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
-                            "publishedAt": "2025-11-08T11:02:20.000Z",
-                            "expiresAt": "2100-01-01T00:01:00.000Z",
-                            "resolvesAt": null,
-                            "fees": {
-                                "buy": {
-                                    "fee": "0",
-                                    "treasury_fee": "0",
-                                    "distributor_fee": "0"
-                                },
-                                "sell": {
-                                    "fee": "0",
-                                    "treasury_fee": "0",
-                                    "distributor_fee": "0"
-                                },
-                                "treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
-                                "distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
-                            },
-                            "state": "open",
-                            "voided": false,
-                            "resolvedOutcomeId": "-1",
-                            "topics": [
-                                "Sentiment"
-                            ],
-                            "tags": [],
-                            "resolutionSource": "https://x.com/myriadmarkets",
-                            "resolutionTitle": "You",
-                            "token": {
-                                "name": "Bridged USDC (Stargate)",
-                                "address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                                "symbol": "USDC.e",
-                                "decimals": "6"
-                            },
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
-                            "ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
-                            "liquidity": "1000",
-                            "liquidityPrice": "0.89296615",
-                            "volume": "11792850.814653",
-                            "volume24h": "1.029",
-                            "volumeNotional": "15796115.564182",
-                            "volumeNotional24h": "1.418676",
-                            "users": "1071",
-                            "shares": "2240.415558",
-                            "featured": false,
-                            "featuredAt": null,
-                            "inPlay": false,
-                            "inPlayStartsAt": null,
-                            "perpetual": true,
-                            "moneyline": false,
-                            "executionMode": "0",
-                            "tradingModel": "amm",
-                            "topHolders": [
-                                "0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
-                                "0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
-                                "0x304fc7881ce775dd94607B4165006b70D885b441"
-                            ],
-                            "outcomes": [
-                                {
-                                    "id": "0",
-                                    "title": "Polymarket",
-                                    "shares": "615.670527",
-                                    "sharesHeld": "1559.441408",
-                                    "price": "0.72519807",
-                                    "closingPrice": null,
-                                    "priceChange24h": "-0.00034775",
-                                    "bestBid": null,
-                                    "bestAsk": null,
-                                    "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                                    "holders": "122",
-                                    "tokenId": "1098"
-                                },
-                                {
-                                    "id": "1",
-                                    "title": "Kalshi",
-                                    "shares": "1624.745031",
-                                    "sharesHeld": "550.366904",
-                                    "price": "0.27480193",
-                                    "closingPrice": null,
-                                    "priceChange24h": "0.00091887",
-                                    "bestBid": null,
-                                    "bestAsk": null,
-                                    "imageUrl": null,
-                                    "holders": "10",
-                                    "tokenId": "1099"
-                                }
-                            ],
-                            "eventId": null,
-                            "outcomeIndex": null,
-                            "negRisk": false,
-                            "oracle": {
-                                "address": null,
-                                "name": "Myriad",
-                                "url": "https://myriad.markets",
-                                "image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
-                                "data": null
-                            },
-                            "externalSources": []
-                        },
-                        "indexPrice": null,
-                        "markPrice": null
-                    },
-                    "POLYMARKET_KALSHI:KALSHI": {
-                        "symbol": "POLYMARKET_KALSHI:KALSHI",
-                        "timestamp": 1781357703529,
-                        "datetime": "2026-06-13T13:35:03.529Z",
-                        "high": null,
-                        "low": null,
-                        "bid": 0.27480193,
-                        "bidVolume": null,
-                        "ask": 0.27480193,
-                        "askVolume": null,
-                        "vwap": 1.3786938775510205,
-                        "open": 0.27388306,
-                        "close": 0.27480193,
-                        "last": 0.27480193,
-                        "previousClose": null,
-                        "change": 0.00091887,
-                        "percentage": 0.00091887,
-                        "average": 0.27480193,
-                        "baseVolume": 1.029,
-                        "quoteVolume": 1.418676,
-                        "info": {
-                            "id": "549",
-                            "networkId": "2741",
-                            "slug": "polymarket-or-kalshi",
-                            "title": "Polymarket or Kalshi?",
-                            "shortName": null,
-                            "ctaName": null,
-                            "description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
-                            "publishedAt": "2025-11-08T11:02:20.000Z",
-                            "expiresAt": "2100-01-01T00:01:00.000Z",
-                            "resolvesAt": null,
-                            "fees": {
-                                "buy": {
-                                    "fee": "0",
-                                    "treasury_fee": "0",
-                                    "distributor_fee": "0"
-                                },
-                                "sell": {
-                                    "fee": "0",
-                                    "treasury_fee": "0",
-                                    "distributor_fee": "0"
-                                },
-                                "treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
-                                "distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
-                            },
-                            "state": "open",
-                            "voided": false,
-                            "resolvedOutcomeId": "-1",
-                            "topics": [
-                                "Sentiment"
-                            ],
-                            "tags": [],
-                            "resolutionSource": "https://x.com/myriadmarkets",
-                            "resolutionTitle": "You",
-                            "token": {
-                                "name": "Bridged USDC (Stargate)",
-                                "address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                                "symbol": "USDC.e",
-                                "decimals": "6"
-                            },
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
-                            "ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
-                            "liquidity": "1000",
-                            "liquidityPrice": "0.89296615",
-                            "volume": "11792850.814653",
-                            "volume24h": "1.029",
-                            "volumeNotional": "15796115.564182",
-                            "volumeNotional24h": "1.418676",
-                            "users": "1071",
-                            "shares": "2240.415558",
-                            "featured": false,
-                            "featuredAt": null,
-                            "inPlay": false,
-                            "inPlayStartsAt": null,
-                            "perpetual": true,
-                            "moneyline": false,
-                            "executionMode": "0",
-                            "tradingModel": "amm",
-                            "topHolders": [
-                                "0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
-                                "0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
-                                "0x304fc7881ce775dd94607B4165006b70D885b441"
-                            ],
-                            "outcomes": [
-                                {
-                                    "id": "0",
-                                    "title": "Polymarket",
-                                    "shares": "615.670527",
-                                    "sharesHeld": "1559.441408",
-                                    "price": "0.72519807",
-                                    "closingPrice": null,
-                                    "priceChange24h": "-0.00034775",
-                                    "bestBid": null,
-                                    "bestAsk": null,
-                                    "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                                    "holders": "122",
-                                    "tokenId": "1098"
-                                },
-                                {
-                                    "id": "1",
-                                    "title": "Kalshi",
-                                    "shares": "1624.745031",
-                                    "sharesHeld": "550.366904",
-                                    "price": "0.27480193",
-                                    "closingPrice": null,
-                                    "priceChange24h": "0.00091887",
-                                    "bestBid": null,
-                                    "bestAsk": null,
-                                    "imageUrl": null,
-                                    "holders": "10",
-                                    "tokenId": "1099"
-                                }
-                            ],
-                            "eventId": null,
-                            "outcomeIndex": null,
-                            "negRisk": false,
-                            "oracle": {
-                                "address": null,
-                                "name": "Myriad",
-                                "url": "https://myriad.markets",
-                                "image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
-                                "data": null
-                            },
-                            "externalSources": []
-                        },
-                        "indexPrice": null,
-                        "markPrice": null
-                    }
-                }
-            }
-        ],
-        "fetchOrderBook": [
-            {
-                "description": "fetchOrderBook for an amm market",
-                "method": "fetchOrderBook",
-                "input": [
-                    "POLYMARKET_KALSHI:POLYMARKET"
-                ],
-                "httpResponse": {
-                    "id": "549",
-                    "networkId": "2741",
-                    "slug": "polymarket-or-kalshi",
-                    "title": "Polymarket or Kalshi?",
-                    "shortName": null,
-                    "ctaName": null,
-                    "description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
-                    "publishedAt": "2025-11-08T11:02:20.000Z",
-                    "expiresAt": "2100-01-01T00:01:00.000Z",
-                    "resolvesAt": null,
-                    "fees": {
-                        "buy": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "sell": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
-                        "distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
-                    },
-                    "state": "open",
-                    "voided": false,
-                    "resolvedOutcomeId": "-1",
-                    "topics": [
-                        "Sentiment"
-                    ],
-                    "tags": [],
-                    "resolutionSource": "https://x.com/myriadmarkets",
-                    "resolutionTitle": "You",
-                    "token": {
-                        "name": "Bridged USDC (Stargate)",
-                        "address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                        "symbol": "USDC.e",
-                        "decimals": "6"
-                    },
-                    "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                    "bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
-                    "ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
-                    "liquidity": "1000",
-                    "liquidityPrice": "0.89296615",
-                    "volume": "11792850.814653",
-                    "volume24h": "1.029",
-                    "volumeNotional": "15796115.564182",
-                    "volumeNotional24h": "1.418676",
-                    "users": "1071",
-                    "shares": "2240.415558",
-                    "featured": false,
-                    "featuredAt": null,
-                    "inPlay": false,
-                    "inPlayStartsAt": null,
-                    "perpetual": true,
-                    "moneyline": false,
-                    "executionMode": "0",
-                    "tradingModel": "amm",
-                    "topHolders": [
-                        "0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
-                        "0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
-                        "0x304fc7881ce775dd94607B4165006b70D885b441"
-                    ],
-                    "outcomes": [
-                        {
-                            "id": "0",
-                            "title": "Polymarket",
-                            "shares": "615.670527",
-                            "sharesHeld": "1559.441408",
-                            "price": "0.72519807",
-                            "closingPrice": null,
-                            "priceChange24h": "-0.00034775",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "holders": "122",
-                            "tokenId": "1098"
-                        },
-                        {
-                            "id": "1",
-                            "title": "Kalshi",
-                            "shares": "1624.745031",
-                            "sharesHeld": "550.366904",
-                            "price": "0.27480193",
-                            "closingPrice": null,
-                            "priceChange24h": "0.00091887",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": null,
-                            "holders": "10",
-                            "tokenId": "1099"
-                        }
-                    ],
-                    "eventId": null,
-                    "outcomeIndex": null,
-                    "negRisk": false,
-                    "oracle": {
-                        "address": null,
-                        "name": "Myriad",
-                        "url": "https://myriad.markets",
-                        "image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
-                        "data": null
-                    },
-                    "externalSources": []
-                },
-                "parsedResponse": {
-                    "symbol": "POLYMARKET_KALSHI:POLYMARKET",
-                    "bids": [
-                        [
-                            0.72419807,
-                            9999
-                        ]
-                    ],
-                    "asks": [
-                        [
-                            0.72619807,
-                            9999
-                        ]
-                    ],
-                    "timestamp": 1781289454527,
-                    "datetime": "2026-06-12T18:37:34.527Z",
-                    "nonce": null
-                }
-            }
-        ],
-        "fetchTrades": [
-            {
-                "description": "fetchTrades with limit",
-                "method": "fetchTrades",
-                "input": [
-                    "POLYMARKET_KALSHI:POLYMARKET",
-                    null,
-                    3
-                ],
-                "httpResponse": {
-                    "data": [
-                        {
-                            "user": "0xD567662886faC76A73537c7a0cb18f4D5c2D841F",
-                            "action": "sell",
-                            "marketTitle": "Polymarket or Kalshi?",
-                            "marketSlug": "polymarket-or-kalshi",
-                            "marketId": "549",
-                            "networkId": "2741",
-                            "outcomeTitle": "Polymarket",
-                            "outcomeId": "0",
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "shares": "1.418676",
-                            "value": "1.029",
-                            "timestamp": "1780852609",
-                            "blockNumber": "68248304",
-                            "token": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                            "txId": "0x7cb221d8f840a7f5fb4d2655d34df7092b4b40762c34ebdd2233e81daa60365d"
-                        },
-                        {
-                            "user": "0x43De6c46B54f4dd51F4ECDaaeEed11ac4D11301e",
-                            "action": "sell",
-                            "marketTitle": "Polymarket or Kalshi?",
-                            "marketSlug": "polymarket-or-kalshi",
-                            "marketId": "549",
-                            "networkId": "2741",
-                            "outcomeTitle": "Kalshi",
-                            "outcomeId": "1",
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "shares": "46.494609",
-                            "value": "12.959",
-                            "timestamp": "1779777188",
-                            "blockNumber": "65022091",
-                            "token": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                            "txId": "0xb456979a025926006e603017ef724db4ff50639257c2b5903c3d24e2f28bf1dc"
-                        },
-                        {
-                            "user": "0x0458DcB6A70776f7d13F5E4c170E2ec3c1F53976",
-                            "action": "sell",
-                            "marketTitle": "Polymarket or Kalshi?",
-                            "marketSlug": "polymarket-or-kalshi",
-                            "marketId": "549",
-                            "networkId": "2741",
-                            "outcomeTitle": "Kalshi",
-                            "outcomeId": "1",
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "shares": "32.614935",
-                            "value": "9.325553",
-                            "timestamp": "1779684631",
-                            "blockNumber": "64775443",
-                            "token": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                            "txId": "0xbff632359aefef69d307b8297cda73fe2084fe5a2dfb608070e4914875fcc2c4"
-                        }
-                    ],
-                    "pagination": {
-                        "page": "1",
-                        "limit": "3",
-                        "total": "401250",
-                        "totalPages": "133750",
-                        "hasNext": true,
-                        "hasPrev": false
-                    }
-                },
-                "parsedResponse": [
-                    {
-                        "id": "0x7cb221d8f840a7f5fb4d2655d34df7092b4b40762c34ebdd2233e81daa60365d",
-                        "info": {
-                            "user": "0xD567662886faC76A73537c7a0cb18f4D5c2D841F",
-                            "action": "sell",
-                            "marketTitle": "Polymarket or Kalshi?",
-                            "marketSlug": "polymarket-or-kalshi",
-                            "marketId": "549",
-                            "networkId": "2741",
-                            "outcomeTitle": "Polymarket",
-                            "outcomeId": "0",
-                            "imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
-                            "shares": "1.418676",
-                            "value": "1.029",
-                            "timestamp": "1780852609",
-                            "blockNumber": "68248304",
-                            "token": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                            "txId": "0x7cb221d8f840a7f5fb4d2655d34df7092b4b40762c34ebdd2233e81daa60365d"
-                        },
-                        "timestamp": 1780852609000,
-                        "datetime": "2026-06-07T17:16:49.000Z",
-                        "symbol": "POLYMARKET_KALSHI:POLYMARKET",
-                        "order": null,
-                        "type": null,
-                        "side": "sell",
-                        "takerOrMaker": "taker",
-                        "price": 0.7253241754988454,
-                        "amount": 1.418676,
-                        "cost": 1.029,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    }
-                ]
-            }
-        ],
-        "fetchOHLCV": [
-            {
-                "description": "fetchOHLCV daily",
-                "method": "fetchOHLCV",
-                "input": [
-                    "FEAR_GREED:FEAR",
-                    "1d"
-                ],
-                "httpResponse": {
-                    "id": "449",
-                    "networkId": "2741",
-                    "slug": "fear-or-greed",
-                    "title": "Fear or Greed?",
-                    "shortName": null,
-                    "ctaName": null,
-                    "description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nMarkets move on emotion, and none matter more than **Fear** and **Gr",
-                    "publishedAt": "2025-10-07T15:48:47.000Z",
-                    "expiresAt": "2100-01-01T00:01:00.000Z",
-                    "resolvesAt": null,
-                    "fees": {
-                        "buy": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "sell": {
-                            "fee": "0",
-                            "treasury_fee": "0",
-                            "distributor_fee": "0"
-                        },
-                        "treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
-                        "distributor": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3"
-                    },
-                    "state": "open",
-                    "voided": false,
-                    "resolvedOutcomeId": "-1",
-                    "topics": [
-                        "Crypto",
-                        "Sentiment"
-                    ],
-                    "tags": [],
-                    "resolutionSource": "https://x.com/myriadmarkets",
-                    "resolutionTitle": "You",
-                    "token": {
-                        "name": "Bridged USDC (Stargate)",
-                        "address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-                        "symbol": "USDC.e",
-                        "decimals": "6"
-                    },
-                    "imageUrl": "https://cdn.polkamarkets.com/QmWkt7sqJ74vGeFvSSLkFuW5ukAA2zKt24eHD7KRbwV2rz",
-                    "bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/bb255b5e-03ff-4960-7d42-fdcdb0354a00/public",
-                    "ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/9cf5170f-fb63-4a0a-8743-04d701f49a00/public",
-                    "liquidity": "1000",
-                    "liquidityPrice": "0.99769669",
-                    "volume": "1122416.505018",
-                    "volume24h": "1.039",
-                    "volumeNotional": "2215102.718962",
-                    "volumeNotional24h": "1.944775",
-                    "users": "1258",
-                    "shares": "2004.66888",
-                    "featured": false,
-                    "featuredAt": null,
-                    "inPlay": false,
-                    "inPlayStartsAt": null,
-                    "perpetual": true,
-                    "moneyline": false,
-                    "executionMode": "0",
-                    "tradingModel": "amm",
-                    "topHolders": [
-                        "0x950a42a5E748455Dc5d8B33F8A0c344Ba9cdb384",
-                        "0x7988E00745d107B5605EE9935A49Ff3ECD4D3ED9",
-                        "0x5497dbf37b8553f0C3d36D3458C558c0195685C5"
-                    ],
-                    "outcomes": [
-                        {
-                            "id": "0",
-                            "title": "Fear",
-                            "shares": "1070.514885",
-                            "sharesHeld": "743.109033",
-                            "price": "0.46598917",
-                            "closingPrice": null,
-                            "priceChange24h": "0.00103708",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": "https://cdn.polkamarkets.com/QmWkt7sqJ74vGeFvSSLkFuW5ukAA2zKt24eHD7KRbwV2rz",
-                            "holders": "40",
-                            "tokenId": "898",
-                            "price_charts": [
-                                {
-                                    "timeframe": "30d",
-                                    "prices": [
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778702400",
-                                            "date": "2026-05-13T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778716800",
-                                            "date": "2026-05-14T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778731200",
-                                            "date": "2026-05-14T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778745600",
-                                            "date": "2026-05-14T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778760000",
-                                            "date": "2026-05-14T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778774400",
-                                            "date": "2026-05-14T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778788800",
-                                            "date": "2026-05-14T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778803200",
-                                            "date": "2026-05-15T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778817600",
-                                            "date": "2026-05-15T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778832000",
-                                            "date": "2026-05-15T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778846400",
-                                            "date": "2026-05-15T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778860800",
-                                            "date": "2026-05-15T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778875200",
-                                            "date": "2026-05-15T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778889600",
-                                            "date": "2026-05-16T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778904000",
-                                            "date": "2026-05-16T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778918400",
-                                            "date": "2026-05-16T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778932800",
-                                            "date": "2026-05-16T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778947200",
-                                            "date": "2026-05-16T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778961600",
-                                            "date": "2026-05-16T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778976000",
-                                            "date": "2026-05-17T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1778990400",
-                                            "date": "2026-05-17T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779004800",
-                                            "date": "2026-05-17T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779019200",
-                                            "date": "2026-05-17T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779033600",
-                                            "date": "2026-05-17T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779048000",
-                                            "date": "2026-05-17T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779062400",
-                                            "date": "2026-05-18T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779076800",
-                                            "date": "2026-05-18T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779091200",
-                                            "date": "2026-05-18T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779105600",
-                                            "date": "2026-05-18T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.4776",
-                                            "timestamp": "1779120000",
-                                            "date": "2026-05-18T16:00:00.000Z"
-                                        }
-                                    ],
-                                    "change_percent": "-0.024288107202680063"
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1",
-                            "title": "Greed",
-                            "shares": "934.153995",
-                            "sharesHeld": "879.469923",
-                            "price": "0.53401083",
-                            "closingPrice": null,
-                            "priceChange24h": "-0.00090323",
-                            "bestBid": null,
-                            "bestAsk": null,
-                            "imageUrl": null,
-                            "holders": "53",
-                            "tokenId": "899",
-                            "price_charts": [
-                                {
-                                    "timeframe": "30d",
-                                    "prices": [
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778702400",
-                                            "date": "2026-05-13T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778716800",
-                                            "date": "2026-05-14T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778731200",
-                                            "date": "2026-05-14T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778745600",
-                                            "date": "2026-05-14T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778760000",
-                                            "date": "2026-05-14T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778774400",
-                                            "date": "2026-05-14T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778788800",
-                                            "date": "2026-05-14T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778803200",
-                                            "date": "2026-05-15T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778817600",
-                                            "date": "2026-05-15T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778832000",
-                                            "date": "2026-05-15T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778846400",
-                                            "date": "2026-05-15T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778860800",
-                                            "date": "2026-05-15T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778875200",
-                                            "date": "2026-05-15T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778889600",
-                                            "date": "2026-05-16T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778904000",
-                                            "date": "2026-05-16T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778918400",
-                                            "date": "2026-05-16T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778932800",
-                                            "date": "2026-05-16T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778947200",
-                                            "date": "2026-05-16T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778961600",
-                                            "date": "2026-05-16T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778976000",
-                                            "date": "2026-05-17T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1778990400",
-                                            "date": "2026-05-17T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779004800",
-                                            "date": "2026-05-17T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779019200",
-                                            "date": "2026-05-17T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779033600",
-                                            "date": "2026-05-17T16:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779048000",
-                                            "date": "2026-05-17T20:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779062400",
-                                            "date": "2026-05-18T00:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779076800",
-                                            "date": "2026-05-18T04:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779091200",
-                                            "date": "2026-05-18T08:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779105600",
-                                            "date": "2026-05-18T12:00:00.000Z"
-                                        },
-                                        {
-                                            "value": "0.5224",
-                                            "timestamp": "1779120000",
-                                            "date": "2026-05-18T16:00:00.000Z"
-                                        }
-                                    ],
-                                    "change_percent": "0.022205206738131807"
-                                }
-                            ]
-                        }
-                    ],
-                    "eventId": null,
-                    "outcomeIndex": null,
-                    "negRisk": false,
-                    "oracle": {
-                        "address": null,
-                        "name": "Myriad",
-                        "url": "https://myriad.markets",
-                        "image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
-                        "data": null
-                    },
-                    "externalSources": []
-                },
-                "parsedResponse": [
-                    [
-                        1778702400000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778716800000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778731200000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778745600000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778760000000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778774400000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778788800000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778803200000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778817600000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778832000000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778846400000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778860800000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778875200000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778889600000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778904000000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778918400000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778932800000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778947200000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778961600000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778976000000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1778990400000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779004800000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779019200000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779033600000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779048000000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779062400000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779076800000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779091200000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779105600000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ],
-                    [
-                        1779120000000,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0.4776,
-                        0
-                    ]
-                ]
-            }
-        ]
-    }
+	"exchange": "myriad",
+	"skipKeys": [
+		"timestamp",
+		"datetime"
+	],
+	"options": {},
+	"methods": {
+		"fetchTicker": [
+			{
+				"description": "fetchTicker for an outcome",
+				"method": "fetchTicker",
+				"input": [
+					"POLYMARKET_KALSHI:POLYMARKET"
+				],
+				"httpResponse": {
+					"id": "549",
+					"networkId": "2741",
+					"slug": "polymarket-or-kalshi",
+					"title": "Polymarket or Kalshi?",
+					"shortName": null,
+					"ctaName": null,
+					"description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
+					"publishedAt": "2025-11-08T11:02:20.000Z",
+					"expiresAt": "2100-01-01T00:01:00.000Z",
+					"resolvesAt": null,
+					"fees": {
+						"buy": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"sell": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
+						"distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
+					},
+					"state": "open",
+					"voided": false,
+					"resolvedOutcomeId": "-1",
+					"topics": [
+						"Sentiment"
+					],
+					"tags": [],
+					"resolutionSource": "https://x.com/myriadmarkets",
+					"resolutionTitle": "You",
+					"token": {
+						"name": "Bridged USDC (Stargate)",
+						"address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+						"symbol": "USDC.e",
+						"decimals": "6"
+					},
+					"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+					"bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
+					"ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
+					"liquidity": "1000",
+					"liquidityPrice": "0.89296615",
+					"volume": "11792850.814653",
+					"volume24h": "1.029",
+					"volumeNotional": "15796115.564182",
+					"volumeNotional24h": "1.418676",
+					"users": "1071",
+					"shares": "2240.415558",
+					"featured": false,
+					"featuredAt": null,
+					"inPlay": false,
+					"inPlayStartsAt": null,
+					"perpetual": true,
+					"moneyline": false,
+					"executionMode": "0",
+					"tradingModel": "amm",
+					"topHolders": [
+						"0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
+						"0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
+						"0x304fc7881ce775dd94607B4165006b70D885b441"
+					],
+					"outcomes": [
+						{
+							"id": "0",
+							"title": "Polymarket",
+							"shares": "615.670527",
+							"sharesHeld": "1559.441408",
+							"price": "0.72519807",
+							"closingPrice": null,
+							"priceChange24h": "-0.00034775",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"holders": "122",
+							"tokenId": "1098"
+						},
+						{
+							"id": "1",
+							"title": "Kalshi",
+							"shares": "1624.745031",
+							"sharesHeld": "550.366904",
+							"price": "0.27480193",
+							"closingPrice": null,
+							"priceChange24h": "0.00091887",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": null,
+							"holders": "10",
+							"tokenId": "1099"
+						}
+					],
+					"eventId": null,
+					"outcomeIndex": null,
+					"negRisk": false,
+					"oracle": {
+						"address": null,
+						"name": "Myriad",
+						"url": "https://myriad.markets",
+						"image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
+						"data": null
+					},
+					"externalSources": []
+				},
+				"parsedResponse": {
+					"outcomeId": "2741:549/0",
+					"label": "Polymarket",
+					"market": "POLYMARKET_KALSHI:POLYMARKET",
+					"timestamp": 1781895628750,
+					"datetime": "2026-06-19T19:00:28.750Z",
+					"high": null,
+					"low": null,
+					"bid": 0.72519807,
+					"bidVolume": null,
+					"ask": 0.72519807,
+					"askVolume": null,
+					"vwap": 1.3786938775510205,
+					"open": 0.72554582,
+					"close": 0.72519807,
+					"last": 0.72519807,
+					"previousClose": null,
+					"change": -0.00034775,
+					"percentage": -0.00034775,
+					"average": 0.72519807,
+					"baseVolume": 1.029,
+					"quoteVolume": 1.418676,
+					"info": {
+						"id": "549",
+						"networkId": "2741",
+						"slug": "polymarket-or-kalshi",
+						"title": "Polymarket or Kalshi?",
+						"shortName": null,
+						"ctaName": null,
+						"description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
+						"publishedAt": "2025-11-08T11:02:20.000Z",
+						"expiresAt": "2100-01-01T00:01:00.000Z",
+						"resolvesAt": null,
+						"fees": {
+							"buy": {
+								"fee": "0",
+								"treasury_fee": "0",
+								"distributor_fee": "0"
+							},
+							"sell": {
+								"fee": "0",
+								"treasury_fee": "0",
+								"distributor_fee": "0"
+							},
+							"treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
+							"distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
+						},
+						"state": "open",
+						"voided": false,
+						"resolvedOutcomeId": "-1",
+						"topics": [
+							"Sentiment"
+						],
+						"tags": [],
+						"resolutionSource": "https://x.com/myriadmarkets",
+						"resolutionTitle": "You",
+						"token": {
+							"name": "Bridged USDC (Stargate)",
+							"address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+							"symbol": "USDC.e",
+							"decimals": "6"
+						},
+						"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+						"bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
+						"ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
+						"liquidity": "1000",
+						"liquidityPrice": "0.89296615",
+						"volume": "11792850.814653",
+						"volume24h": "1.029",
+						"volumeNotional": "15796115.564182",
+						"volumeNotional24h": "1.418676",
+						"users": "1071",
+						"shares": "2240.415558",
+						"featured": false,
+						"featuredAt": null,
+						"inPlay": false,
+						"inPlayStartsAt": null,
+						"perpetual": true,
+						"moneyline": false,
+						"executionMode": "0",
+						"tradingModel": "amm",
+						"topHolders": [
+							"0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
+							"0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
+							"0x304fc7881ce775dd94607B4165006b70D885b441"
+						],
+						"outcomes": [
+							{
+								"id": "0",
+								"title": "Polymarket",
+								"shares": "615.670527",
+								"sharesHeld": "1559.441408",
+								"price": "0.72519807",
+								"closingPrice": null,
+								"priceChange24h": "-0.00034775",
+								"bestBid": null,
+								"bestAsk": null,
+								"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+								"holders": "122",
+								"tokenId": "1098"
+							},
+							{
+								"id": "1",
+								"title": "Kalshi",
+								"shares": "1624.745031",
+								"sharesHeld": "550.366904",
+								"price": "0.27480193",
+								"closingPrice": null,
+								"priceChange24h": "0.00091887",
+								"bestBid": null,
+								"bestAsk": null,
+								"imageUrl": null,
+								"holders": "10",
+								"tokenId": "1099"
+							}
+						],
+						"eventId": null,
+						"outcomeIndex": null,
+						"negRisk": false,
+						"oracle": {
+							"address": null,
+							"name": "Myriad",
+							"url": "https://myriad.markets",
+							"image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
+							"data": null
+						},
+						"externalSources": []
+					},
+					"indexPrice": null,
+					"markPrice": null,
+					"outcome": "POLYMARKET_KALSHI:POLYMARKET",
+					"event": null
+				}
+			}
+		],
+		"fetchTickers": [
+			{
+				"description": "fetchTickers with two outcomes of the same market",
+				"method": "fetchTickers",
+				"input": [
+					[
+						"POLYMARKET_KALSHI:POLYMARKET",
+						"POLYMARKET_KALSHI:KALSHI"
+					]
+				],
+				"httpResponse": {
+					"id": "549",
+					"networkId": "2741",
+					"slug": "polymarket-or-kalshi",
+					"title": "Polymarket or Kalshi?",
+					"shortName": null,
+					"ctaName": null,
+					"description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
+					"publishedAt": "2025-11-08T11:02:20.000Z",
+					"expiresAt": "2100-01-01T00:01:00.000Z",
+					"resolvesAt": null,
+					"fees": {
+						"buy": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"sell": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
+						"distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
+					},
+					"state": "open",
+					"voided": false,
+					"resolvedOutcomeId": "-1",
+					"topics": [
+						"Sentiment"
+					],
+					"tags": [],
+					"resolutionSource": "https://x.com/myriadmarkets",
+					"resolutionTitle": "You",
+					"token": {
+						"name": "Bridged USDC (Stargate)",
+						"address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+						"symbol": "USDC.e",
+						"decimals": "6"
+					},
+					"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+					"bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
+					"ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
+					"liquidity": "1000",
+					"liquidityPrice": "0.89296615",
+					"volume": "11792850.814653",
+					"volume24h": "1.029",
+					"volumeNotional": "15796115.564182",
+					"volumeNotional24h": "1.418676",
+					"users": "1071",
+					"shares": "2240.415558",
+					"featured": false,
+					"featuredAt": null,
+					"inPlay": false,
+					"inPlayStartsAt": null,
+					"perpetual": true,
+					"moneyline": false,
+					"executionMode": "0",
+					"tradingModel": "amm",
+					"topHolders": [
+						"0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
+						"0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
+						"0x304fc7881ce775dd94607B4165006b70D885b441"
+					],
+					"outcomes": [
+						{
+							"id": "0",
+							"title": "Polymarket",
+							"shares": "615.670527",
+							"sharesHeld": "1559.441408",
+							"price": "0.72519807",
+							"closingPrice": null,
+							"priceChange24h": "-0.00034775",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"holders": "122",
+							"tokenId": "1098"
+						},
+						{
+							"id": "1",
+							"title": "Kalshi",
+							"shares": "1624.745031",
+							"sharesHeld": "550.366904",
+							"price": "0.27480193",
+							"closingPrice": null,
+							"priceChange24h": "0.00091887",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": null,
+							"holders": "10",
+							"tokenId": "1099"
+						}
+					],
+					"eventId": null,
+					"outcomeIndex": null,
+					"negRisk": false,
+					"oracle": {
+						"address": null,
+						"name": "Myriad",
+						"url": "https://myriad.markets",
+						"image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
+						"data": null
+					},
+					"externalSources": []
+				},
+				"parsedResponse": {
+					"POLYMARKET_KALSHI:POLYMARKET": {
+						"outcomeId": "2741:549/0",
+						"label": "Polymarket",
+						"market": "POLYMARKET_KALSHI:POLYMARKET",
+						"timestamp": 1781895628952,
+						"datetime": "2026-06-19T19:00:28.952Z",
+						"high": null,
+						"low": null,
+						"bid": 0.72519807,
+						"bidVolume": null,
+						"ask": 0.72519807,
+						"askVolume": null,
+						"vwap": 1.3786938775510205,
+						"open": 0.72554582,
+						"close": 0.72519807,
+						"last": 0.72519807,
+						"previousClose": null,
+						"change": -0.00034775,
+						"percentage": -0.00034775,
+						"average": 0.72519807,
+						"baseVolume": 1.029,
+						"quoteVolume": 1.418676,
+						"info": {
+							"id": "549",
+							"networkId": "2741",
+							"slug": "polymarket-or-kalshi",
+							"title": "Polymarket or Kalshi?",
+							"shortName": null,
+							"ctaName": null,
+							"description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
+							"publishedAt": "2025-11-08T11:02:20.000Z",
+							"expiresAt": "2100-01-01T00:01:00.000Z",
+							"resolvesAt": null,
+							"fees": {
+								"buy": {
+									"fee": "0",
+									"treasury_fee": "0",
+									"distributor_fee": "0"
+								},
+								"sell": {
+									"fee": "0",
+									"treasury_fee": "0",
+									"distributor_fee": "0"
+								},
+								"treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
+								"distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
+							},
+							"state": "open",
+							"voided": false,
+							"resolvedOutcomeId": "-1",
+							"topics": [
+								"Sentiment"
+							],
+							"tags": [],
+							"resolutionSource": "https://x.com/myriadmarkets",
+							"resolutionTitle": "You",
+							"token": {
+								"name": "Bridged USDC (Stargate)",
+								"address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+								"symbol": "USDC.e",
+								"decimals": "6"
+							},
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
+							"ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
+							"liquidity": "1000",
+							"liquidityPrice": "0.89296615",
+							"volume": "11792850.814653",
+							"volume24h": "1.029",
+							"volumeNotional": "15796115.564182",
+							"volumeNotional24h": "1.418676",
+							"users": "1071",
+							"shares": "2240.415558",
+							"featured": false,
+							"featuredAt": null,
+							"inPlay": false,
+							"inPlayStartsAt": null,
+							"perpetual": true,
+							"moneyline": false,
+							"executionMode": "0",
+							"tradingModel": "amm",
+							"topHolders": [
+								"0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
+								"0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
+								"0x304fc7881ce775dd94607B4165006b70D885b441"
+							],
+							"outcomes": [
+								{
+									"id": "0",
+									"title": "Polymarket",
+									"shares": "615.670527",
+									"sharesHeld": "1559.441408",
+									"price": "0.72519807",
+									"closingPrice": null,
+									"priceChange24h": "-0.00034775",
+									"bestBid": null,
+									"bestAsk": null,
+									"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+									"holders": "122",
+									"tokenId": "1098"
+								},
+								{
+									"id": "1",
+									"title": "Kalshi",
+									"shares": "1624.745031",
+									"sharesHeld": "550.366904",
+									"price": "0.27480193",
+									"closingPrice": null,
+									"priceChange24h": "0.00091887",
+									"bestBid": null,
+									"bestAsk": null,
+									"imageUrl": null,
+									"holders": "10",
+									"tokenId": "1099"
+								}
+							],
+							"eventId": null,
+							"outcomeIndex": null,
+							"negRisk": false,
+							"oracle": {
+								"address": null,
+								"name": "Myriad",
+								"url": "https://myriad.markets",
+								"image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
+								"data": null
+							},
+							"externalSources": []
+						},
+						"indexPrice": null,
+						"markPrice": null,
+						"outcome": "POLYMARKET_KALSHI:POLYMARKET",
+						"event": null
+					},
+					"POLYMARKET_KALSHI:KALSHI": {
+						"outcomeId": "2741:549/1",
+						"label": "Kalshi",
+						"market": "POLYMARKET_KALSHI:KALSHI",
+						"timestamp": 1781895628952,
+						"datetime": "2026-06-19T19:00:28.952Z",
+						"high": null,
+						"low": null,
+						"bid": 0.27480193,
+						"bidVolume": null,
+						"ask": 0.27480193,
+						"askVolume": null,
+						"vwap": 1.3786938775510205,
+						"open": 0.27388306,
+						"close": 0.27480193,
+						"last": 0.27480193,
+						"previousClose": null,
+						"change": 0.00091887,
+						"percentage": 0.00091887,
+						"average": 0.27480193,
+						"baseVolume": 1.029,
+						"quoteVolume": 1.418676,
+						"info": {
+							"id": "549",
+							"networkId": "2741",
+							"slug": "polymarket-or-kalshi",
+							"title": "Polymarket or Kalshi?",
+							"shortName": null,
+							"ctaName": null,
+							"description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
+							"publishedAt": "2025-11-08T11:02:20.000Z",
+							"expiresAt": "2100-01-01T00:01:00.000Z",
+							"resolvesAt": null,
+							"fees": {
+								"buy": {
+									"fee": "0",
+									"treasury_fee": "0",
+									"distributor_fee": "0"
+								},
+								"sell": {
+									"fee": "0",
+									"treasury_fee": "0",
+									"distributor_fee": "0"
+								},
+								"treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
+								"distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
+							},
+							"state": "open",
+							"voided": false,
+							"resolvedOutcomeId": "-1",
+							"topics": [
+								"Sentiment"
+							],
+							"tags": [],
+							"resolutionSource": "https://x.com/myriadmarkets",
+							"resolutionTitle": "You",
+							"token": {
+								"name": "Bridged USDC (Stargate)",
+								"address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+								"symbol": "USDC.e",
+								"decimals": "6"
+							},
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
+							"ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
+							"liquidity": "1000",
+							"liquidityPrice": "0.89296615",
+							"volume": "11792850.814653",
+							"volume24h": "1.029",
+							"volumeNotional": "15796115.564182",
+							"volumeNotional24h": "1.418676",
+							"users": "1071",
+							"shares": "2240.415558",
+							"featured": false,
+							"featuredAt": null,
+							"inPlay": false,
+							"inPlayStartsAt": null,
+							"perpetual": true,
+							"moneyline": false,
+							"executionMode": "0",
+							"tradingModel": "amm",
+							"topHolders": [
+								"0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
+								"0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
+								"0x304fc7881ce775dd94607B4165006b70D885b441"
+							],
+							"outcomes": [
+								{
+									"id": "0",
+									"title": "Polymarket",
+									"shares": "615.670527",
+									"sharesHeld": "1559.441408",
+									"price": "0.72519807",
+									"closingPrice": null,
+									"priceChange24h": "-0.00034775",
+									"bestBid": null,
+									"bestAsk": null,
+									"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+									"holders": "122",
+									"tokenId": "1098"
+								},
+								{
+									"id": "1",
+									"title": "Kalshi",
+									"shares": "1624.745031",
+									"sharesHeld": "550.366904",
+									"price": "0.27480193",
+									"closingPrice": null,
+									"priceChange24h": "0.00091887",
+									"bestBid": null,
+									"bestAsk": null,
+									"imageUrl": null,
+									"holders": "10",
+									"tokenId": "1099"
+								}
+							],
+							"eventId": null,
+							"outcomeIndex": null,
+							"negRisk": false,
+							"oracle": {
+								"address": null,
+								"name": "Myriad",
+								"url": "https://myriad.markets",
+								"image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
+								"data": null
+							},
+							"externalSources": []
+						},
+						"indexPrice": null,
+						"markPrice": null,
+						"outcome": "POLYMARKET_KALSHI:KALSHI",
+						"event": null
+					}
+				}
+			}
+		],
+		"fetchOrderBook": [
+			{
+				"description": "fetchOrderBook for an amm market",
+				"method": "fetchOrderBook",
+				"input": [
+					"POLYMARKET_KALSHI:POLYMARKET"
+				],
+				"httpResponse": {
+					"id": "549",
+					"networkId": "2741",
+					"slug": "polymarket-or-kalshi",
+					"title": "Polymarket or Kalshi?",
+					"shortName": null,
+					"ctaName": null,
+					"description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nPolymarket vs Kalshi: Both have emerged as strong contenders in the ",
+					"publishedAt": "2025-11-08T11:02:20.000Z",
+					"expiresAt": "2100-01-01T00:01:00.000Z",
+					"resolvesAt": null,
+					"fees": {
+						"buy": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"sell": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
+						"distributor": "0xE44984C586FeBB31605D23b6316cA11B6f4D86b2"
+					},
+					"state": "open",
+					"voided": false,
+					"resolvedOutcomeId": "-1",
+					"topics": [
+						"Sentiment"
+					],
+					"tags": [],
+					"resolutionSource": "https://x.com/myriadmarkets",
+					"resolutionTitle": "You",
+					"token": {
+						"name": "Bridged USDC (Stargate)",
+						"address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+						"symbol": "USDC.e",
+						"decimals": "6"
+					},
+					"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+					"bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/20176323-324a-4b47-283e-8c2f6e1d0900/public",
+					"ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/54523a13-d80d-403f-8282-e10f06393000/public",
+					"liquidity": "1000",
+					"liquidityPrice": "0.89296615",
+					"volume": "11792850.814653",
+					"volume24h": "1.029",
+					"volumeNotional": "15796115.564182",
+					"volumeNotional24h": "1.418676",
+					"users": "1071",
+					"shares": "2240.415558",
+					"featured": false,
+					"featuredAt": null,
+					"inPlay": false,
+					"inPlayStartsAt": null,
+					"perpetual": true,
+					"moneyline": false,
+					"executionMode": "0",
+					"tradingModel": "amm",
+					"topHolders": [
+						"0x4841Ec2b14C129F03Ce6dcA3ce61f482D48DCE29",
+						"0x44d4b4189ACFD8B18d9939f7E76a78672eAd40c2",
+						"0x304fc7881ce775dd94607B4165006b70D885b441"
+					],
+					"outcomes": [
+						{
+							"id": "0",
+							"title": "Polymarket",
+							"shares": "615.670527",
+							"sharesHeld": "1559.441408",
+							"price": "0.72519807",
+							"closingPrice": null,
+							"priceChange24h": "-0.00034775",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"holders": "122",
+							"tokenId": "1098"
+						},
+						{
+							"id": "1",
+							"title": "Kalshi",
+							"shares": "1624.745031",
+							"sharesHeld": "550.366904",
+							"price": "0.27480193",
+							"closingPrice": null,
+							"priceChange24h": "0.00091887",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": null,
+							"holders": "10",
+							"tokenId": "1099"
+						}
+					],
+					"eventId": null,
+					"outcomeIndex": null,
+					"negRisk": false,
+					"oracle": {
+						"address": null,
+						"name": "Myriad",
+						"url": "https://myriad.markets",
+						"image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
+						"data": null
+					},
+					"externalSources": []
+				},
+				"parsedResponse": {
+					"symbol": "POLYMARKET_KALSHI:POLYMARKET",
+					"bids": [
+						[
+							0.72419807,
+							9999
+						]
+					],
+					"asks": [
+						[
+							0.72619807,
+							9999
+						]
+					],
+					"timestamp": 1781895629152,
+					"datetime": "2026-06-19T19:00:29.152Z",
+					"nonce": null
+				}
+			}
+		],
+		"fetchTrades": [
+			{
+				"description": "fetchTrades with limit",
+				"method": "fetchTrades",
+				"input": [
+					"POLYMARKET_KALSHI:POLYMARKET",
+					null,
+					3
+				],
+				"httpResponse": {
+					"data": [
+						{
+							"user": "0xD567662886faC76A73537c7a0cb18f4D5c2D841F",
+							"action": "sell",
+							"marketTitle": "Polymarket or Kalshi?",
+							"marketSlug": "polymarket-or-kalshi",
+							"marketId": "549",
+							"networkId": "2741",
+							"outcomeTitle": "Polymarket",
+							"outcomeId": "0",
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"shares": "1.418676",
+							"value": "1.029",
+							"timestamp": "1780852609",
+							"blockNumber": "68248304",
+							"token": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+							"txId": "0x7cb221d8f840a7f5fb4d2655d34df7092b4b40762c34ebdd2233e81daa60365d"
+						},
+						{
+							"user": "0x43De6c46B54f4dd51F4ECDaaeEed11ac4D11301e",
+							"action": "sell",
+							"marketTitle": "Polymarket or Kalshi?",
+							"marketSlug": "polymarket-or-kalshi",
+							"marketId": "549",
+							"networkId": "2741",
+							"outcomeTitle": "Kalshi",
+							"outcomeId": "1",
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"shares": "46.494609",
+							"value": "12.959",
+							"timestamp": "1779777188",
+							"blockNumber": "65022091",
+							"token": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+							"txId": "0xb456979a025926006e603017ef724db4ff50639257c2b5903c3d24e2f28bf1dc"
+						},
+						{
+							"user": "0x0458DcB6A70776f7d13F5E4c170E2ec3c1F53976",
+							"action": "sell",
+							"marketTitle": "Polymarket or Kalshi?",
+							"marketSlug": "polymarket-or-kalshi",
+							"marketId": "549",
+							"networkId": "2741",
+							"outcomeTitle": "Kalshi",
+							"outcomeId": "1",
+							"imageUrl": "https://cdn.polkamarkets.com/QmaHmjD4WmrBLKg4Nd92KwQMC9P1KfYaUcZQFb2AfWUws7",
+							"shares": "32.614935",
+							"value": "9.325553",
+							"timestamp": "1779684631",
+							"blockNumber": "64775443",
+							"token": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+							"txId": "0xbff632359aefef69d307b8297cda73fe2084fe5a2dfb608070e4914875fcc2c4"
+						}
+					],
+					"pagination": {
+						"page": "1",
+						"limit": "3",
+						"total": "401250",
+						"totalPages": "133750",
+						"hasNext": true,
+						"hasPrev": false
+					}
+				},
+				"parsedResponse": []
+			}
+		],
+		"fetchOHLCV": [
+			{
+				"description": "fetchOHLCV daily",
+				"method": "fetchOHLCV",
+				"input": [
+					"FEAR_GREED:FEAR",
+					"1d"
+				],
+				"httpResponse": {
+					"id": "449",
+					"networkId": "2741",
+					"slug": "fear-or-greed",
+					"title": "Fear or Greed?",
+					"shortName": null,
+					"ctaName": null,
+					"description": "**There are zero trading fees charged for this market.**\n\n**This market is to gauge social sentiment, is trading only, and will never be resolved towards either option.**\n\nMarkets move on emotion, and none matter more than **Fear** and **Gr",
+					"publishedAt": "2025-10-07T15:48:47.000Z",
+					"expiresAt": "2100-01-01T00:01:00.000Z",
+					"resolvesAt": null,
+					"fees": {
+						"buy": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"sell": {
+							"fee": "0",
+							"treasury_fee": "0",
+							"distributor_fee": "0"
+						},
+						"treasury": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3",
+						"distributor": "0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3"
+					},
+					"state": "open",
+					"voided": false,
+					"resolvedOutcomeId": "-1",
+					"topics": [
+						"Crypto",
+						"Sentiment"
+					],
+					"tags": [],
+					"resolutionSource": "https://x.com/myriadmarkets",
+					"resolutionTitle": "You",
+					"token": {
+						"name": "Bridged USDC (Stargate)",
+						"address": "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+						"symbol": "USDC.e",
+						"decimals": "6"
+					},
+					"imageUrl": "https://cdn.polkamarkets.com/QmWkt7sqJ74vGeFvSSLkFuW5ukAA2zKt24eHD7KRbwV2rz",
+					"bannerImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/bb255b5e-03ff-4960-7d42-fdcdb0354a00/public",
+					"ogImageUrl": "https://imagedelivery.net/YN1-rdnufJQJCgu3i1CbVw/9cf5170f-fb63-4a0a-8743-04d701f49a00/public",
+					"liquidity": "1000",
+					"liquidityPrice": "0.99769669",
+					"volume": "1122416.505018",
+					"volume24h": "1.039",
+					"volumeNotional": "2215102.718962",
+					"volumeNotional24h": "1.944775",
+					"users": "1258",
+					"shares": "2004.66888",
+					"featured": false,
+					"featuredAt": null,
+					"inPlay": false,
+					"inPlayStartsAt": null,
+					"perpetual": true,
+					"moneyline": false,
+					"executionMode": "0",
+					"tradingModel": "amm",
+					"topHolders": [
+						"0x950a42a5E748455Dc5d8B33F8A0c344Ba9cdb384",
+						"0x7988E00745d107B5605EE9935A49Ff3ECD4D3ED9",
+						"0x5497dbf37b8553f0C3d36D3458C558c0195685C5"
+					],
+					"outcomes": [
+						{
+							"id": "0",
+							"title": "Fear",
+							"shares": "1070.514885",
+							"sharesHeld": "743.109033",
+							"price": "0.46598917",
+							"closingPrice": null,
+							"priceChange24h": "0.00103708",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": "https://cdn.polkamarkets.com/QmWkt7sqJ74vGeFvSSLkFuW5ukAA2zKt24eHD7KRbwV2rz",
+							"holders": "40",
+							"tokenId": "898",
+							"price_charts": [
+								{
+									"timeframe": "30d",
+									"prices": [
+										{
+											"value": "0.4776",
+											"timestamp": "1778702400",
+											"date": "2026-05-13T20:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778716800",
+											"date": "2026-05-14T00:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778731200",
+											"date": "2026-05-14T04:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778745600",
+											"date": "2026-05-14T08:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778760000",
+											"date": "2026-05-14T12:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778774400",
+											"date": "2026-05-14T16:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778788800",
+											"date": "2026-05-14T20:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778803200",
+											"date": "2026-05-15T00:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778817600",
+											"date": "2026-05-15T04:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778832000",
+											"date": "2026-05-15T08:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778846400",
+											"date": "2026-05-15T12:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778860800",
+											"date": "2026-05-15T16:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778875200",
+											"date": "2026-05-15T20:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778889600",
+											"date": "2026-05-16T00:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778904000",
+											"date": "2026-05-16T04:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778918400",
+											"date": "2026-05-16T08:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778932800",
+											"date": "2026-05-16T12:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778947200",
+											"date": "2026-05-16T16:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778961600",
+											"date": "2026-05-16T20:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778976000",
+											"date": "2026-05-17T00:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1778990400",
+											"date": "2026-05-17T04:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779004800",
+											"date": "2026-05-17T08:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779019200",
+											"date": "2026-05-17T12:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779033600",
+											"date": "2026-05-17T16:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779048000",
+											"date": "2026-05-17T20:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779062400",
+											"date": "2026-05-18T00:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779076800",
+											"date": "2026-05-18T04:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779091200",
+											"date": "2026-05-18T08:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779105600",
+											"date": "2026-05-18T12:00:00.000Z"
+										},
+										{
+											"value": "0.4776",
+											"timestamp": "1779120000",
+											"date": "2026-05-18T16:00:00.000Z"
+										}
+									],
+									"change_percent": "-0.024288107202680063"
+								}
+							]
+						},
+						{
+							"id": "1",
+							"title": "Greed",
+							"shares": "934.153995",
+							"sharesHeld": "879.469923",
+							"price": "0.53401083",
+							"closingPrice": null,
+							"priceChange24h": "-0.00090323",
+							"bestBid": null,
+							"bestAsk": null,
+							"imageUrl": null,
+							"holders": "53",
+							"tokenId": "899",
+							"price_charts": [
+								{
+									"timeframe": "30d",
+									"prices": [
+										{
+											"value": "0.5224",
+											"timestamp": "1778702400",
+											"date": "2026-05-13T20:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778716800",
+											"date": "2026-05-14T00:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778731200",
+											"date": "2026-05-14T04:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778745600",
+											"date": "2026-05-14T08:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778760000",
+											"date": "2026-05-14T12:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778774400",
+											"date": "2026-05-14T16:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778788800",
+											"date": "2026-05-14T20:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778803200",
+											"date": "2026-05-15T00:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778817600",
+											"date": "2026-05-15T04:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778832000",
+											"date": "2026-05-15T08:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778846400",
+											"date": "2026-05-15T12:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778860800",
+											"date": "2026-05-15T16:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778875200",
+											"date": "2026-05-15T20:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778889600",
+											"date": "2026-05-16T00:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778904000",
+											"date": "2026-05-16T04:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778918400",
+											"date": "2026-05-16T08:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778932800",
+											"date": "2026-05-16T12:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778947200",
+											"date": "2026-05-16T16:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778961600",
+											"date": "2026-05-16T20:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778976000",
+											"date": "2026-05-17T00:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1778990400",
+											"date": "2026-05-17T04:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779004800",
+											"date": "2026-05-17T08:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779019200",
+											"date": "2026-05-17T12:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779033600",
+											"date": "2026-05-17T16:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779048000",
+											"date": "2026-05-17T20:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779062400",
+											"date": "2026-05-18T00:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779076800",
+											"date": "2026-05-18T04:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779091200",
+											"date": "2026-05-18T08:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779105600",
+											"date": "2026-05-18T12:00:00.000Z"
+										},
+										{
+											"value": "0.5224",
+											"timestamp": "1779120000",
+											"date": "2026-05-18T16:00:00.000Z"
+										}
+									],
+									"change_percent": "0.022205206738131807"
+								}
+							]
+						}
+					],
+					"eventId": null,
+					"outcomeIndex": null,
+					"negRisk": false,
+					"oracle": {
+						"address": null,
+						"name": "Myriad",
+						"url": "https://myriad.markets",
+						"image_url": "https://wp.decrypt.co/wp-content/uploads/2026/05/myriad.png",
+						"data": null
+					},
+					"externalSources": []
+				},
+				"parsedResponse": [
+					[
+						1778702400000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778716800000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778731200000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778745600000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778760000000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778774400000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778788800000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778803200000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778817600000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778832000000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778846400000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778860800000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778875200000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778889600000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778904000000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778918400000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778932800000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778947200000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778961600000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778976000000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1778990400000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779004800000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779019200000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779033600000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779048000000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779062400000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779076800000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779091200000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779105600000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					],
+					[
+						1779120000000,
+						0.4776,
+						0.4776,
+						0.4776,
+						0.4776,
+						0
+					]
+				]
+			}
+		]
+	}
 }

--- a/ts/src/test/static/response/polymarket.json
+++ b/ts/src/test/static/response/polymarket.json
@@ -1,860 +1,871 @@
 {
-    "exchange": "polymarket",
-    "skipKeys": [],
-    "options": {
-        "l2ApiKey": "0xabc123",
-        "l2Secret": "0xdef456"
-    },
-    "methods": {
-        "fetchTicker": [
-            {
-                "description": "fetchTicker for a yes outcome",
-                "method": "fetchTicker",
-                "input": [
-                    "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES"
-                ],
-                "httpResponse": {
-                    "market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                    "asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                    "timestamp": "1781289337944",
-                    "hash": "3082b8da1567a4510e93544031cb9144524f2de7",
-                    "bids": [
-                        {
-                            "price": "0.001",
-                            "size": "2202468"
-                        },
-                        {
-                            "price": "0.002",
-                            "size": "1000005"
-                        },
-                        {
-                            "price": "0.003",
-                            "size": "135826.51"
-                        },
-                        {
-                            "price": "0.004",
-                            "size": "12364"
-                        },
-                        {
-                            "price": "0.005",
-                            "size": "1000"
-                        }
-                    ],
-                    "asks": [
-                        {
-                            "price": "0.999",
-                            "size": "45521.44"
-                        },
-                        {
-                            "price": "0.998",
-                            "size": "5007500"
-                        },
-                        {
-                            "price": "0.997",
-                            "size": "7.06"
-                        },
-                        {
-                            "price": "0.996",
-                            "size": "5000"
-                        },
-                        {
-                            "price": "0.995",
-                            "size": "222222"
-                        }
-                    ],
-                    "min_order_size": "5",
-                    "tick_size": "0.001",
-                    "neg_risk": true,
-                    "last_trade_price": "0.152",
-                    "mid": "0.1515"
-                },
-                "parsedResponse": {
-                    "symbol": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                    "timestamp": 1781289337944,
-                    "datetime": "2026-06-12T18:35:37.944Z",
-                    "high": null,
-                    "low": null,
-                    "bid": 0.005,
-                    "bidVolume": 1000,
-                    "ask": 0.995,
-                    "askVolume": 222222,
-                    "vwap": null,
-                    "open": null,
-                    "close": 0.1515,
-                    "last": 0.1515,
-                    "previousClose": null,
-                    "change": null,
-                    "percentage": null,
-                    "average": 0.1515,
-                    "baseVolume": null,
-                    "quoteVolume": 21920.557926999998,
-                    "info": {
-                        "midpoint": {
-                            "market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                            "asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                            "timestamp": "1781289337944",
-                            "hash": "3082b8da1567a4510e93544031cb9144524f2de7",
-                            "bids": [
-                                {
-                                    "price": "0.001",
-                                    "size": "2202468"
-                                },
-                                {
-                                    "price": "0.002",
-                                    "size": "1000005"
-                                },
-                                {
-                                    "price": "0.003",
-                                    "size": "135826.51"
-                                },
-                                {
-                                    "price": "0.004",
-                                    "size": "12364"
-                                },
-                                {
-                                    "price": "0.005",
-                                    "size": "1000"
-                                }
-                            ],
-                            "asks": [
-                                {
-                                    "price": "0.999",
-                                    "size": "45521.44"
-                                },
-                                {
-                                    "price": "0.998",
-                                    "size": "5007500"
-                                },
-                                {
-                                    "price": "0.997",
-                                    "size": "7.06"
-                                },
-                                {
-                                    "price": "0.996",
-                                    "size": "5000"
-                                },
-                                {
-                                    "price": "0.995",
-                                    "size": "222222"
-                                }
-                            ],
-                            "min_order_size": "5",
-                            "tick_size": "0.001",
-                            "neg_risk": true,
-                            "last_trade_price": "0.152",
-                            "mid": "0.1515"
-                        },
-                        "book": {
-                            "market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                            "asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                            "timestamp": "1781289337944",
-                            "hash": "3082b8da1567a4510e93544031cb9144524f2de7",
-                            "bids": [
-                                {
-                                    "price": "0.001",
-                                    "size": "2202468"
-                                },
-                                {
-                                    "price": "0.002",
-                                    "size": "1000005"
-                                },
-                                {
-                                    "price": "0.003",
-                                    "size": "135826.51"
-                                },
-                                {
-                                    "price": "0.004",
-                                    "size": "12364"
-                                },
-                                {
-                                    "price": "0.005",
-                                    "size": "1000"
-                                }
-                            ],
-                            "asks": [
-                                {
-                                    "price": "0.999",
-                                    "size": "45521.44"
-                                },
-                                {
-                                    "price": "0.998",
-                                    "size": "5007500"
-                                },
-                                {
-                                    "price": "0.997",
-                                    "size": "7.06"
-                                },
-                                {
-                                    "price": "0.996",
-                                    "size": "5000"
-                                },
-                                {
-                                    "price": "0.995",
-                                    "size": "222222"
-                                }
-                            ],
-                            "min_order_size": "5",
-                            "tick_size": "0.001",
-                            "neg_risk": true,
-                            "last_trade_price": "0.152",
-                            "mid": "0.1515"
-                        }
-                    },
-                    "indexPrice": null,
-                    "markPrice": null
-                }
-            }
-        ],
-        "fetchOrderBook": [
-            {
-                "description": "fetchOrderBook for a yes outcome",
-                "method": "fetchOrderBook",
-                "input": [
-                    "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES"
-                ],
-                "httpResponse": {
-                    "market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                    "asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                    "timestamp": "1781289337944",
-                    "hash": "3082b8da1567a4510e93544031cb9144524f2de7",
-                    "bids": [
-                        {
-                            "price": "0.001",
-                            "size": "2202468"
-                        },
-                        {
-                            "price": "0.002",
-                            "size": "1000005"
-                        },
-                        {
-                            "price": "0.003",
-                            "size": "135826.51"
-                        },
-                        {
-                            "price": "0.004",
-                            "size": "12364"
-                        },
-                        {
-                            "price": "0.005",
-                            "size": "1000"
-                        }
-                    ],
-                    "asks": [
-                        {
-                            "price": "0.999",
-                            "size": "45521.44"
-                        },
-                        {
-                            "price": "0.998",
-                            "size": "5007500"
-                        },
-                        {
-                            "price": "0.997",
-                            "size": "7.06"
-                        },
-                        {
-                            "price": "0.996",
-                            "size": "5000"
-                        },
-                        {
-                            "price": "0.995",
-                            "size": "222222"
-                        }
-                    ],
-                    "min_order_size": "5",
-                    "tick_size": "0.001",
-                    "neg_risk": true,
-                    "last_trade_price": "0.152"
-                },
-                "parsedResponse": {
-                    "symbol": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                    "bids": [
-                        [
-                            0.005,
-                            1000
-                        ],
-                        [
-                            0.004,
-                            12364
-                        ],
-                        [
-                            0.003,
-                            135826.51
-                        ],
-                        [
-                            0.002,
-                            1000005
-                        ],
-                        [
-                            0.001,
-                            2202468
-                        ]
-                    ],
-                    "asks": [
-                        [
-                            0.995,
-                            222222
-                        ],
-                        [
-                            0.996,
-                            5000
-                        ],
-                        [
-                            0.997,
-                            7.06
-                        ],
-                        [
-                            0.998,
-                            5007500
-                        ],
-                        [
-                            0.999,
-                            45521.44
-                        ]
-                    ],
-                    "timestamp": 1781289337944,
-                    "datetime": "2026-06-12T18:35:37.944Z",
-                    "nonce": null
-                }
-            }
-        ],
-        "fetchTrades": [
-            {
-                "description": "fetchTrades with limit",
-                "method": "fetchTrades",
-                "input": [
-                    "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                    null,
-                    3
-                ],
-                "httpResponse": [
-                    {
-                        "proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
-                        "side": "BUY",
-                        "asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                        "conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                        "size": "256",
-                        "price": "0.152",
-                        "timestamp": "1781289172",
-                        "title": "Will JD Vance win the 2028 US Presidential Election?",
-                        "slug": "will-jd-vance-win-the-2028-us-presidential-election",
-                        "icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
-                        "eventSlug": "presidential-election-winner-2028",
-                        "outcome": "Yes",
-                        "outcomeIndex": "0",
-                        "name": "",
-                        "pseudonym": "",
-                        "bio": "",
-                        "profileImage": "",
-                        "profileImageOptimized": "",
-                        "transactionHash": "0x3c49025c45025d25c7e4a88619ca9454135f6dcb53343096a7aa361003b471d0"
-                    },
-                    {
-                        "proxyWallet": "0xbe55fa3947e0dd06887444f9b6cbf05dcfb8c2ee",
-                        "side": "SELL",
-                        "asset": "94476829201604408463453426454480212459887267917122244941405244686637914508323",
-                        "conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                        "size": "11.77",
-                        "price": "0.848",
-                        "timestamp": "1781288635",
-                        "title": "Will JD Vance win the 2028 US Presidential Election?",
-                        "slug": "will-jd-vance-win-the-2028-us-presidential-election",
-                        "icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
-                        "eventSlug": "presidential-election-winner-2028",
-                        "outcome": "No",
-                        "outcomeIndex": "1",
-                        "name": "",
-                        "pseudonym": "",
-                        "bio": "",
-                        "profileImage": "",
-                        "profileImageOptimized": "",
-                        "transactionHash": "0xd3c0aa3da570bb98dcf7ed9f41a4d72ba6db652cd790f9f0fdbee688bd207e19"
-                    },
-                    {
-                        "proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
-                        "side": "BUY",
-                        "asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                        "conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                        "size": "368",
-                        "price": "0.152",
-                        "timestamp": "1781288632",
-                        "title": "Will JD Vance win the 2028 US Presidential Election?",
-                        "slug": "will-jd-vance-win-the-2028-us-presidential-election",
-                        "icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
-                        "eventSlug": "presidential-election-winner-2028",
-                        "outcome": "Yes",
-                        "outcomeIndex": "0",
-                        "name": "",
-                        "pseudonym": "",
-                        "bio": "",
-                        "profileImage": "",
-                        "profileImageOptimized": "",
-                        "transactionHash": "0xc371cfbf045bb2a76073e33dd8538c3aa24fbee3b53e66c1e408871cdc27f3ad"
-                    }
-                ],
-                "parsedResponse": [
-                    {
-                        "id": "0xc371cfbf045bb2a76073e33dd8538c3aa24fbee3b53e66c1e408871cdc27f3ad",
-                        "info": {
-                            "proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
-                            "side": "BUY",
-                            "asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                            "conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                            "size": "368",
-                            "price": "0.152",
-                            "timestamp": "1781288632",
-                            "title": "Will JD Vance win the 2028 US Presidential Election?",
-                            "slug": "will-jd-vance-win-the-2028-us-presidential-election",
-                            "icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
-                            "eventSlug": "presidential-election-winner-2028",
-                            "outcome": "Yes",
-                            "outcomeIndex": "0",
-                            "name": "",
-                            "pseudonym": "",
-                            "bio": "",
-                            "profileImage": "",
-                            "profileImageOptimized": "",
-                            "transactionHash": "0xc371cfbf045bb2a76073e33dd8538c3aa24fbee3b53e66c1e408871cdc27f3ad"
-                        },
-                        "timestamp": 1781288632000,
-                        "datetime": "2026-06-12T18:23:52.000Z",
-                        "symbol": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                        "outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                        "outcomeId": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": null,
-                        "price": 0.152,
-                        "amount": 368,
-                        "cost": 55.936,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    },
-                    {
-                        "id": "0x3c49025c45025d25c7e4a88619ca9454135f6dcb53343096a7aa361003b471d0",
-                        "info": {
-                            "proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
-                            "side": "BUY",
-                            "asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                            "conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
-                            "size": "256",
-                            "price": "0.152",
-                            "timestamp": "1781289172",
-                            "title": "Will JD Vance win the 2028 US Presidential Election?",
-                            "slug": "will-jd-vance-win-the-2028-us-presidential-election",
-                            "icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
-                            "eventSlug": "presidential-election-winner-2028",
-                            "outcome": "Yes",
-                            "outcomeIndex": "0",
-                            "name": "",
-                            "pseudonym": "",
-                            "bio": "",
-                            "profileImage": "",
-                            "profileImageOptimized": "",
-                            "transactionHash": "0x3c49025c45025d25c7e4a88619ca9454135f6dcb53343096a7aa361003b471d0"
-                        },
-                        "timestamp": 1781289172000,
-                        "datetime": "2026-06-12T18:32:52.000Z",
-                        "symbol": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                        "outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                        "outcomeId": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": null,
-                        "price": 0.152,
-                        "amount": 256,
-                        "cost": 38.912,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "fees": []
-                    }
-                ]
-            }
-        ],
-        "fetchOHLCV": [
-            {
-                "description": "fetchOHLCV with since and limit",
-                "method": "fetchOHLCV",
-                "input": [
-                    "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
-                    "1m",
-                    1781282000000,
-                    60
-                ],
-                "httpResponse": {
-                    "history": [
-                        {
-                            "t": "1781282044",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282118",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282163",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282224",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282284",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282344",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282403",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282463",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282524",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282584",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282658",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282704",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282763",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282825",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282884",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781282944",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781283004",
-                            "p": "0.151"
-                        },
-                        {
-                            "t": "1781283064",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283124",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283184",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283244",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283305",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283365",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283428",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283486",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283544",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283606",
-                            "p": "0.1505"
-                        },
-                        {
-                            "t": "1781283666",
-                            "p": "0.1515"
-                        },
-                        {
-                            "t": "1781283725",
-                            "p": "0.1515"
-                        },
-                        {
-                            "t": "1781283784",
-                            "p": "0.1515"
-                        }
-                    ]
-                },
-                "parsedResponse": [
-                    [
-                        1781282040000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282100000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282160000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282220000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282280000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282340000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282400000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282460000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282520000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282580000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282640000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282700000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282760000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282820000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282880000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781282940000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781283000000,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0.151,
-                        0
-                    ],
-                    [
-                        1781283060000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283120000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283180000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283240000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283300000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283360000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283420000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283480000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283540000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283600000,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0.1505,
-                        0
-                    ],
-                    [
-                        1781283660000,
-                        0.1515,
-                        0.1515,
-                        0.1515,
-                        0.1515,
-                        0
-                    ],
-                    [
-                        1781283720000,
-                        0.1515,
-                        0.1515,
-                        0.1515,
-                        0.1515,
-                        0
-                    ],
-                    [
-                        1781283780000,
-                        0.1515,
-                        0.1515,
-                        0.1515,
-                        0.1515,
-                        0
-                    ]
-                ]
-            }
-        ]
-    }
+	"exchange": "polymarket",
+	"skipKeys": [],
+	"options": {
+		"l2ApiKey": "0xabc123",
+		"l2Secret": "0xdef456"
+	},
+	"methods": {
+		"fetchTicker": [
+			{
+				"description": "fetchTicker for a yes outcome",
+				"method": "fetchTicker",
+				"input": [
+					"JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES"
+				],
+				"httpResponse": {
+					"market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+					"asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+					"timestamp": "1781289337944",
+					"hash": "3082b8da1567a4510e93544031cb9144524f2de7",
+					"bids": [
+						{
+							"price": "0.001",
+							"size": "2202468"
+						},
+						{
+							"price": "0.002",
+							"size": "1000005"
+						},
+						{
+							"price": "0.003",
+							"size": "135826.51"
+						},
+						{
+							"price": "0.004",
+							"size": "12364"
+						},
+						{
+							"price": "0.005",
+							"size": "1000"
+						}
+					],
+					"asks": [
+						{
+							"price": "0.999",
+							"size": "45521.44"
+						},
+						{
+							"price": "0.998",
+							"size": "5007500"
+						},
+						{
+							"price": "0.997",
+							"size": "7.06"
+						},
+						{
+							"price": "0.996",
+							"size": "5000"
+						},
+						{
+							"price": "0.995",
+							"size": "222222"
+						}
+					],
+					"min_order_size": "5",
+					"tick_size": "0.001",
+					"neg_risk": true,
+					"last_trade_price": "0.152",
+					"mid": "0.1515"
+				},
+				"parsedResponse": {
+					"outcomeId": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+					"label": "Yes",
+					"market": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION",
+					"timestamp": 1781289337944,
+					"datetime": "2026-06-12T18:35:37.944Z",
+					"high": null,
+					"low": null,
+					"bid": 0.005,
+					"bidVolume": 1000,
+					"ask": 0.995,
+					"askVolume": 222222,
+					"vwap": null,
+					"open": null,
+					"close": 0.1515,
+					"last": 0.1515,
+					"previousClose": null,
+					"change": null,
+					"percentage": null,
+					"average": 0.1515,
+					"baseVolume": null,
+					"quoteVolume": 21920.557926999998,
+					"info": {
+						"midpoint": {
+							"market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+							"asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+							"timestamp": "1781289337944",
+							"hash": "3082b8da1567a4510e93544031cb9144524f2de7",
+							"bids": [
+								{
+									"price": "0.001",
+									"size": "2202468"
+								},
+								{
+									"price": "0.002",
+									"size": "1000005"
+								},
+								{
+									"price": "0.003",
+									"size": "135826.51"
+								},
+								{
+									"price": "0.004",
+									"size": "12364"
+								},
+								{
+									"price": "0.005",
+									"size": "1000"
+								}
+							],
+							"asks": [
+								{
+									"price": "0.999",
+									"size": "45521.44"
+								},
+								{
+									"price": "0.998",
+									"size": "5007500"
+								},
+								{
+									"price": "0.997",
+									"size": "7.06"
+								},
+								{
+									"price": "0.996",
+									"size": "5000"
+								},
+								{
+									"price": "0.995",
+									"size": "222222"
+								}
+							],
+							"min_order_size": "5",
+							"tick_size": "0.001",
+							"neg_risk": true,
+							"last_trade_price": "0.152",
+							"mid": "0.1515"
+						},
+						"book": {
+							"market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+							"asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+							"timestamp": "1781289337944",
+							"hash": "3082b8da1567a4510e93544031cb9144524f2de7",
+							"bids": [
+								{
+									"price": "0.001",
+									"size": "2202468"
+								},
+								{
+									"price": "0.002",
+									"size": "1000005"
+								},
+								{
+									"price": "0.003",
+									"size": "135826.51"
+								},
+								{
+									"price": "0.004",
+									"size": "12364"
+								},
+								{
+									"price": "0.005",
+									"size": "1000"
+								}
+							],
+							"asks": [
+								{
+									"price": "0.999",
+									"size": "45521.44"
+								},
+								{
+									"price": "0.998",
+									"size": "5007500"
+								},
+								{
+									"price": "0.997",
+									"size": "7.06"
+								},
+								{
+									"price": "0.996",
+									"size": "5000"
+								},
+								{
+									"price": "0.995",
+									"size": "222222"
+								}
+							],
+							"min_order_size": "5",
+							"tick_size": "0.001",
+							"neg_risk": true,
+							"last_trade_price": "0.152",
+							"mid": "0.1515"
+						}
+					},
+					"indexPrice": null,
+					"markPrice": null,
+					"outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
+					"event": null
+				}
+			}
+		],
+		"fetchOrderBook": [
+			{
+				"description": "fetchOrderBook for a yes outcome",
+				"method": "fetchOrderBook",
+				"input": [
+					"JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES"
+				],
+				"httpResponse": {
+					"market": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+					"asset_id": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+					"timestamp": "1781289337944",
+					"hash": "3082b8da1567a4510e93544031cb9144524f2de7",
+					"bids": [
+						{
+							"price": "0.001",
+							"size": "2202468"
+						},
+						{
+							"price": "0.002",
+							"size": "1000005"
+						},
+						{
+							"price": "0.003",
+							"size": "135826.51"
+						},
+						{
+							"price": "0.004",
+							"size": "12364"
+						},
+						{
+							"price": "0.005",
+							"size": "1000"
+						}
+					],
+					"asks": [
+						{
+							"price": "0.999",
+							"size": "45521.44"
+						},
+						{
+							"price": "0.998",
+							"size": "5007500"
+						},
+						{
+							"price": "0.997",
+							"size": "7.06"
+						},
+						{
+							"price": "0.996",
+							"size": "5000"
+						},
+						{
+							"price": "0.995",
+							"size": "222222"
+						}
+					],
+					"min_order_size": "5",
+					"tick_size": "0.001",
+					"neg_risk": true,
+					"last_trade_price": "0.152"
+				},
+				"parsedResponse": {
+					"symbol": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
+					"bids": [
+						[
+							0.005,
+							1000
+						],
+						[
+							0.004,
+							12364
+						],
+						[
+							0.003,
+							135826.51
+						],
+						[
+							0.002,
+							1000005
+						],
+						[
+							0.001,
+							2202468
+						]
+					],
+					"asks": [
+						[
+							0.995,
+							222222
+						],
+						[
+							0.996,
+							5000
+						],
+						[
+							0.997,
+							7.06
+						],
+						[
+							0.998,
+							5007500
+						],
+						[
+							0.999,
+							45521.44
+						]
+					],
+					"timestamp": 1781289337944,
+					"datetime": "2026-06-12T18:35:37.944Z",
+					"nonce": null,
+					"outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
+					"outcomeId": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+					"market": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION"
+				}
+			}
+		],
+		"fetchTrades": [
+			{
+				"description": "fetchTrades with limit",
+				"method": "fetchTrades",
+				"input": [
+					"JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
+					null,
+					3
+				],
+				"httpResponse": [
+					{
+						"proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
+						"side": "BUY",
+						"asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+						"conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+						"size": "256",
+						"price": "0.152",
+						"timestamp": "1781289172",
+						"title": "Will JD Vance win the 2028 US Presidential Election?",
+						"slug": "will-jd-vance-win-the-2028-us-presidential-election",
+						"icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
+						"eventSlug": "presidential-election-winner-2028",
+						"outcome": "Yes",
+						"outcomeIndex": "0",
+						"name": "",
+						"pseudonym": "",
+						"bio": "",
+						"profileImage": "",
+						"profileImageOptimized": "",
+						"transactionHash": "0x3c49025c45025d25c7e4a88619ca9454135f6dcb53343096a7aa361003b471d0"
+					},
+					{
+						"proxyWallet": "0xbe55fa3947e0dd06887444f9b6cbf05dcfb8c2ee",
+						"side": "SELL",
+						"asset": "94476829201604408463453426454480212459887267917122244941405244686637914508323",
+						"conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+						"size": "11.77",
+						"price": "0.848",
+						"timestamp": "1781288635",
+						"title": "Will JD Vance win the 2028 US Presidential Election?",
+						"slug": "will-jd-vance-win-the-2028-us-presidential-election",
+						"icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
+						"eventSlug": "presidential-election-winner-2028",
+						"outcome": "No",
+						"outcomeIndex": "1",
+						"name": "",
+						"pseudonym": "",
+						"bio": "",
+						"profileImage": "",
+						"profileImageOptimized": "",
+						"transactionHash": "0xd3c0aa3da570bb98dcf7ed9f41a4d72ba6db652cd790f9f0fdbee688bd207e19"
+					},
+					{
+						"proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
+						"side": "BUY",
+						"asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+						"conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+						"size": "368",
+						"price": "0.152",
+						"timestamp": "1781288632",
+						"title": "Will JD Vance win the 2028 US Presidential Election?",
+						"slug": "will-jd-vance-win-the-2028-us-presidential-election",
+						"icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
+						"eventSlug": "presidential-election-winner-2028",
+						"outcome": "Yes",
+						"outcomeIndex": "0",
+						"name": "",
+						"pseudonym": "",
+						"bio": "",
+						"profileImage": "",
+						"profileImageOptimized": "",
+						"transactionHash": "0xc371cfbf045bb2a76073e33dd8538c3aa24fbee3b53e66c1e408871cdc27f3ad"
+					}
+				],
+				"parsedResponse": [
+					{
+						"id": "0xc371cfbf045bb2a76073e33dd8538c3aa24fbee3b53e66c1e408871cdc27f3ad",
+						"info": {
+							"proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
+							"side": "BUY",
+							"asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+							"conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+							"size": "368",
+							"price": "0.152",
+							"timestamp": "1781288632",
+							"title": "Will JD Vance win the 2028 US Presidential Election?",
+							"slug": "will-jd-vance-win-the-2028-us-presidential-election",
+							"icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
+							"eventSlug": "presidential-election-winner-2028",
+							"outcome": "Yes",
+							"outcomeIndex": "0",
+							"name": "",
+							"pseudonym": "",
+							"bio": "",
+							"profileImage": "",
+							"profileImageOptimized": "",
+							"transactionHash": "0xc371cfbf045bb2a76073e33dd8538c3aa24fbee3b53e66c1e408871cdc27f3ad"
+						},
+						"timestamp": 1781288632000,
+						"datetime": "2026-06-12T18:23:52.000Z",
+						"outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
+						"outcomeId": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+						"label": "Yes",
+						"market": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION",
+						"order": null,
+						"type": null,
+						"side": "buy",
+						"takerOrMaker": null,
+						"price": 0.152,
+						"amount": 368,
+						"cost": 55.936,
+						"fee": {
+							"cost": null,
+							"currency": null
+						},
+						"fees": [],
+						"event": null
+					},
+					{
+						"id": "0x3c49025c45025d25c7e4a88619ca9454135f6dcb53343096a7aa361003b471d0",
+						"info": {
+							"proxyWallet": "0xa0f21e6d351baa9185716b5c00c2925ed9621848",
+							"side": "BUY",
+							"asset": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+							"conditionId": "0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422",
+							"size": "256",
+							"price": "0.152",
+							"timestamp": "1781289172",
+							"title": "Will JD Vance win the 2028 US Presidential Election?",
+							"slug": "will-jd-vance-win-the-2028-us-presidential-election",
+							"icon": "https://polymarket-upload.s3.us-east-2.amazonaws.com/will-jd-vance-win-the-2028-us-presidential-election-P-zEgXjCWbdY.png",
+							"eventSlug": "presidential-election-winner-2028",
+							"outcome": "Yes",
+							"outcomeIndex": "0",
+							"name": "",
+							"pseudonym": "",
+							"bio": "",
+							"profileImage": "",
+							"profileImageOptimized": "",
+							"transactionHash": "0x3c49025c45025d25c7e4a88619ca9454135f6dcb53343096a7aa361003b471d0"
+						},
+						"timestamp": 1781289172000,
+						"datetime": "2026-06-12T18:32:52.000Z",
+						"outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
+						"outcomeId": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
+						"label": "Yes",
+						"market": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION",
+						"order": null,
+						"type": null,
+						"side": "buy",
+						"takerOrMaker": null,
+						"price": 0.152,
+						"amount": 256,
+						"cost": 38.912,
+						"fee": {
+							"cost": null,
+							"currency": null
+						},
+						"fees": [],
+						"event": null
+					}
+				]
+			}
+		],
+		"fetchOHLCV": [
+			{
+				"description": "fetchOHLCV with since and limit",
+				"method": "fetchOHLCV",
+				"input": [
+					"JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
+					"1m",
+					1781282000000,
+					60
+				],
+				"httpResponse": {
+					"history": [
+						{
+							"t": "1781282044",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282118",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282163",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282224",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282284",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282344",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282403",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282463",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282524",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282584",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282658",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282704",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282763",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282825",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282884",
+							"p": "0.151"
+						},
+						{
+							"t": "1781282944",
+							"p": "0.151"
+						},
+						{
+							"t": "1781283004",
+							"p": "0.151"
+						},
+						{
+							"t": "1781283064",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283124",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283184",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283244",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283305",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283365",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283428",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283486",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283544",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283606",
+							"p": "0.1505"
+						},
+						{
+							"t": "1781283666",
+							"p": "0.1515"
+						},
+						{
+							"t": "1781283725",
+							"p": "0.1515"
+						},
+						{
+							"t": "1781283784",
+							"p": "0.1515"
+						}
+					]
+				},
+				"parsedResponse": [
+					[
+						1781282040000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282100000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282160000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282220000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282280000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282340000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282400000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282460000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282520000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282580000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282640000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282700000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282760000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282820000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282880000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781282940000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781283000000,
+						0.151,
+						0.151,
+						0.151,
+						0.151,
+						0
+					],
+					[
+						1781283060000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283120000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283180000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283240000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283300000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283360000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283420000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283480000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283540000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283600000,
+						0.1505,
+						0.1505,
+						0.1505,
+						0.1505,
+						0
+					],
+					[
+						1781283660000,
+						0.1515,
+						0.1515,
+						0.1515,
+						0.1515,
+						0
+					],
+					[
+						1781283720000,
+						0.1515,
+						0.1515,
+						0.1515,
+						0.1515,
+						0
+					],
+					[
+						1781283780000,
+						0.1515,
+						0.1515,
+						0.1515,
+						0.1515,
+						0
+					]
+				]
+			}
+		]
+	}
 }

--- a/ts/src/test/static/response/polymarket.json
+++ b/ts/src/test/static/response/polymarket.json
@@ -69,6 +69,7 @@
 					"mid": "0.1515"
 				},
 				"parsedResponse": {
+					"outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
 					"outcomeId": "16040015440196279900485035793550429453516625694844857319147506590755961451627",
 					"label": "Yes",
 					"market": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION",
@@ -204,7 +205,6 @@
 					},
 					"indexPrice": null,
 					"markPrice": null,
-					"outcome": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
 					"event": null
 				}
 			}
@@ -271,7 +271,6 @@
 					"last_trade_price": "0.152"
 				},
 				"parsedResponse": {
-					"symbol": "JD_VANCE_WIN_2028_US_PRESIDENTIAL_ELECTION:YES",
 					"bids": [
 						[
 							0.005,


### PR DESCRIPTION
## Summary

Makes the prediction-market exchanges (polymarket, kalshi, limitless, myriad, hyperliquid) transpile and pass static tests across **all six languages**. The static prediction tests previously did not even compile/import in C#/Go/Java and crashed at runtime in Python/PHP; this fixes that and unifies the order-book structure.

## What changed

- **`safePredictionOrderBook` base helper** — books now expose `outcome`/`outcomeId`/`market` (no `symbol`), consistent with the other prediction structures. Applied in all 5 exchanges' `fetchOrderBook`.
- **Cross-language crash fixes**
  - `toPredictionStructure` / `safePredictionOrderBook` now **omit** (not `delete`) `symbol` — `del`/direct access raised `KeyError` in Python/PHP for outcome-keyed structures.
  - base `filterByValueSinceLimit` reads `safeValue(entry, field)` instead of `entry[field]` (same KeyError class; aligns Py/PHP with JS semantics, no behaviour change for regular exchanges).
- **Native prediction structs completed in C#/Go/Java** — `PredictionOrderBook`, `PredictionTradingFee`, `PredictionOpenInterest` were referenced by generated wrappers but never defined, so prediction did not compile. Added structs + converters + transpiler type/import mappings.
- **`fetchEvents`** typed with `fetchEventsParams` on the base too (PHP signature compatibility); `fetchEventsParams` mapped per language.
- **hyperliquid** `fetchTickers`/`fetchPositions` param aligned to `symbols` (matches the other four; lets the Go wrapper reuse the base options struct).
- **myriad** `populateOutcomes` normalizes legacy `symbol`/`id`/`marketSymbol` keys — Go/C#/Java don't dispatch the prediction `setMarkets` override that pre-normalizes them.
- Refreshed response fixtures; test framework treats prediction as **async-only** (`ccxt.prediction.<id>`).

## Tests — static request + response, all 6 languages

| | polymarket | kalshi | limitless | myriad |
|---|---|---|---|---|
| JS / Python / PHP / C# / Java / Go | ✅ | ✅ | ✅ | ✅ |

Regular-exchange regression (binance response) green in JS/Py/PHP/Go after the base `safeValue` change.

## Notes
- `js/` and the Go generated package (`go/v4/prediction/*`, `exchange_generated.go`) are **not** committed — they're regenerated from the included `ts/` source + transpiler fixes (Go base `exchange_generated.go` is mid-refactor on this branch). The Go transpiler fixes and hand-written `exchange_prediction_types.go` are included so a clean base regen produces a passing Go build (verified locally).