### PR TITLE
fix(examples): scope the polymarket end-to-end fetchEvents in all languages

### DIFF
--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -1156,6 +1156,9 @@ class NewTranspiler {
         }
 
         if (prediction) {
+            // the venues override methods declared in the prediction base — regenerate it
+            // in the same pass so a scoped prediction run can't leave the base stale
+            this.transpilePredictionBaseMethods ()
             log.bright.green ('Transpiled prediction exchanges successfully.')
             return;
         }

--- a/examples/cs/examples/prediction/PolymarketEndToEnd.cs
+++ b/examples/cs/examples/prediction/PolymarketEndToEnd.cs
@@ -35,7 +35,8 @@ partial class Examples
         });
 
         // 1) pick a high-volume event and an outcome with a live two-sided book ------------
-        var events = await exchange.FetchEvents(new Dictionary<string, object>() { { "sort", "volume" }, { "limit", 15 } });
+        // FetchEvents requires a scope (query/queries/tags/eventId/slug); sort/limit apply within it
+        var events = await exchange.FetchEvents(new Dictionary<string, object>() { { "query", "fed" }, { "sort", "volume" }, { "limit", 15 } });
         string symbol = null;
         PredictionOrderBook? chosenBook = null;
         double tick = 0.01;

--- a/examples/go/prediction/polymarketEndToEnd.go
+++ b/examples/go/prediction/polymarketEndToEnd.go
@@ -38,7 +38,8 @@ func PolymarketEndToEndExample() {
 	})
 
 	// 1) pick a high-volume event and an outcome with a live two-sided book ----------------
-	events, err := exchange.FetchEvents(map[string]interface{}{"sort": "volume", "limit": 15})
+	// FetchEvents requires a scope (query/queries/tags/eventId/slug); sort/limit apply within it
+	events, err := exchange.FetchEvents(map[string]interface{}{"query": "fed", "sort": "volume", "limit": 15})
 	if err != nil {
 		fmt.Println("fetchEvents failed:", err)
 		return

--- a/examples/go/prediction/predictionMarkets.go
+++ b/examples/go/prediction/predictionMarkets.go
@@ -8,7 +8,7 @@ package prediction
 import (
 	"fmt"
 
-	ccxtprediction "ccxt/go/ccxt/prediction"
+	ccxtprediction "github.com/ccxt/ccxt/go/v4/prediction"
 )
 
 func PredictionMarketsExample() {

--- a/examples/js/prediction/prediction-polymarket-end-to-end.js
+++ b/examples/js/prediction/prediction-polymarket-end-to-end.js
@@ -26,7 +26,8 @@ async function main() {
         'options': options,
     });
     // 1) pick a high-volume event and an outcome with a live two-sided book ----------------
-    const events = await exchange.fetchEvents({ 'sort': 'volume', 'limit': 15 });
+    // fetchEvents requires a scope (query/queries/tags/eventId/slug); sort/limit apply within it
+    const events = await exchange.fetchEvents({ 'query': 'fed', 'sort': 'volume', 'limit': 15 });
     let chosen = undefined;
     let probes = 0;
     for (const ev of events) {

--- a/examples/php/prediction/prediction-polymarket-end-to-end.php
+++ b/examples/php/prediction/prediction-polymarket-end-to-end.php
@@ -34,7 +34,8 @@ $exchange = new \ccxt\prediction\polymarket([
 ]);
 
 // 1) pick a high-volume event and an outcome with a live two-sided book -------------------
-$events = await($exchange->fetch_events(['sort' => 'volume', 'limit' => 15]));
+// fetch_events requires a scope (query/queries/tags/eventId/slug); sort/limit apply within it
+$events = await($exchange->fetch_events(['query' => 'fed', 'sort' => 'volume', 'limit' => 15]));
 $chosen = null;
 $probes = 0;
 foreach ($events as $event) {

--- a/examples/py/prediction/prediction-polymarket-end-to-end.py
+++ b/examples/py/prediction/prediction-polymarket-end-to-end.py
@@ -39,7 +39,8 @@ async def main():
     })
     try:
         # 1) pick a high-volume event and an outcome with a live two-sided book ------------
-        events = await exchange.fetch_events({'sort': 'volume', 'limit': 15})
+        # fetch_events requires a scope (query/queries/tags/eventId/slug); sort/limit apply within it
+        events = await exchange.fetch_events({'query': 'fed', 'sort': 'volume', 'limit': 15})
         chosen = None
         probes = 0
         for event in events:

--- a/examples/ts/prediction/prediction-polymarket-end-to-end.ts
+++ b/examples/ts/prediction/prediction-polymarket-end-to-end.ts
@@ -31,7 +31,8 @@ async function main () {
     });
 
     // 1) pick a high-volume event and an outcome with a live two-sided book ----------------
-    const events = await exchange.fetchEvents ({ 'sort': 'volume', 'limit': 15 });
+    // fetchEvents requires a scope (query/queries/tags/eventId/slug); sort/limit apply within it
+    const events = await exchange.fetchEvents ({ 'query': 'fed', 'sort': 'volume', 'limit': 15 });
     let chosen: any = undefined;
     let probes = 0;
     for (const ev of events) {

--- a/java/examples/src/main/java/examples/prediction/PolymarketEndToEnd.java
+++ b/java/examples/src/main/java/examples/prediction/PolymarketEndToEnd.java
@@ -47,6 +47,8 @@ public class PolymarketEndToEnd {
 
         // 1) pick a high-volume event and an outcome with a live two-sided book ------------
         Map<String, Object> eventsParams = new HashMap<>();
+        // fetchEvents requires a scope (query/queries/tags/eventId/slug); sort/limit apply within it
+        eventsParams.put("query", "fed");
         eventsParams.put("sort", "volume");
         eventsParams.put("limit", 15);
         List<PredictionEvent> events = exchange.fetchEvents(eventsParams);


### PR DESCRIPTION
## Summary
fetchEvents now requires a scope (query/queries/tags/eventId/slug), so the polymarket end-to-end example threw ArgumentsRequired in every language — adds a query scope to all six ports, fixes an invalid import path in the Go predictionMarkets example, and makes the scoped C# --prediction transpile regenerate the prediction base (a scoped run left PredictionExchange.cs missing fetchOutcomes → CS0115).

## Notes
Verified live (public flow + signed order POST, rejected only on a throwaway banned address) in js, py, php, cs, go and java; C# examples build 0 errors; Go examples compile.